### PR TITLE
Don't cancel in progress Build if new one is queued.

### DIFF
--- a/.github/workflows/Node_Project_Check.yml
+++ b/.github/workflows/Node_Project_Check.yml
@@ -11,7 +11,7 @@ on:  # yamllint disable-line rule:truthy
       - dev
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 jobs:
   install-build:
     name: NPM Install and Build


### PR DESCRIPTION
- Update UI on Edit User and Edit Group to match revamped Edit Tenant.
- Remove remaining uses of CAlert and replace with CCallout.
- Don't cancel in progress builds if a new one is queued.
