### PR TITLE
Fix CellBoolean error on load

### DIFF
--- a/src/components/cipp/CellBoolean.js
+++ b/src/components/cipp/CellBoolean.js
@@ -52,3 +52,5 @@ export const cellBooleanFormatter =
     const cell = cellGetProperty(row, index, column, id)
     return CellBoolean({ cell, reverse, warning })
   }
+
+export default CellBoolean


### PR DESCRIPTION
Issue on load where there was no default export in CellBoolean which caused pages to fail on load