### PR TITLE
Better line break removal in version check function.

### DIFF
--- a/src/store/api/app.js
+++ b/src/store/api/app.js
@@ -7,7 +7,7 @@ export const appApi = baseApi.injectEndpoints({
         baseQuery({ path: '/version_latest.txt' }).then(({ data }) =>
           baseQuery({
             path: '/api/GetVersion',
-            params: { localversion: data.replace('\r\n', '') },
+            params: { localversion: data.replace(/(\r\n|\n|\r)/gm, '') },
           }),
         ),
     }),


### PR DESCRIPTION
Fix for an issue where the version check was sending a request to the API with a newline at the end `%0A` `/n`. Replaced the "replace" function with RegEx for all line end types.