### PR TITLE
Document self service licenses standard

### DIFF
--- a/docs/user/usingcipp/tenantadministration/standards.mdx
+++ b/docs/user/usingcipp/tenantadministration/standards.mdx
@@ -34,6 +34,8 @@ Below the are standards explained:
 | Enable auto expanding archives                                 | Medium/High | Enables automatically expanding Archive Mailboxes. This has impacts on inactive mailboxes and recovering deleted mailboxes and once enabled this is permanent. Please read the [Microsoft documentation on auto expanding archiving](https://docs.microsoft.com/en-gb/microsoft-365/compliance/enable-autoexpanding-archiving?view=o365-worldwide#before-you-enable-auto-expanding-archiving). |
 | Enable Spoofing warnings for Outlook                           | Low         | Adds indicators to e-mail messages received from external senders in Outlook. You can read more about this feature on [Microsoft's Exchange Team Blog](https://techcommunity.microsoft.com/t5/exchange-team-blog/native-external-sender-callouts-on-email-in-outlook/ba-p/2250098). |
 | Enable per-user MFA for all users                              | Medium/High | Deploys per-user Multi-Factor Authentication (MFA) for all the users in the tenant. Doesn't support exclusions. If you'd like to make exclusions, please use Conditional Access instead. |
+| Disable Self Service Licenses                                  | Low         | Prevents users from being able to purchase or provision licenses for themselves. |
+| 
 
 ### Impact Levels
 


### PR DESCRIPTION
- Re-add API docs.
- Update standards documentation for new standard 'disable self service licenses'.
