### PR TITLE
Removed superfluous line from example config

### DIFF
--- a/docs/dev/preparing.mdx
+++ b/docs/dev/preparing.mdx
@@ -56,7 +56,6 @@ The contents of your `local.settings.json` file differs depending on whether you
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "FUNCTIONS_WORKER_RUNTIME_VERSION": "~7",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "AzureWebJobsSecretStorageType": "files",
     "ApplicationId": "<APPLICATION ID>",
     "ApplicationSecret": "<APPLICATION SECRET>",
     "RefreshToken": "<REFRESH TOKEN>",


### PR DESCRIPTION
That line that I have removed was actually breaking my devenv from running successfully on the latest dev branch. Removing this line was the fix, updating doco to save others having same issue. 🌵