### PR TITLE
Fix example local.settings.json

### DIFF
--- a/docs/dev/preparing.mdx
+++ b/docs/dev/preparing.mdx
@@ -57,10 +57,10 @@ The contents of your `local.settings.json` file differs depending on whether you
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "~7",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsSecretStorageType": "files",
-    "applicationid": "<APPLICATION ID>",
-    "applicationsecret": "<APPLICATION SECRET>",
-    "refreshtoken": "<REFRESH TOKEN>",
-    "exchangerefreshtoken": "<EXCHANGE REFRESH TOKEN>",
+    "ApplicationId": "<APPLICATION ID>",
+    "ApplicationSecret": "<APPLICATION SECRET>",
+    "RefreshToken": "<REFRESH TOKEN>",
+    "ExchangeRefreshToken": "<EXCHANGE REFRESH TOKEN>",
     "tenantid":"<TENANT ID>"
   }
 }
@@ -76,10 +76,10 @@ The contents of your `local.settings.json` file differs depending on whether you
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "~7",
     "AzureWebJobsStorage": "DefaultEndpointsProtocol=<AZURESTORAGECONNECTIONSTRING>",
-    "applicationid": "<APPLICATION ID>",
-    "applicationsecret": "<APPLICATION SECRET>",
-    "refreshtoken": "<REFRESH TOKEN>",
-    "exchangerefreshtoken": "<EXCHANGE REFRESH TOKEN>",
+    "ApplicationId": "<APPLICATION ID>",
+    "ApplicationSecret": "<APPLICATION SECRET>",
+    "RefreshToken": "<REFRESH TOKEN>",
+    "ExchangeRefreshToken": "<EXCHANGE REFRESH TOKEN>",
     "tenantid":"<TENANT ID>"
   }
 }


### PR DESCRIPTION
The example local.settings.json was mapped case insensitive compared to the variable definitions in code. This is acceptable for the  operating system Windows. But alas, when we are using more advanced operating systems gifted to us by aliens from the future, the settings never set. This remedies that. 👽