### PR TITLE
add column "Display Name" to "AutopilotDeviceList" view

### DIFF
--- a/AutopilotDeviceList.html
+++ b/AutopilotDeviceList.html
@@ -42,6 +42,7 @@
                     <table cellpadding="0" cellspacing="0" class="datatable-1 table table-striped" width="100%">
                         <thead>
                             <tr>
+                                <th>Name</th>
                                 <th>Serial</th>
                                 <th>Manufacturer</th>
                                 <th>Model</th>
@@ -54,6 +55,7 @@
                         </tbody>
                         <tfoot>
                             <tr>
+                                <th>Name</th>
                                 <th>Serial</th>
                                 <th>Manufacturer</th>
                                 <th>Model</th>
@@ -63,6 +65,7 @@
                             </tr>
                         </tfoot>
                     </table>
+                </table>
             </div>
         </div>
     </div>
@@ -79,7 +82,7 @@
                     <section id="APIContent">
                         <div class="spinner-border text-primary" role="status">
                             <span class="sr-only"></span>
-                        </div></span>
+                        </div>
                     </section>
                 </div>
                 <div class="modal-footer"><button class="btn btn-secondary" type="button"

--- a/AutopilotDeviceList.html
+++ b/AutopilotDeviceList.html
@@ -42,7 +42,7 @@
                     <table cellpadding="0" cellspacing="0" class="datatable-1 table table-striped" width="100%">
                         <thead>
                             <tr>
-                                <th>Name</th>
+                                <th>Display Name</th>
                                 <th>Serial</th>
                                 <th>Manufacturer</th>
                                 <th>Model</th>
@@ -55,7 +55,7 @@
                         </tbody>
                         <tfoot>
                             <tr>
-                                <th>Name</th>
+                                <th>Display Name</th>
                                 <th>Serial</th>
                                 <th>Manufacturer</th>
                                 <th>Model</th>

--- a/js/datatables/datatablesAPDevices.js
+++ b/js/datatables/datatablesAPDevices.js
@@ -32,6 +32,7 @@ $(document).ready(function () {
                 { extend: 'pdfHtml5', className: 'btn btn-primary btn-sm', orientation: 'landscape', title: 'Autopilot Device List - ' + TenantID + " - " + todayDate, exportOptions: { columns: [0, 1, 2, 3, 4] } },
             ],
             "columns": [
+                { "data": "displayName" },
                 { "data": "serialNumber" },
                 { "data": "manufacturer" },
                 { "data": "model" },


### PR DESCRIPTION
Our company requires the visibility of the "Display Name" of devises within the "AutopilotDeviceList" view.

This PR does exactly that and also fixes some minor HTML errors/inconsistencies within `AutopilotDeviceList.html`.

I'm not sure if this PR is suitable for the upstream, but here is the PR anyway. If you're not inst rested in this change, feel free to close the PR.