### PR TITLE
Removed "Select all" on AddStandards

### DIFF
--- a/Addstandard.html
+++ b/Addstandard.html
@@ -129,74 +129,74 @@
                                     These standards will be applied every 3 hours on a repeated schedule.
                                     <div class="form-check mb-2">
                                         <input class="form-check-input" id="AuditLog" name="AuditLog" type="checkbox"
-                                            value="true" checked />
+                                            value="true"  />
                                         <label class="form-next buttocheck-label" for="AuditLog">Enable the
                                             Unified Audit Log</label>
                                     </div>
                                     <div class="form-check mb-2">
                                         <input class="form-check-input" id="SecurityDefaults" name="SecurityDefaults"
-                                            type="checkbox" value="true" checked />
+                                            type="checkbox" value="true"  />
                                         <label class="form-next buttocheck-label" for="SecurityDefaults">Enable Security
                                             Defaults</label>
                                     </div>
                                     <div class="form-check mb-2">
                                         <input class="form-check-input" id="DelegateSentItems" name="DelegateSentItems"
-                                            type="checkbox" value="true" checked />
+                                            type="checkbox" value="true"  />
                                         <label class="form-next buttocheck-label" for="DelegateSentItems">Set mailbox
                                             Sent Items delegation (Sent items for shared mailboxes)</label>
                                     </div>
                                     <div class="form-check mb-2">
                                         <input class="form-check-input" id="OauthConsent" name="OauthConsent"
-                                            type="checkbox" value="true" checked />
+                                            type="checkbox" value="true"  />
                                         <label class="form-next buttocheck-label" for="OauthConsent">Require
                                             admin consent for applications (Prevent OAuth phishing)</label>
                                     </div>
                                     <div class="form-check mb-2">
                                         <input class="form-check-input" id="PasswordExpireDisabled"
-                                            name="PasswordExpireDisabled" type="checkbox" value="true" checked />
+                                            name="PasswordExpireDisabled" type="checkbox" value="true"  />
                                         <label class="form-next buttocheck-label" for="PasswordExpireDisabled">Do not
                                             expire passwords</label>
                                     </div>
                                     <div class="form-check mb-2">
                                         <input class="form-check-input" id="AnonReportDisable" name="AnonReportDisable"
-                                            type="checkbox" value="true" checked />
+                                            type="checkbox" value="true"  />
                                         <label class="form-next buttocheck-label" for="AnonReportDisable">Enable
                                             Usernames instead of pseudo anonymised names
                                             in reports</label>
                                     </div>
                                     <div class="form-check mb-2">
                                         <input class="form-check-input" id="SSPR" name="SSPR" type="checkbox"
-                                            value="true" checked />
+                                            value="true"  />
                                         <label class="form-next buttocheck-label" for="SSPR">Enable Self
                                             Service Password Reset</label>
                                     </div>
                                     <div class="form-check mb-2">
                                         <input class="form-check-input" id="ModernAuth" name="ModernAuth"
-                                            type="checkbox" value="true" checked />
+                                            type="checkbox" value="true"  />
                                         <label class="form-next buttocheck-label" for="ModernAuth">Enable Modern
                                             Authentication</label>
                                     </div>
                                     <div class="form-check mb-2">
                                         <input class="form-check-input" id="DisableBasicAuth" name="DisableBasicAuth"
-                                            type="checkbox" value="true" checked />
+                                            type="checkbox" value="true"  />
                                         <label class="form-next buttocheck-label" for="DisableBasicAuth">Disable Basic
                                             Authentication</label>
                                     </div>
                                     <div class="form-check mb-2">
                                         <input class="form-check-input" id="DisableSharedMailbox"
-                                            name="DisableSharedMailbox" type="checkbox" value="true" checked />
+                                            name="DisableSharedMailbox" type="checkbox" value="true"  />
                                         <label class="form-next buttocheck-label" for="DisableSharedMailbox">Disable
                                             Shared Mailbox AAD accounts</label>
                                     </div>
                                     <div class="form-check mb-2">
                                         <input class="form-check-input" id="AutoExpandArchive" name="AutoExpandArchive"
-                                            type="checkbox" value="true" checked />
+                                            type="checkbox" value="true"  />
                                         <label class="form-next buttocheck-label" for="AutoExpandArchive">Enable
                                             Auto-expanding archives</label>
                                     </div>
                                     <div class="form-check mb-2">
                                         <input class="form-check-input" id="LegacyMFA" name="LegacyMFA" type="checkbox"
-                                            value="true" checked />
+                                            value="true"  />
                                         <label class="form-next buttocheck-label" for="LegacyMFA">Enable
                                             per-user MFA for all users</label>
                                     </div>


### PR DESCRIPTION
This commit is for #218 

Removes the default "checked all" 

Tested both graphically and ensuring that only the selected standards is applied to the cache.json file on submit