### PR TITLE
Stylistic Change - Made tables more condensed and lowered font size

### DIFF
--- a/css/dataTables.bootstrap5.min.css
+++ b/css/dataTables.bootstrap5.min.css
@@ -144,7 +144,7 @@ table.dataTable tbody tr.selected {
 
 table.dataTable tbody th,
 table.dataTable tbody td {
-	padding: 8px 10px
+	padding: 4px 5px
 }
 
 table.dataTable.row-border tbody th,

--- a/css/styles.css
+++ b/css/styles.css
@@ -134,7 +134,7 @@
 body {
   margin: 0;
   font-family: var(--bs-body-font-family);
-  font-size: var(--bs-body-font-size);
+  font-size: 0.85rem;
   font-weight: var(--bs-body-font-weight);
   line-height: var(--bs-body-line-height);
   color: var(--bs-body-color);


### PR DESCRIPTION
In dataTables bootstrap I changed the padding on td to 4px 5px and changed overall font size of body from 1REM to 0.85REM

Attempt to fixes #42 