### PR TITLE
Consistent casing/naming - re-add Intune to MEM portal link

### DIFF
--- a/tenants.html
+++ b/tenants.html
@@ -36,10 +36,10 @@
                                 <th>Default Domain</th>
                                 <th>M365 Portal</th>
                                 <th>Exchange Portal</th>
-                                <th>AAD portal</th>
+                                <th>AAD Portal</th>
                                 <th>Teams Portal</th>
-                                <th>Azure portal</th>
-                                <th>MEM portal</th>
+                                <th>Azure Portal</th>
+                                <th>MEM (Intune) Portal</th>
                                 <th>Domains</th>
                             </tr>
                         </thead>
@@ -51,10 +51,10 @@
                                 <th>Default Domain</th>
                                 <th>M365 Portal</th>
                                 <th>Exchange Portal</th>
-                                <th>AAD portal</th>
+                                <th>AAD Portal</th>
                                 <th>Teams Portal</th>
-                                <th>Azure portal</th>
-                                <th>MEM portal</th>
+                                <th>Azure Portal</th>
+                                <th>MEM (Intune) Portal</th>
                                 <th>Domains</th>
                             </tr>
                         </tfoot>


### PR DESCRIPTION
Consistent casing/naming - re-add Intune to MEM portal link. This brings consistent use of capital P for Portal and changes MEM Portal to MEM (Intune) Portal