### PR TITLE
CIPP Wars Episode IV: A New Lint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "auto-changelog": "~2.3.0",
         "azurite": "^3.15.0",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-config-react-app": "^7.0.0",
         "eslint-plugin-prettier": "^4.0.0",
         "husky": "^7.0.4",
         "prettier": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "auto-changelog": "~2.3.0",
     "azurite": "^3.15.0",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-config-react-app": "^7.0.0",
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.4",
     "prettier": "2.4.1",
@@ -87,8 +88,5 @@
   "engines": {
     "node": "16",
     "npm": ">=7"
-  },
-  "eslintIgnore": [
-    "node_modules/"
-  ]
+  }
 }


### PR DESCRIPTION
- Fix linter action reference.
- Fix incorrect command in Node Project Check.
- Fix incorrect action version.
- Remove Node 17 checks.
- Fix linter config.
- Remove Windows and MacOS build tests.
- Combine install and build.
- Fix job titles.
- Add ESLint config paths.
- Disable unused linters.
- Fix error identified by actionlint.
- Fix linting config.
- Declare react ESLint dep explicitly.
