### PR TITLE
UI/UX Love + a few bug squashes

### DIFF
--- a/src/components/contentcards/ListGroupContentCard.js
+++ b/src/components/contentcards/ListGroupContentCard.js
@@ -4,6 +4,7 @@ import { CListGroup, CListGroupItem } from '@coreui/react'
 import { CippContentCard } from '../layout'
 import Skeleton from 'react-loading-skeleton'
 import 'react-loading-skeleton/dist/skeleton.css'
+import { CellTip } from 'src/components/tables'
 
 export default function ListGroupContentCard({
   title,
@@ -13,10 +14,32 @@ export default function ListGroupContentCard({
   isFetching,
   error,
   errorMessage,
+  tooltip = false,
 }) {
   let bodyClass = ''
   if (!isFetching && !error) {
     bodyClass = 'p-0'
+  }
+  function bodycontent(item) {
+    // Wrapping fancy objects with tooltip has bad result so we ensure we only do ones
+    // that produce legible results
+    if (
+      tooltip &&
+      (typeof item.body === 'string' ||
+        typeof item.body === 'number' ||
+        typeof item.body === 'boolean' ||
+        typeof item.body === 'bigint')
+    ) {
+      return CellTip(item.body, true)
+    }
+
+    return item.body
+  }
+  function classcontent(item) {
+    if (item.className !== undefined) {
+      return <span className={item.className}>{bodycontent(item) ?? null}</span>
+    }
+    return bodycontent(item) ?? null
   }
   return (
     <CippContentCard
@@ -32,10 +55,10 @@ export default function ListGroupContentCard({
           {content.map((item, index) => (
             <CListGroupItem
               key={index}
-              className="d-flex justify-content-between align-items-center"
+              className="d-flex justify-content-between align-items-center overflow-auto"
             >
-              {item.heading ? <h6 className="w-50 mb-0">{item.heading}</h6> : null}
-              {item.body ?? null}
+              {item.heading ? <h6 className="w-50 mb-0 mr-15">{item.heading}</h6> : null}
+              {classcontent(item)}
               {item.link ? <a href={item.link}>{item.linkText ?? 'URL'}</a> : null}
             </CListGroupItem>
           ))}
@@ -54,10 +77,12 @@ ListGroupContentCard.propTypes = {
       body: PropTypes.any,
       link: PropTypes.string,
       linkText: PropTypes.string,
+      className: PropTypes.string,
     }),
   ).isRequired,
   className: PropTypes.string,
   isFetching: PropTypes.bool,
   error: PropTypes.object,
   errorMessage: PropTypes.string,
+  tooltip: PropTypes.bool,
 }

--- a/src/components/layout/AppFooter.js
+++ b/src/components/layout/AppFooter.js
@@ -8,7 +8,7 @@ const AppFooter = () => {
     <CFooter className="d-flex justify-content-between align-items-center">
       <div className="sponsors">
         <p>
-          This application is sponsored by
+          This application is sponsored by&nbsp;
           <CLink href="https://www.huntress.com/">
             <CImage src={huntressLogo} alt="Huntress" />
           </CLink>

--- a/src/components/tables/CellBoolean.js
+++ b/src/components/tables/CellBoolean.js
@@ -12,7 +12,20 @@ const IconWarning = () => <FontAwesomeIcon icon={faExclamationCircle} className=
 const IconError = () => <FontAwesomeIcon icon={faTimesCircle} className="text-danger" />
 const IconSuccess = () => <FontAwesomeIcon icon={faCheckCircle} className="text-success" />
 
-export default function CellBoolean({ cell, warning = false, reverse = false }) {
+function nocolour(colourless, content) {
+  if (colourless) {
+    return <span className="no-colour">{content}</span>
+  }
+
+  return content
+}
+
+export default function CellBoolean({
+  cell,
+  warning = false,
+  reverse = false,
+  colourless = false,
+}) {
   let normalized = cell
   if (typeof cell === 'boolean') {
     normalized = cell
@@ -27,13 +40,13 @@ export default function CellBoolean({ cell, warning = false, reverse = false }) 
   if (cell === '') {
     return <CellBadge label="No Data" color="info" />
   } else if (!reverse && !warning) {
-    return normalized ? <IconSuccess /> : <IconError />
+    return nocolour(colourless, normalized ? <IconSuccess /> : <IconError />)
   } else if (!reverse && warning) {
-    return normalized ? <IconSuccess /> : <IconWarning />
+    return nocolour(colourless, normalized ? <IconSuccess /> : <IconWarning />)
   } else if (reverse && !warning) {
-    return normalized ? <IconError /> : <IconSuccess />
+    return nocolour(colourless, normalized ? <IconError /> : <IconSuccess />)
   } else if (reverse && warning) {
-    return normalized ? <IconWarning /> : <IconSuccess />
+    return nocolour(colourless, normalized ? <IconWarning /> : <IconSuccess />)
   }
 }
 
@@ -41,17 +54,19 @@ CellBoolean.propTypes = {
   cell: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   warning: PropTypes.bool,
   reverse: PropTypes.bool,
+  colourless: PropTypes.bool,
 }
 
 /**
  *
  * @param [reverse]
  * @param [warning]
+ * @param [colourless]
  * @returns {function(*, *, *, *): *}
  */
 export const cellBooleanFormatter =
-  ({ reverse = false, warning = false } = {}) =>
+  ({ reverse = false, warning = false, colourless = false } = {}) =>
   (row, index, column, id) => {
     const cell = column.selector(row)
-    return CellBoolean({ cell, reverse, warning })
+    return CellBoolean({ cell, warning, reverse, colourless })
   }

--- a/src/components/tables/CellBoolean.js
+++ b/src/components/tables/CellBoolean.js
@@ -12,14 +12,22 @@ const IconWarning = () => <FontAwesomeIcon icon={faExclamationCircle} className=
 const IconError = () => <FontAwesomeIcon icon={faTimesCircle} className="text-danger" />
 const IconSuccess = () => <FontAwesomeIcon icon={faCheckCircle} className="text-success" />
 
-function nocolour(colourless, content) {
-  if (colourless) {
+function nocolour(iscolourless, content) {
+  if (iscolourless) {
     return <span className="no-colour">{content}</span>
   }
 
   return content
 }
 
+/**
+ *
+ * @param [cell]
+ * @param [warning]
+ * @param [reverse]
+ * @param [colourless]
+ * @returns {function(*, *, *, *): *}
+ */
 export default function CellBoolean({
   cell,
   warning = false,
@@ -30,9 +38,13 @@ export default function CellBoolean({
   if (typeof cell === 'boolean') {
     normalized = cell
   } else if (typeof cell === 'string') {
-    if (cell.toLowerCase() === 'success' || cell.toLowerCase() === 'pass') {
+    if (
+      cell.toLowerCase() === 'success' ||
+      cell.toLowerCase() === 'pass' ||
+      cell.toLowerCase() === 'true'
+    ) {
       normalized = true
-    } else if (cell.toLowerCase() === 'fail') {
+    } else if (cell.toLowerCase() === 'fail' || cell.toLowerCase() === 'false') {
       normalized = false
     }
   }
@@ -53,7 +65,7 @@ export default function CellBoolean({
 }
 
 CellBoolean.propTypes = {
-  cell: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  cell: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.any]),
   warning: PropTypes.bool,
   reverse: PropTypes.bool,
   colourless: PropTypes.bool,
@@ -61,13 +73,13 @@ CellBoolean.propTypes = {
 
 /**
  *
- * @param [reverse]
  * @param [warning]
+ * @param [reverse]
  * @param [colourless]
  * @returns {function(*, *, *, *): *}
  */
 export const cellBooleanFormatter =
-  ({ reverse = false, warning = false, colourless = false } = {}) =>
+  ({ warning = false, reverse = false, colourless = false } = {}) =>
   (row, index, column, id) => {
     const cell = column.selector(row)
     return CellBoolean({ cell, warning, reverse, colourless })

--- a/src/components/tables/CellBoolean.js
+++ b/src/components/tables/CellBoolean.js
@@ -39,6 +39,8 @@ export default function CellBoolean({
 
   if (cell === '') {
     return <CellBadge label="No Data" color="info" />
+  } else if (colourless && warning && reverse) {
+    return nocolour(colourless, normalized ? <IconWarning /> : <IconError />)
   } else if (!reverse && !warning) {
     return nocolour(colourless, normalized ? <IconSuccess /> : <IconError />)
   } else if (!reverse && warning) {

--- a/src/components/tables/CellBoolean.js
+++ b/src/components/tables/CellBoolean.js
@@ -26,6 +26,7 @@ function nocolour(iscolourless, content) {
  * @param [warning]
  * @param [reverse]
  * @param [colourless]
+ * @param [noDataIsFalse]
  * @returns {function(*, *, *, *): *}
  */
 export default function CellBoolean({
@@ -33,6 +34,7 @@ export default function CellBoolean({
   warning = false,
   reverse = false,
   colourless = false,
+  noDataIsFalse = false,
 }) {
   let normalized = cell
   if (typeof cell === 'boolean') {
@@ -49,7 +51,7 @@ export default function CellBoolean({
     }
   }
 
-  if (cell === '') {
+  if (cell === '' && !noDataIsFalse) {
     return <CellBadge label="No Data" color="info" />
   } else if (colourless && warning && reverse) {
     return nocolour(colourless, normalized ? <IconWarning /> : <IconError />)
@@ -69,6 +71,7 @@ CellBoolean.propTypes = {
   warning: PropTypes.bool,
   reverse: PropTypes.bool,
   colourless: PropTypes.bool,
+  noDataIsFalse: PropTypes.bool,
 }
 
 /**
@@ -76,11 +79,12 @@ CellBoolean.propTypes = {
  * @param [warning]
  * @param [reverse]
  * @param [colourless]
+ * @param [noDataIsFalse]
  * @returns {function(*, *, *, *): *}
  */
 export const cellBooleanFormatter =
-  ({ warning = false, reverse = false, colourless = false } = {}) =>
+  ({ warning = false, reverse = false, colourless = false, noDataIsFalse } = {}) =>
   (row, index, column, id) => {
     const cell = column.selector(row)
-    return CellBoolean({ cell, warning, reverse, colourless })
+    return CellBoolean({ cell, warning, reverse, colourless, noDataIsFalse })
   }

--- a/src/components/tables/CellTip.js
+++ b/src/components/tables/CellTip.js
@@ -23,13 +23,21 @@ export const CellTipButton = (value, display) => {
   )
 }
 
-export const CellTip = (value) => {
+export const CellTip = (value, overflow = false) => {
   if (!value) {
     return <div />
   }
-  return (
-    <CTooltip content={value}>
-      <div className="celltip-content-nowrap">{String(value)}</div>
-    </CTooltip>
-  )
+  if (!overflow) {
+    return (
+      <CTooltip content={value}>
+        <div className="celltip-content-nowrap">{String(value)}</div>
+      </CTooltip>
+    )
+  } else {
+    return (
+      <CTooltip content={value}>
+        <div>{String(value)}</div>
+      </CTooltip>
+    )
+  }
 }

--- a/src/scss/_custom.scss
+++ b/src/scss/_custom.scss
@@ -567,3 +567,18 @@
 .select-width {
   min-width: 100%;
 }
+
+.mr-15 {
+  margin-right: 15px;
+}
+
+.no-colour {
+
+  .text-success {
+    color: var(--cui-body-color) !important;
+  }
+
+  .text-danger {
+    color: var(--cui-body-color) !important;
+  }
+}

--- a/src/scss/_custom.scss
+++ b/src/scss/_custom.scss
@@ -582,3 +582,7 @@
     color: var(--cui-body-color) !important;
   }
 }
+
+.teams-wide-card {
+  width: 500px;
+}

--- a/src/views/email-exchange/administration/ContactsList.js
+++ b/src/views/email-exchange/administration/ContactsList.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { useSelector } from 'react-redux'
 import { CButton } from '@coreui/react'
 import { CippPageList } from 'src/components/layout'
-import { cellBooleanFormatter } from 'src/components/tables'
+import { CellTip, cellBooleanFormatter } from 'src/components/tables'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEdit } from '@fortawesome/free-solid-svg-icons'
 const Actions = (row, rowIndex, formatExtraData) => {
@@ -24,18 +24,21 @@ const columns = [
     selector: (row) => row['displayName'],
     name: 'Display Name',
     sortable: true,
+    cell: (row) => CellTip(row['displayName']),
     exportSelector: 'displayName',
   },
   {
     selector: (row) => row['mail'],
     name: 'E-Mail Address',
     sortable: true,
+    cell: (row) => CellTip(row['mail']),
     exportSelector: 'mail',
   },
   {
-    selector: (row) => row['company'],
+    selector: (row) => row['companyName'],
     name: 'Company',
     sortable: true,
+    cell: (row) => CellTip(row['companyName']),
     exportSelector: 'company',
   },
   {
@@ -48,11 +51,12 @@ const columns = [
     name: 'On Premises Sync',
     sortable: true,
     exportSelector: 'onPremisesSyncEnabled',
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
   },
   {
     name: 'Actions',
     cell: Actions,
+    maxWidth: '80px',
   },
 ]
 

--- a/src/views/email-exchange/administration/MailboxesList.js
+++ b/src/views/email-exchange/administration/MailboxesList.js
@@ -7,6 +7,7 @@ import { faEye, faEdit, faEllipsisV, faMobileAlt } from '@fortawesome/free-solid
 import { Link } from 'react-router-dom'
 import { CippActionsOffcanvas } from 'src/components/utilities'
 import { TitleButton } from 'src/components/buttons'
+import { CellTip } from 'src/components/tables'
 
 const MailboxList = () => {
   const tenant = useSelector((state) => state.app.currentTenant)
@@ -109,30 +110,38 @@ const MailboxList = () => {
       name: 'User Prinicipal Name',
       sortable: true,
       exportSelector: 'UPN',
+      cell: (row) => CellTip(row['UPN']),
+      maxWidth: '300px',
     },
     {
       selector: (row) => row['displayName'],
       name: 'Display Name',
       sortable: true,
+      cell: (row) => CellTip(row['displayName']),
       exportSelector: 'displayName',
+      maxWidth: '300px',
     },
     {
       selector: (row) => row['primarySmtpAddress'],
       name: 'Primary E-mail Address',
       sortable: true,
+      cell: (row) => CellTip(row['primarySmtpAddress']),
       exportSelector: 'primarySmtpAddress',
+      maxWidth: '300px',
     },
     {
       selector: (row) => row['recipientType'],
       name: 'Recipient Type',
       sortable: true,
       exportSelector: 'recipientType',
+      maxWidth: '150px',
     },
     {
       selector: (row) => row['recipientTypeDetails'],
       name: 'Recipient Type Details',
       sortable: true,
       exportSelector: 'recipientTypeDetails',
+      maxWidth: '170px',
     },
     {
       name: 'Additional Email Addresses',
@@ -144,6 +153,7 @@ const MailboxList = () => {
     {
       name: 'Actions',
       cell: Offcanvas,
+      maxWidth: '150px',
     },
   ]
   const titleButton = (

--- a/src/views/email-exchange/administration/ViewMobileDevices.js
+++ b/src/views/email-exchange/administration/ViewMobileDevices.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { useSelector } from 'react-redux'
 import { CippPageList } from 'src/components/layout'
 import useQuery from 'src/hooks/useQuery'
+import { CellTip, cellDateFormatter } from 'src/components/tables'
 
 //TODO: Add CellBoolean
 const columns = [
@@ -9,6 +10,7 @@ const columns = [
     selector: (row) => row['clientType'],
     name: 'Client Type',
     sortable: true,
+    cell: (row) => CellTip(row['clientType']),
     exportSelector: 'clientType',
   },
   {
@@ -27,24 +29,28 @@ const columns = [
     selector: (row) => row['deviceFriendlyName'],
     name: 'Friendly Name',
     sortable: true,
+    cell: (row) => CellTip(row['deviceFriendlyName']),
     exportSelector: 'deviceFriendlyName',
   },
   {
     selector: (row) => row['deviceModel'],
     name: 'Model',
     sortable: true,
+    cell: (row) => CellTip(row['deviceModel']),
     exportSelector: 'deviceModel',
   },
   {
     selector: (row) => row['deviceOS'],
     name: 'OS',
     sortable: true,
+    cell: (row) => CellTip(row['deviceOS']),
     exportSelector: 'deviceOS',
   },
   {
     selector: (row) => row['deviceType'],
     name: 'Device Type',
     sortable: true,
+    cell: (row) => CellTip(row['deviceType']),
     exportSelector: 'deviceType',
   },
   {
@@ -52,18 +58,21 @@ const columns = [
     name: 'First Sync',
     sortable: true,
     exportSelector: 'firstSync',
+    cell: cellDateFormatter(),
   },
   {
     selector: (row) => row['lastSyncAttempt'],
     name: 'Last Sync Attempt',
     sortable: true,
     exportSelector: 'lastSyncAttempt',
+    cell: cellDateFormatter(),
   },
   {
     selector: (row) => row['lastSuccessSync'],
     name: 'Last Succesfull Sync',
     sortable: true,
     exportSelector: 'lastSuccessSync',
+    cell: cellDateFormatter(),
   },
   {
     selector: (row) => row['status'],

--- a/src/views/email-exchange/reports/MailboxClientAccessSettingsList.js
+++ b/src/views/email-exchange/reports/MailboxClientAccessSettingsList.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
-import { cellBooleanFormatter } from 'src/components/tables'
+import { CellTip, cellBooleanFormatter } from 'src/components/tables'
 import { CippPageList } from 'src/components/layout'
 
 const columns = [
@@ -8,19 +8,23 @@ const columns = [
     selector: (row) => row['displayName'],
     name: 'Display Name',
     sortable: true,
+    cell: (row) => CellTip(row['displayName']),
     exportSelector: 'displayName',
+    minWidth: '200px',
   },
   {
     selector: (row) => row['primarySmtpAddress'],
     name: 'Primary E-mail',
     sortable: true,
+    cell: (row) => CellTip(row['primarySmtpAddress']),
     exportSelector: 'primarySmtpAddress',
+    minWidth: '200px',
   },
   {
     selector: (row) => row['ecpenabled'],
     name: 'ECP Enabled',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     center: true,
     exportSelector: 'ecpenabled',
   },
@@ -28,7 +32,7 @@ const columns = [
     selector: (row) => row['ewsenabled'],
     name: 'EWS Enabled',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     center: true,
     exportSelector: 'ewsenabled',
   },
@@ -36,7 +40,7 @@ const columns = [
     selector: (row) => row['imapenabled'],
     name: 'IMAP Enabled',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     center: true,
     exportSelector: 'imapenabled',
   },
@@ -44,7 +48,7 @@ const columns = [
     selector: (row) => row['mapienabled'],
     name: 'MAPI Enabled',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     center: true,
     exportSelector: 'mapienabled',
   },
@@ -52,7 +56,7 @@ const columns = [
     selector: (row) => row['owaenabled'],
     name: 'OWA Enabled',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     center: true,
     exportSelector: 'owaenabled',
   },
@@ -60,7 +64,7 @@ const columns = [
     selector: (row) => row['popenabled'],
     name: 'POP Enabled',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     center: true,
     exportSelector: 'popenabled',
   },
@@ -68,7 +72,7 @@ const columns = [
     selector: (row) => row['activesyncenabled'],
     name: 'ActiveSync Enabled',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     center: true,
     exportSelector: 'activesyncenabled',
   },

--- a/src/views/email-exchange/reports/MailboxStatisticsList.js
+++ b/src/views/email-exchange/reports/MailboxStatisticsList.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
-import { cellBooleanFormatter } from 'src/components/tables'
+import { CellTip, cellBooleanFormatter } from 'src/components/tables'
 import { CippPageList } from 'src/components/layout'
 
 const conditionalRowStyles = [
@@ -19,12 +19,15 @@ const columns = [
     selector: (row) => row['UPN'],
     name: 'User Prinicipal Name',
     sortable: true,
+    cell: (row) => CellTip(row['UPN']),
     exportSelector: 'UPN',
+    minWidth: '200px',
   },
   {
     selector: (row) => row['displayName'],
     name: 'Display Name',
     sortable: true,
+    cell: (row) => CellTip(row['displayName']),
     exportSelector: 'displayName',
   },
   {
@@ -55,7 +58,7 @@ const columns = [
     selector: (row) => row['HasArchive'],
     name: 'Archiving Enabled',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     exportSelector: 'HasArchive',
   },
 ]

--- a/src/views/email-exchange/reports/PhishingPoliciesList.js
+++ b/src/views/email-exchange/reports/PhishingPoliciesList.js
@@ -21,14 +21,14 @@ const columns = [
     selector: (row) => row['Enabled'],
     name: 'Enabled',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ warning: true, colourless: true }),
     exportSelector: 'Enabled',
   },
   {
     selector: (row) => row['ExcludedSenders'],
     name: 'Excluded Senders',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ warning: true, colourless: true, noDataIsFalse: true }),
     exportSelector: 'ExcludedSenders',
   },
   {
@@ -40,7 +40,7 @@ const columns = [
   },
   {
     selector: (row) => row['WhenChangedUTC'],
-    name: 'Last Change Date',
+    name: 'Last Change Date (Local)',
     sortable: true,
     cell: cellDateFormatter(),
     exportSelector: 'WhenChangedUTC',

--- a/src/views/email-exchange/transport/ListTransportTemplates.js
+++ b/src/views/email-exchange/transport/ListTransportTemplates.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { CippCodeBlock, CippOffcanvas } from 'src/components/utilities'
-import { CippDatatable } from 'src/components/tables'
+import { CippDatatable, CellTip } from 'src/components/tables'
 import {
   CCardBody,
   CButton,
@@ -69,23 +69,27 @@ const TransportListTemplates = () => {
       name: 'Display Name',
       selector: (row) => row['name'],
       sortable: true,
+      cell: (row) => CellTip(row['name']),
       exportSelector: 'name',
     },
     {
-      name: 'Description',
-      selector: (row) => row['Description'],
+      name: 'Comments',
+      selector: (row) => row['comments'],
       sortable: true,
-      exportSelector: 'Description',
+      cell: (row) => CellTip(row['comments']),
+      exportSelector: 'Comments',
     },
     {
       name: 'GUID',
       selector: (row) => row['GUID'],
       sortable: true,
+      cell: (row) => CellTip(row['GUID']),
       exportSelector: 'GUID',
     },
     {
       name: 'Actions',
       cell: Offcanvas,
+      maxWidth: '80px',
     },
   ]
 

--- a/src/views/email-exchange/transport/TransportRules.js
+++ b/src/views/email-exchange/transport/TransportRules.js
@@ -5,6 +5,7 @@ import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { CippPageList } from 'src/components/layout'
 import { CippActionsOffcanvas } from 'src/components/utilities'
+import { CellTip } from 'src/components/tables'
 
 const Offcanvas = (row, rowIndex, formatExtraData) => {
   const tenant = useSelector((state) => state.app.currentTenant)
@@ -73,6 +74,7 @@ const columns = [
     selector: (row) => row['Name'],
     sortable: true,
     wrap: true,
+    cell: (row) => CellTip(row['Name']),
     exportSelector: 'Name',
   },
   {
@@ -106,6 +108,7 @@ const columns = [
   {
     name: 'Actions',
     cell: Offcanvas,
+    maxWidth: '80px',
   },
 ]
 

--- a/src/views/endpoint/MEM/MEMListPolicies.js
+++ b/src/views/endpoint/MEM/MEMListPolicies.js
@@ -79,6 +79,7 @@ const columns = [
   {
     name: 'Actions',
     cell: Actions,
+    maxWidth: '80px',
   },
 ]
 

--- a/src/views/endpoint/MEM/MEMListPolicyTemplates.js
+++ b/src/views/endpoint/MEM/MEMListPolicyTemplates.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { CippCodeBlock, CippOffcanvas } from 'src/components/utilities'
-import { CippDatatable } from 'src/components/tables'
+import { CellTip, CippDatatable } from 'src/components/tables'
 import {
   CCardBody,
   CButton,
@@ -71,19 +71,26 @@ const AutopilotListTemplates = () => {
       name: 'Display Name',
       selector: (row) => row['Displayname'],
       sortable: true,
+      cell: (row) => CellTip(row['Displayname']),
       exportSelector: 'Displayname',
+      minWidth: '400px',
+      maxWidth: '400px',
     },
     {
       name: 'Description',
       selector: (row) => row['Description'],
       sortable: true,
+      cell: (row) => CellTip(row['Description']),
       exportSelector: 'Description',
+      minWidth: '400px',
+      maxWidth: '400px',
     },
     {
       name: 'Type',
       selector: (row) => row['Type'],
       sortable: true,
       exportSelector: 'Type',
+      maxWidth: '100px',
     },
     {
       name: 'GUID',
@@ -94,6 +101,7 @@ const AutopilotListTemplates = () => {
     {
       name: 'Actions',
       cell: Offcanvas,
+      maxWidth: '100px',
     },
   ]
 

--- a/src/views/endpoint/applications/ApplicationsList.js
+++ b/src/views/endpoint/applications/ApplicationsList.js
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { CippPageList } from 'src/components/layout'
 import { faEllipsisV, faGlobeEurope, faPager, faUser } from '@fortawesome/free-solid-svg-icons'
 import { CippActionsOffcanvas } from 'src/components/utilities'
+import { CellTip } from 'src/components/tables'
 
 const Offcanvas = (row, rowIndex, formatExtraData) => {
   const tenant = useSelector((state) => state.app.currentTenant)
@@ -90,7 +91,9 @@ const columns = [
     selector: (row) => row.displayName,
     name: 'Name',
     sortable: true,
+    cell: (row) => CellTip(row.displayName),
     exportSelector: 'displayName',
+    minWidth: '350px',
   },
   {
     selector: (row) => row.publishingState,
@@ -102,12 +105,14 @@ const columns = [
     selector: (row) => row.installCommandLine,
     name: 'Install Command',
     sortable: true,
+    cell: (row) => CellTip(row.installCommandLine),
     exportSelector: 'installCommandLine',
   },
   {
     selector: (row) => row.uninstallCommandLine,
     name: 'Uninstall Command',
     sortable: true,
+    cell: (row) => CellTip(row.uninstallCommandLine),
     exportSelector: 'uninstallCommandLine',
   },
   {

--- a/src/views/endpoint/applications/ListApplicationQueue.js
+++ b/src/views/endpoint/applications/ListApplicationQueue.js
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { CippPageList } from 'src/components/layout'
 import { ModalService } from 'src/components/utilities'
 import { useLazyGenericGetRequestQuery } from 'src/store/api/app'
+import { CellTip } from 'src/components/tables'
 
 const RefreshAction = () => {
   const [execStandards, execStandardsResults] = useLazyGenericGetRequestQuery()
@@ -72,24 +73,30 @@ const ListApplicationQueue = () => {
       name: 'Tenant',
       selector: (row) => row['tenantName'],
       sortable: true,
+      cell: (row) => CellTip(row['tenantName']),
       exportSelector: 'tenantName',
+      minWidth: '200px',
     },
     {
       name: 'Application Name',
       selector: (row) => row['applicationName'],
       sortable: true,
+      cell: (row) => CellTip(row['applicationName']),
       exportSelector: 'applicationName',
+      minWidth: '200px',
     },
     {
       name: 'Install command',
       selector: (row) => row['cmdLine'],
       sortable: true,
+      cell: (row) => CellTip(row['cmdLine']),
       exportSelector: 'cmdLine',
     },
     {
       name: 'Assign To',
       selector: (row) => row['assignTo'],
       sortable: true,
+      cell: (row) => CellTip(row['assignTo']),
       exportSelector: 'assignTo',
     },
     {

--- a/src/views/endpoint/autopilot/AutopilotListDevices.js
+++ b/src/views/endpoint/autopilot/AutopilotListDevices.js
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { CippPageList } from 'src/components/layout'
 import { ModalService } from 'src/components/utilities'
 import { useLazyGenericGetRequestQuery } from 'src/store/api/app'
+import { CellTip } from 'src/components/tables'
 
 const AutopilotListDevices = () => {
   const tenant = useSelector((state) => state.app.currentTenant)
@@ -42,36 +43,42 @@ const AutopilotListDevices = () => {
       selector: (row) => row['displayName'],
       name: 'Display Name',
       sortable: true,
+      cell: (row) => CellTip(row['displayName']),
       exportSelector: 'displayName',
     },
     {
       selector: (row) => row['serialNumber'],
       name: 'Serial',
       sortable: true,
+      cell: (row) => CellTip(row['serialNumber']),
       exportSelector: 'serialNumber',
     },
     {
       selector: (row) => row['model'],
       name: 'Model',
       sortable: true,
+      cell: (row) => CellTip(row['model']),
       exportSelector: 'model',
     },
     {
       selector: (row) => row['manufacturer'],
       name: 'Manufacturer',
       sortable: true,
+      cell: (row) => CellTip(row['manufacturer']),
       exportSelector: 'manufacturer',
     },
     {
       selector: (row) => row['groupTag'],
       name: 'Group Tag',
       sortable: true,
+      cell: (row) => CellTip(row['groupTag']),
       exportSelector: 'groupTag',
     },
     {
       selector: (row) => row['enrollmentState'],
       name: 'Enrollment',
       sortable: true,
+      cell: (row) => CellTip(row['enrollmentState']),
       exportSelector: 'enrollmentState',
     },
     {

--- a/src/views/endpoint/autopilot/AutopilotListProfiles.js
+++ b/src/views/endpoint/autopilot/AutopilotListProfiles.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
-import { cellBooleanFormatter } from 'src/components/tables'
+import { CellTip, cellBooleanFormatter } from 'src/components/tables'
 import { CButton } from '@coreui/react'
 import { faEye } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -42,6 +42,7 @@ const columns = [
     selector: (row) => row['displayName'],
     name: 'Name',
     sortable: true,
+    cell: (row) => CellTip(row['displayName']),
     wrap: true,
     exportSelector: 'displayName',
   },
@@ -49,6 +50,7 @@ const columns = [
     selector: (row) => row['Description'],
     name: 'Description',
     sortable: true,
+    cell: (row) => CellTip(row['Description']),
     wrap: true,
     exportSelector: 'Description',
   },
@@ -56,19 +58,21 @@ const columns = [
     selector: (row) => row['language'],
     name: 'Language',
     sortable: true,
+    cell: (row) => CellTip(row['language']),
     exportSelector: 'language',
   },
   {
     selector: (row) => row['extractHardwareHash'],
     name: 'Convert to Autopilot',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     exportSelector: 'extractHardwareHash',
   },
   {
     selector: (row) => row['deviceNameTemplate'],
     name: 'Device Name Template',
     sortable: true,
+    cell: (row) => CellTip(row['deviceNameTemplate']),
     exportSelector: 'deviceNameTemplate',
   },
   {

--- a/src/views/endpoint/autopilot/AutopilotListStatusPages.js
+++ b/src/views/endpoint/autopilot/AutopilotListStatusPages.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
-import { cellBooleanFormatter } from 'src/components/tables'
+import { CellTip, cellBooleanFormatter } from 'src/components/tables'
 import { CippPageList } from 'src/components/layout'
 
 const columns = [
@@ -8,12 +8,15 @@ const columns = [
     selector: (row) => row['displayName'],
     name: 'Name',
     sortable: true,
+    cell: (row) => CellTip(row['displayName']),
     exportSelector: 'displayName',
+    minWidth: '250px',
   },
   {
     selector: (row) => row['Description'],
     name: 'Description',
     sortable: true,
+    cell: (row) => CellTip(row['Description']),
     exportSelector: 'Description',
   },
   {
@@ -26,21 +29,21 @@ const columns = [
     selector: (row) => row['showInstallationProgress'],
     name: 'Show Installation Progress',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     exportSelector: 'showInstallationProgress',
   },
   {
     selector: (row) => row['blockDeviceSetupRetryByUser'],
     name: 'Block Retries',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     exportSelector: 'blockDeviceSetupRetryByUser',
   },
   {
     selector: (row) => row['allowDeviceResetOnInstallFailure'],
     name: 'Allow reset on failure',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     exportSelector: 'allowDeviceResetOnInstallFailure',
   },
   {
@@ -48,7 +51,7 @@ const columns = [
     name: 'Allow usage on failure',
     sortable: true,
     exportSelector: 'allowDeviceUseOnInstallFailure',
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
   },
 ]
 

--- a/src/views/identity/administration/Groups.js
+++ b/src/views/identity/administration/Groups.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { CButton } from '@coreui/react'
-import { cellBooleanFormatter } from 'src/components/tables'
+import { cellBooleanFormatter, CellTip } from 'src/components/tables'
 import { faEdit } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { CippPageList } from 'src/components/layout'
@@ -26,6 +26,7 @@ const columns = [
     name: 'Name',
     selector: (row) => row['displayName'],
     sortable: true,
+    cell: (row) => CellTip(row['displayName']),
     exportSelector: 'displayName',
     grow: 2,
   },
@@ -34,33 +35,39 @@ const columns = [
     selector: (row) => row['calculatedGroupType'],
     sortable: true,
     exportSelector: 'calculatedGroupType',
+    cell: (row) => CellTip(row['calculatedGroupType']),
+    minWidth: '165px',
   },
   {
     name: 'Dynamic Group',
     selector: (row) => row['dynamicGroupBool'],
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     sortable: true,
     exportSelector: 'dynamicGroupBool',
+    minWidth: '145px',
   },
   {
     name: 'Teams Enabled',
     selector: (row) => row['teamsEnabled'],
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     exportSelector: 'teamsEnabled',
+    minWidth: '140px',
   },
   {
     name: 'On-Prem Sync',
     selector: (row) => row['onPremisesSyncEnabled'],
     sortable: true,
-    cell: cellBooleanFormatter({ warning: true }),
+    cell: cellBooleanFormatter({ colourless: true }),
     exportSelector: 'onPremisessSyncEnabled',
+    minWidth: '140px',
   },
   {
     name: 'Email',
     selector: (row) => row['mail'],
     sortable: true,
     exportSelector: 'mail',
+    cell: (row) => CellTip(row['mail']),
     grow: 2,
   },
   {

--- a/src/views/identity/administration/Roles.js
+++ b/src/views/identity/administration/Roles.js
@@ -5,6 +5,7 @@ import { CButton } from '@coreui/react'
 import { faEye } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { CippOffcanvas } from 'src/components/utilities'
+import { CellTip } from 'src/components/tables'
 
 const Offcanvas = (row, rowIndex, formatExtraData) => {
   const [ocVisible, setOCVisible] = useState(false)
@@ -33,12 +34,15 @@ const columns = [
     selector: (row) => row['DisplayName'],
     name: 'Role Name',
     sortable: true,
+    cell: (row) => CellTip(row['DisplayName']),
     exportSelector: 'DisplayName',
+    maxWidth: '350px',
   },
   {
     selector: (row) => row['Description'],
     name: 'Description',
     sortable: true,
+    cell: (row) => CellTip(row['Description'], true),
     wrap: true,
     exportSelector: 'Description',
   },
@@ -47,6 +51,7 @@ const columns = [
     name: 'Members',
     cell: Offcanvas,
     exportSelector: 'Members',
+    maxWidth: '80px',
   },
 ]
 

--- a/src/views/identity/administration/UserDevices.js
+++ b/src/views/identity/administration/UserDevices.js
@@ -6,6 +6,8 @@ import { DatatableContentCard } from 'src/components/contentcards'
 import { cellBooleanFormatter, cellNullTextFormatter } from 'src/components/tables'
 import { useListUserDevicesQuery } from 'src/store/api/devices'
 
+let tenantDomainFileScope = ''
+
 const columns = [
   {
     name: 'Display Name',
@@ -19,7 +21,7 @@ const columns = [
         return (
           <CLink
             target="_blank"
-            href={`https://endpoint.microsoft.com/${row.tenantDomain}#blade/Microsoft_Intune_Devices/DeviceSettingsMenuBlade/overview/mdmDeviceId/${row.EPMID}`}
+            href={`https://endpoint.microsoft.com/${tenantDomainFileScope}#blade/Microsoft_Intune_Devices/DeviceSettingsMenuBlade/overview/mdmDeviceId/${row.EPMID}`}
           >
             {row.displayName}
           </CLink>
@@ -96,6 +98,7 @@ const columns = [
     sortable: true,
     cell: cellNullTextFormatter(),
     exportSelector: 'enrollmentType',
+    minWidth: '200px',
   },
   {
     name: 'Management Type',
@@ -108,7 +111,7 @@ const columns = [
     name: 'On-Premises Sync Enabled',
     selector: (row) => row['onPremisesSyncEnabled'],
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     exportSelector: 'onPremisessSyncEnabled',
   },
   {
@@ -126,7 +129,7 @@ export default function UserDevices({ userId, tenantDomain, className = null }) 
     isFetching,
     error,
   } = useListUserDevicesQuery({ userId, tenantDomain })
-
+  tenantDomainFileScope = tenantDomain
   // inject tenant domain into devices for column render
   const mapped = devices.map((device) => ({ ...device, tenantDomain }))
 

--- a/src/views/identity/administration/UserDevices.js
+++ b/src/views/identity/administration/UserDevices.js
@@ -78,13 +78,17 @@ const columns = [
     cell: cellNullTextFormatter(),
     exportSelector: 'createdDateTime',
   },
+  /*
+  * This should not be used, it is not anywhere near accurate, it is out by days even weeks 
+  * in my testing, I don't recommend we display it, we have alternate sources for this
+  * as well which are significantly closer to (if not) accurate - knightian
   {
     name: 'Approx Last SignIn',
     selector: (row) => row['approximateLastSignInDateTime'],
     sortable: true,
     cell: cellNullTextFormatter(),
     exportSelector: 'approximateLastSignInDateTime',
-  },
+  },**/
   {
     name: 'Ownership',
     selector: (row) => row['deviceOwnership'],

--- a/src/views/identity/administration/UserEmailDetails.js
+++ b/src/views/identity/administration/UserEmailDetails.js
@@ -27,6 +27,7 @@ export default function UserEmailDetails({ user, isFetching, error, className = 
       isFetching={isFetching}
       error={error}
       errorMessage="Failed to fetch email details"
+      tooltip={true}
     />
   )
 }

--- a/src/views/identity/administration/UserEmailSettings.js
+++ b/src/views/identity/administration/UserEmailSettings.js
@@ -5,54 +5,55 @@ import { CellBoolean } from 'src/components/tables'
 import { useListMailboxDetailsQuery } from 'src/store/api/mailbox'
 import { ListGroupContentCard } from 'src/components/contentcards'
 
-const formatter = (cell) => CellBoolean({ cell })
+const formatter = (cell, warning = false, reverse = false, colourless = false) =>
+  CellBoolean({ cell, warning, reverse, colourless })
 
 export default function UserEmailSettings({ userId, tenantDomain, className = null }) {
   const { data: details, isFetching, error } = useListMailboxDetailsQuery({ userId, tenantDomain })
   const content = [
     {
       heading: 'User Not Restricted',
-      body: formatter(details?.BlockedForSpam),
+      body: formatter(details?.BlockedForSpam, false, true),
     },
     {
       heading: 'Litigation Hold',
-      body: formatter(details?.LitiationHold),
+      body: formatter(details?.LitiationHold, false, false, true),
     },
     {
       heading: 'Hidden from Address Lists',
-      body: formatter(details?.HiddenFromAddressLists),
+      body: formatter(details?.HiddenFromAddressLists, false, false, true),
     },
     {
       heading: 'EWS Enabled',
-      body: formatter(details?.EWSEnabled),
+      body: formatter(details?.EWSEnabled, false, false, true),
     },
     {
       heading: 'MAPI Enabled',
-      body: formatter(details?.MailboxMAPIEnabled),
+      body: formatter(details?.MailboxMAPIEnabled, false, false, true),
     },
     {
       heading: 'OWA Enabled',
-      body: formatter(details?.MailboxOWAEnabled),
+      body: formatter(details?.MailboxOWAEnabled, false, false, true),
     },
     {
       heading: 'IMAP Enabled',
-      body: formatter(details?.MailboxImapEnabled),
+      body: formatter(details?.MailboxImapEnabled, false, false, true),
     },
     {
       heading: 'POP Enabled',
-      body: formatter(details?.MailboxPopEnabled),
+      body: formatter(details?.MailboxPopEnabled, false, false, true),
     },
     {
       heading: 'Active Sync Enabled',
-      body: formatter(details?.MailboxActiveSyncEnabled),
+      body: formatter(details?.MailboxActiveSyncEnabled, false, false, true),
     },
     {
       heading: 'Forward and Deliver',
-      body: formatter(details?.ForwardAndDeliver),
+      body: formatter(details?.ForwardAndDeliver, false, false, true),
     },
     {
       heading: 'Forwarding Address',
-      body: formatter(details?.ForwardingAddress),
+      body: formatter(details?.ForwardingAddress, false, false, true),
     },
   ]
   return (

--- a/src/views/identity/administration/UserGroups.js
+++ b/src/views/identity/administration/UserGroups.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { CLink } from '@coreui/react'
 import { DatatableContentCard } from 'src/components/contentcards'
-import { CellBoolean } from 'src/components/tables'
+import { CellBoolean, CellTip, cellBooleanFormatter } from 'src/components/tables'
 import { faUsers } from '@fortawesome/free-solid-svg-icons'
 import { useListUserGroupsQuery } from 'src/store/api/groups'
 
@@ -14,6 +14,8 @@ const columns = [
     selector: (row) => row['DisplayName'],
     sortable: true,
     exportSelector: 'DisplayName',
+    cell: (row) => CellTip(row['DisplayName']),
+    minWidth: '200px',
     formatter: (cell, row) => {
       return (
         <CLink
@@ -36,12 +38,15 @@ const columns = [
     selector: (row) => row['Mail'],
     sortable: true,
     exportSelector: 'Mail',
+    cell: (row) => CellTip(row['Mail']),
+    minWidth: '200px',
   },
   {
     name: 'Security Group',
     selector: (row) => row['SecurityGroup'],
     sortable: true,
     exportSelector: 'SecurityGroup',
+    cell: cellBooleanFormatter({ colourless: true }),
     formatter,
   },
   {
@@ -49,6 +54,7 @@ const columns = [
     selector: (row) => row['GroupTypes'],
     sortable: true,
     exportSelector: 'GroupTypes',
+    cell: (row) => CellTip(row['GroupTypes']),
   },
   {
     name: 'On Premises Sync',

--- a/src/views/identity/administration/UserLastLoginDetails.js
+++ b/src/views/identity/administration/UserLastLoginDetails.js
@@ -9,7 +9,7 @@ export default function UserLastLoginDetails({ tenantDomain, userId, className =
 
   const content = [
     {
-      heading: 'Last Sign in Date',
+      heading: 'Last Sign in Date (UTC)',
       body: user.LastSigninDate,
     },
     {

--- a/src/views/identity/administration/UserOneDriveUsage.js
+++ b/src/views/identity/administration/UserOneDriveUsage.js
@@ -49,6 +49,7 @@ export default function UserOneDriveUsage({ userUPN, tenantDomain, className = n
       isFetching={isFetching}
       error={error}
       errorMessage={!noUsage ? 'Failed to fetch OneDrive details' : 'No OneDrive usage'}
+      tooltip={true}
     />
   )
 }

--- a/src/views/identity/administration/UserSigninLogs.js
+++ b/src/views/identity/administration/UserSigninLogs.js
@@ -9,7 +9,7 @@ import {
   CTableHeaderCell,
   CTableRow,
 } from '@coreui/react'
-import { CellTip, cellBooleanFormatter } from 'src/components/tables'
+import { CellTip, cellBooleanFormatter, cellDateFormatter } from 'src/components/tables'
 import { DatatableContentCard } from 'src/components/contentcards'
 import { faKey } from '@fortawesome/free-solid-svg-icons'
 import { ModalService } from 'src/components/utilities'
@@ -23,6 +23,44 @@ const rowStyle = (row, rowIndex) => {
   }
 
   return style
+}
+
+function ConvertErrorCode(row) {
+  try {
+    return row['LoginStatus']
+      .toString()
+      .replace('50126', '50126 (Invalid username or password)')
+      .replace(
+        '70044',
+        '70044 (The session has expired or is invalid due to sign-in frequency checks by conditional access)',
+      )
+      .replace('50089', '50089 (Flow token expired)')
+      .replace('53003', '53003 (Access has been blocked by Conditional Access policies)')
+      .replace(
+        '50140',
+        '50140 (This error occurred due to "Keep me signed in" interrupt when the user was signing-in)',
+      )
+      .replace('50097', '50097 (Device authentication required)')
+      .replace(
+        '65001',
+        "65001 (Application X doesn't have permission to access application Y or the permission has been revoked)",
+      )
+      .replace(
+        '50053',
+        '50053 (Account is locked because user tried to sign in too many times with an incorrect user ID or password)',
+      )
+      .replace('50020', '50020 (The user is unauthorized)')
+      .replace(
+        '50125',
+        '50125 (Sign-in was interrupted due to a password reset or password registration entry)',
+      )
+      .replace('50074', '50074 (User did not pass the MFA challenge)')
+      .replace('50133', '50133 (Session is invalid due to expiration or recent password change)')
+      .replace('530002', '530002 (Your device is required to be compliant to access this resource)')
+      .replace('9001011', '9001011 (Device policy contains unsupported required device state)')
+  } catch {
+    return null
+  }
 }
 
 export default function UserSigninLogs({ userId, tenantDomain, className = null }) {
@@ -61,11 +99,11 @@ export default function UserSigninLogs({ userId, tenantDomain, className = null 
 
   const columns = [
     {
-      name: 'Date',
-      selector: (row) => row['Date'],
+      name: 'Date (Local)',
+      selector: (row) => row['Date'].toString().trim() + 'Z',
       exportSelector: 'Date',
-      minWidth: '230px',
-      cell: (row) => CellTip(row['Date']),
+      minWidth: '145px',
+      cell: cellDateFormatter(),
     },
     {
       name: 'Application',
@@ -76,29 +114,9 @@ export default function UserSigninLogs({ userId, tenantDomain, className = null 
     },
     {
       name: 'Login Status',
-      selector: (row) =>
-        row['LoginStatus']
-          .toString()
-          .replace('50126', '50126 (Invalid username or password)')
-          .replace(
-            '70044',
-            '70044 (The session has expired or is invalid due to sign-in frequency checks by conditional access)',
-          )
-          .replace('50089', '50089 (Flow token expired)')
-          .replace('53003', '53003 (Access has been blocked by Conditional Access policies)'),
+      selector: (row) => ConvertErrorCode(row),
       exportSelector: 'LoginStatus',
-      cell: (row) =>
-        CellTip(
-          row['LoginStatus']
-            .toString()
-            .replace('50126', '50126 (Invalid username or password)')
-            .replace(
-              '70044',
-              '70044 (The session has expired or is invalid due to sign-in frequency checks by conditional access)',
-            )
-            .replace('50089', '50089 (Flow token expired)')
-            .replace('53003', '53003 (Access has been blocked by Conditional Access policies)'),
-        ),
+      cell: (row) => CellTip(ConvertErrorCode(row)),
       minWidth: '230px',
     },
     {

--- a/src/views/identity/administration/UserSigninLogs.js
+++ b/src/views/identity/administration/UserSigninLogs.js
@@ -9,7 +9,7 @@ import {
   CTableHeaderCell,
   CTableRow,
 } from '@coreui/react'
-import { cellBooleanFormatter } from 'src/components/tables'
+import { CellTip, cellBooleanFormatter } from 'src/components/tables'
 import { DatatableContentCard } from 'src/components/contentcards'
 import { faKey } from '@fortawesome/free-solid-svg-icons'
 import { ModalService } from 'src/components/utilities'
@@ -64,16 +64,42 @@ export default function UserSigninLogs({ userId, tenantDomain, className = null 
       name: 'Date',
       selector: (row) => row['Date'],
       exportSelector: 'Date',
+      minWidth: '230px',
+      cell: (row) => CellTip(row['Date']),
     },
     {
       name: 'Application',
       selector: (row) => row['Application'],
       exportSelector: 'Application',
+      cell: (row) => CellTip(row['Application']),
+      minWidth: '230px',
     },
     {
       name: 'Login Status',
-      selector: (row) => row['LoginStatus'],
+      selector: (row) =>
+        row['LoginStatus']
+          .toString()
+          .replace('50126', '50126 (Invalid username or password)')
+          .replace(
+            '70044',
+            '70044 (The session has expired or is invalid due to sign-in frequency checks by conditional access)',
+          )
+          .replace('50089', '50089 (Flow token expired)')
+          .replace('53003', '53003 (Access has been blocked by Conditional Access policies)'),
       exportSelector: 'LoginStatus',
+      cell: (row) =>
+        CellTip(
+          row['LoginStatus']
+            .toString()
+            .replace('50126', '50126 (Invalid username or password)')
+            .replace(
+              '70044',
+              '70044 (The session has expired or is invalid due to sign-in frequency checks by conditional access)',
+            )
+            .replace('50089', '50089 (Flow token expired)')
+            .replace('53003', '53003 (Access has been blocked by Conditional Access policies)'),
+        ),
+      minWidth: '230px',
     },
     {
       name: 'Conditional Access Status',
@@ -94,11 +120,13 @@ export default function UserSigninLogs({ userId, tenantDomain, className = null 
       name: 'Town',
       selector: (row) => row['Town'],
       exportSelector: 'Town',
+      cell: (row) => CellTip(row['Town']),
     },
     {
       name: 'State',
       selector: (row) => row['State'],
       exportSelector: 'State',
+      cell: (row) => CellTip(row['State']),
     },
     {
       name: 'Country',
@@ -113,7 +141,7 @@ export default function UserSigninLogs({ userId, tenantDomain, className = null 
     {
       name: 'Device Compliant',
       selector: (row) => row['DeviceCompliant'],
-      cell: cellBooleanFormatter,
+      cell: cellBooleanFormatter(),
       exportSelector: 'DeviceCompliant',
     },
     {
@@ -125,6 +153,7 @@ export default function UserSigninLogs({ userId, tenantDomain, className = null 
       name: 'Browser',
       selector: (row) => row['Browser'],
       exportSelector: 'Browser',
+      cell: (row) => CellTip(row['Browser']),
     },
     {
       name: 'Applied CAPs',

--- a/src/views/identity/administration/Users.js
+++ b/src/views/identity/administration/Users.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 import { faEdit, faEllipsisV, faEye } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { cellBooleanFormatter } from 'src/components/tables'
+import { cellBooleanFormatter, CellTip } from 'src/components/tables'
 import { CippPageList } from 'src/components/layout'
 import { TitleButton } from 'src/components/buttons'
 import { CippActionsOffcanvas } from 'src/components/utilities'
@@ -33,19 +33,19 @@ const Offcanvas = (row, rowIndex, formatExtraData) => {
       <CippActionsOffcanvas
         title="User Information"
         extendedInfo={[
-          { label: 'Created on', value: `${row.createdDateTime}` },
-          { label: 'UPN', value: `${row.userPrincipalName}` },
-          { label: 'Given Name', value: `${row.givenName}` },
-          { label: 'Surname', value: `${row.surname}` },
-          { label: 'Job Title', value: `${row.jobTitle}` },
-          { label: 'Licenses', value: `${row.LicJoined}` },
-          { label: 'Business Phone', value: `${row.businessPhones}` },
-          { label: 'Mobile Phone', value: `${row.mobilePhone}` },
-          { label: 'Mail', value: `${row.mail}` },
-          { label: 'City', value: `${row.city}` },
-          { label: 'Department', value: `${row.department}` },
-          { label: 'OnPrem Last Sync', value: `${row.onPremisesLastSyncDateTime}` },
-          { label: 'Unique ID', value: `${row.id}` },
+          { label: 'Created on', value: `${row.createdDateTime ?? ' '}` },
+          { label: 'UPN', value: `${row.userPrincipalName ?? ' '}` },
+          { label: 'Given Name', value: `${row.givenName ?? ' '}` },
+          { label: 'Surname', value: `${row.surname ?? ' '}` },
+          { label: 'Job Title', value: `${row.jobTitle ?? ' '}` },
+          { label: 'Licenses', value: `${row.LicJoined ?? ' '}` },
+          { label: 'Business Phone', value: `${row.businessPhones ?? ' '}` },
+          { label: 'Mobile Phone', value: `${row.mobilePhone ?? ' '}` },
+          { label: 'Mail', value: `${row.mail ?? ' '}` },
+          { label: 'City', value: `${row.city ?? ' '}` },
+          { label: 'Department', value: `${row.department ?? ' '}` },
+          { label: 'OnPrem Last Sync', value: `${row.onPremisesLastSyncDateTime ?? ' '}` },
+          { label: 'Unique ID', value: `${row.id ?? ' '}` },
         ]}
         actions={[
           {
@@ -150,6 +150,7 @@ const columns = [
     name: 'Display Name',
     selector: (row) => row['displayName'],
     sortable: true,
+    cell: (row) => CellTip(row['displayName']),
     exportSelector: 'displayName',
     minWidth: '300px',
   },
@@ -157,34 +158,32 @@ const columns = [
     name: 'Email',
     selector: (row) => row['mail'],
     sortable: true,
+    cell: (row) => CellTip(row['mail']),
     exportSelector: 'mail',
-    minWidth: '350px',
+    minWidth: '250px',
   },
   {
     name: 'User Type',
     selector: (row) => row['userType'],
     sortable: true,
     exportSelector: 'userType',
-    minWidth: '50px',
-    maxWidth: '140px',
+    minWidth: '140px',
   },
   {
     name: 'Enabled',
     selector: (row) => row['accountEnabled'],
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     sortable: true,
     exportSelector: 'accountEnabled',
-    minWidth: '50px',
-    maxWidth: '90px',
+    minWidth: '100px',
   },
   {
     name: 'AD Synced',
     selector: (row) => row['onPremisesSyncEnabled'],
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     sortable: true,
     exportSelector: 'onPremisesSyncEnabled',
-    minWidth: '50px',
-    maxWidth: '110px',
+    minWidth: '120px',
   },
   {
     name: 'Licenses',
@@ -193,6 +192,7 @@ const columns = [
     sortable: true,
     grow: 5,
     wrap: true,
+    minWidth: '200px',
   },
   {
     name: 'id',

--- a/src/views/identity/administration/Users.js
+++ b/src/views/identity/administration/Users.js
@@ -33,7 +33,7 @@ const Offcanvas = (row, rowIndex, formatExtraData) => {
       <CippActionsOffcanvas
         title="User Information"
         extendedInfo={[
-          { label: 'Created on', value: `${row.createdDateTime ?? ' '}` },
+          { label: 'Created Date (UTC)', value: `${row.createdDateTime ?? ' '}` },
           { label: 'UPN', value: `${row.userPrincipalName ?? ' '}` },
           { label: 'Given Name', value: `${row.givenName ?? ' '}` },
           { label: 'Surname', value: `${row.surname ?? ' '}` },

--- a/src/views/identity/reports/AzureADConnectReport.js
+++ b/src/views/identity/reports/AzureADConnectReport.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { CippPageList } from 'src/components/layout'
+import { cellDateFormatter } from 'src/components/tables'
 const columns = [
   {
     name: 'Display Name',
@@ -15,9 +16,10 @@ const columns = [
     exportSelector: 'ObjectType',
   },
   {
-    name: 'Created Date',
+    name: 'Created Date (Local)',
     selector: (row) => row['createdDateTime'],
     sortable: true,
+    cell: cellDateFormatter(),
     exportSelector: 'createdDateTime',
   },
   {

--- a/src/views/identity/reports/Devices.js
+++ b/src/views/identity/reports/Devices.js
@@ -1,20 +1,21 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { CippPageList } from 'src/components/layout'
-import { cellBooleanFormatter, cellDateFormatter } from 'src/components/tables'
+import { cellBooleanFormatter, cellDateFormatter, CellTip } from 'src/components/tables'
 
 const columns = [
   {
     name: 'Name',
     selector: (row) => row['displayName'],
     sortable: true,
+    cell: (row) => CellTip(row['displayName']),
     exportSelector: 'displayName',
   },
   {
     name: 'Enabled',
     selector: (row) => row['accountEnabled'],
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     exportSelector: 'accountEnabled',
   },
   {
@@ -28,12 +29,14 @@ const columns = [
     name: 'Manufacturer',
     selector: (row) => row['manufacturer'],
     sortable: true,
+    cell: (row) => CellTip(row['manufacturer']),
     exportSelector: 'manufacturer',
   },
   {
     name: 'Model',
     selector: (row) => row['model'],
     sortable: true,
+    cell: (row) => CellTip(row['model']),
     exportSelector: 'model',
   },
   {
@@ -73,6 +76,7 @@ const columns = [
     selector: (row) => row['enrollmentType'],
     sortable: true,
     exportSelector: 'enrollmentType',
+    cell: (row) => CellTip(row['enrollmentType']),
   },
   {
     name: 'Management Type',
@@ -83,7 +87,7 @@ const columns = [
   {
     name: 'On-Premises Sync Enabled',
     selector: (row) => row['onPremisesSyncEnabled'],
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     sortable: true,
     exportSelector: 'onPremisessSyncEnabled',
   },

--- a/src/views/identity/reports/Devices.js
+++ b/src/views/identity/reports/Devices.js
@@ -58,13 +58,17 @@ const columns = [
     cell: cellDateFormatter({ format: 'short', showTime: false }),
     exportSelector: 'createdDateTime',
   },
+  /*
+  * This should not be used, it is not anywhere near accurate, it is out by days even weeks 
+  * in my testing, I don't recommend we display it, we have alternate sources for this
+  * as well which are significantly closer to (if not) accurate - knightian
   {
     name: 'Approx Last SignIn',
     selector: (row) => row['approximateLastSignInDateTime'],
     sortable: true,
     cell: cellDateFormatter(),
     exportSelector: 'approximateLastSignInDateTime',
-  },
+  },**/
   {
     name: 'Ownership',
     selector: (row) => row['deviceOwnership'],

--- a/src/views/identity/reports/MFAReport.js
+++ b/src/views/identity/reports/MFAReport.js
@@ -15,7 +15,7 @@ const columns = [
     selector: (row) => row['AccountEnabled'],
     name: 'Account Enabled',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     exportSelector: 'AccountEnabled',
   },
   {
@@ -41,7 +41,7 @@ const columns = [
     selector: (row) => row['CoveredBySD'],
     name: 'Enforced via Security Defaults',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ colourless: true }),
     exportSelector: 'CoveredBySD',
   },
 ]
@@ -54,12 +54,7 @@ const conditionalRowStyles = [
       !row.MFARegistration &&
       row.CoveredByCA === 'None' &&
       !row.CoveredBySD,
-    style: {
-      //backgroundColor: 'var(--cui-danger)',
-      //border: '2px solid var(--cui-warning)',
-      //color: 'var(--cui-warning)',
-    },
-    classNames: ['no-mfa'],
+    //classNames: ['no-mfa'], <- Currently not working
   },
 ]
 

--- a/src/views/security/defender/ListDefender.js
+++ b/src/views/security/defender/ListDefender.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
-import { cellBooleanFormatter } from 'src/components/tables'
+import { CellTip, cellBooleanFormatter } from 'src/components/tables'
 import { CippPageList } from 'src/components/layout'
 
 const columns = [
@@ -8,6 +8,7 @@ const columns = [
     selector: (row) => row['managedDeviceName'],
     name: 'Device Name',
     sortable: true,
+    cell: (row) => CellTip(row['managedDeviceName']),
     exportSelector: 'managedDeviceName',
   },
   {
@@ -41,34 +42,34 @@ const columns = [
     selector: (row) => row['quickScanOverdue'],
     name: 'Quick Scan overdue',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ warning: true, reverse: true, colourless: true }),
     exportSelector: 'quickScanOverdue',
   },
   {
     selector: (row) => row['fullScanOverdue'],
     name: 'Full Scan overdue',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ warning: true, reverse: true, colourless: true }),
     exportSelector: 'fullScanOverdue',
   },
   {
     selector: (row) => row['signatureUpdateOverdue'],
     name: 'Signature Update Required',
     sortable: true,
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ warning: true, reverse: true, colourless: true }),
     exportSelector: 'signatureUpdateOverdue',
   },
   {
     selector: (row) => row['rebootRequired'],
     name: 'Reboot Required',
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ warning: true, reverse: true, colourless: true }),
     sortable: true,
     exportSelector: 'rebootRequired',
   },
   {
     selector: (row) => row['attentionRequired'],
     name: 'Attention Required',
-    cell: cellBooleanFormatter(),
+    cell: cellBooleanFormatter({ warning: true, reverse: true, colourless: true }),
     sortable: true,
     exportSelector: 'attentionRequired',
   },

--- a/src/views/security/incidents/ListAlerts.js
+++ b/src/views/security/incidents/ListAlerts.js
@@ -6,7 +6,7 @@ import { useLazyExecAlertsListQuery } from 'src/store/api/security'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { CippPage } from 'src/components/layout'
 import PropTypes from 'prop-types'
-import { faEye, faRedo, faEdit, faCheck } from '@fortawesome/free-solid-svg-icons'
+import { faEllipsisV, faRedo, faEdit, faCheck } from '@fortawesome/free-solid-svg-icons'
 import { CippActionsOffcanvas } from 'src/components/utilities'
 import { useSelector } from 'react-redux'
 import Skeleton from 'react-loading-skeleton'
@@ -68,8 +68,8 @@ const ListAlerts = () => {
     const extendedInfo = extendedInfoRaw.concat(mappedUsers)
     return (
       <>
-        <CButton size="sm" color="success" variant="ghost" onClick={() => setOCVisible(true)}>
-          <FontAwesomeIcon icon={faEye} />
+        <CButton size="sm" color="link" onClick={() => setOCVisible(true)}>
+          <FontAwesomeIcon icon={faEllipsisV} />
         </CButton>
         <CippActionsOffcanvas
           title="Alert Information"
@@ -150,7 +150,7 @@ const ListAlerts = () => {
       maxWidth: '100px',
     },
     {
-      name: 'More Info',
+      name: 'Info & Actions',
       cell: Offcanvas,
     },
   ]

--- a/src/views/security/incidents/ListAlerts.js
+++ b/src/views/security/incidents/ListAlerts.js
@@ -110,12 +110,12 @@ const ListAlerts = () => {
 
   const columns = [
     {
-      name: 'Created Date',
+      name: 'Created Date (Local)',
       selector: (row) => row['EventDateTime'],
       sortable: true,
       cell: cellDateFormatter(),
       exportSelector: 'EventDateTime',
-      minWidth: '145px',
+      minWidth: '155px',
     },
     {
       name: 'Tenant',

--- a/src/views/security/incidents/ListIncidents.js
+++ b/src/views/security/incidents/ListIncidents.js
@@ -232,12 +232,12 @@ const ListIncidents = () => {
 
   const columns = [
     {
-      name: ' Created Date',
+      name: ' Created Date (Local)',
       selector: (row) => row['Created'],
       sortable: true,
       cell: cellDateFormatter(),
       exportSelector: 'Created',
-      minWidth: '145px',
+      minWidth: '155px',
     },
     {
       name: 'Tenant',

--- a/src/views/security/incidents/ListIncidents.js
+++ b/src/views/security/incidents/ListIncidents.js
@@ -8,7 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { CippPage } from 'src/components/layout'
 import PropTypes from 'prop-types'
 import {
-  faEye,
+  faEllipsisV,
   faEdit,
   faCheck,
   faRedo,
@@ -171,8 +171,8 @@ const ListIncidents = () => {
 
     return (
       <>
-        <CButton size="sm" color="success" variant="ghost" onClick={() => setOCVisible(true)}>
-          <FontAwesomeIcon icon={faEye} />
+        <CButton size="sm" color="link" onClick={() => setOCVisible(true)}>
+          <FontAwesomeIcon icon={faEllipsisV} />
         </CButton>
         <CippActionsOffcanvas
           title="Incident Information"
@@ -285,7 +285,7 @@ const ListIncidents = () => {
       exportSelector: 'Tags',
     },
     {
-      name: 'More Info',
+      name: 'Info & Actions',
       cell: Offcanvas,
     },
   ]

--- a/src/views/security/reports/ListDeviceComplianceReport.js
+++ b/src/views/security/reports/ListDeviceComplianceReport.js
@@ -62,11 +62,12 @@ const columns = [
     exportSelector: 'model',
   },
   {
-    name: 'Last Sync',
+    name: 'Last Sync (Local)',
     selector: (row) => row['lastSyncDateTime'],
     sortable: true,
     cell: cellDateFormatter(),
     exportSelector: 'lastSyncDateTime',
+    minWidth: '155px',
   },
 ]
 

--- a/src/views/security/reports/ListDeviceComplianceReport.js
+++ b/src/views/security/reports/ListDeviceComplianceReport.js
@@ -1,19 +1,22 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { CippPageList } from 'src/components/layout'
-import { cellDateFormatter } from 'src/components/tables'
+import { CellTip, cellDateFormatter } from 'src/components/tables'
 import { StatusIcon } from 'src/components/utilities'
 const columns = [
   {
     name: 'Tenant',
     selector: (row) => row['tenantDisplayName'],
     sortable: true,
+    cell: (row) => CellTip(row['tenantDisplayName']),
     exportSelector: 'tenantDisplayName',
+    minWidth: '200px',
   },
   {
     name: 'Device Name',
     selector: (row) => row['managedDeviceName'],
     sortable: true,
+    cell: (row) => CellTip(row['managedDeviceName']),
     exportSelector: 'managedDeviceName',
   },
   {
@@ -48,12 +51,14 @@ const columns = [
     name: 'Manufacturer',
     selector: (row) => row['manufacturer'],
     sortable: true,
+    cell: (row) => CellTip(row['manufacturer']),
     exportSelector: 'manufacturer',
   },
   {
     name: 'Model',
     selector: (row) => row['model'],
     sortable: true,
+    cell: (row) => CellTip(row['model']),
     exportSelector: 'model',
   },
   {

--- a/src/views/teams-share/onedrive/OneDriveList.js
+++ b/src/views/teams-share/onedrive/OneDriveList.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { CippPageList } from 'src/components/layout'
+import { CellTip } from 'src/components/tables'
 
 const OneDriveList = () => {
   const tenant = useSelector((state) => state.app.currentTenant)
@@ -9,12 +10,14 @@ const OneDriveList = () => {
       name: 'Name',
       selector: (row) => row['displayName'],
       sortable: true,
+      cell: (row) => CellTip(row['displayName']),
       exportSelector: 'displayName',
     },
     {
       name: 'UPN',
       selector: (row) => row['UPN'],
       sortable: true,
+      cell: (row) => CellTip(row['UPN']),
       exportSelector: 'UPN',
     },
     {

--- a/src/views/teams-share/sharepoint/SharepointList.js
+++ b/src/views/teams-share/sharepoint/SharepointList.js
@@ -1,18 +1,21 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { CippPageList } from 'src/components/layout'
+import { CellTip } from 'src/components/tables'
 
 const columns = [
   {
     name: 'URL',
     selector: (row) => row['URL'],
     sortable: true,
+    cell: (row) => CellTip(row['URL']),
     exportSelector: 'URL',
   },
   {
     name: 'Owner',
     selector: (row) => row['displayName'],
     sortable: true,
+    cell: (row) => CellTip(row['displayName']),
     exportSelector: 'displayName',
     maxWidth: '300px',
   },
@@ -48,6 +51,7 @@ const columns = [
     name: 'Root Template',
     selector: (row) => row['Template'],
     sortable: true,
+    cell: (row) => CellTip(row['Template']),
     exportSelector: 'Template',
     maxWidth: '200px',
   },

--- a/src/views/teams-share/teams/TeamChannels.js
+++ b/src/views/teams-share/teams/TeamChannels.js
@@ -20,7 +20,7 @@ export default function TeamChannels({ data, className = null, isFetching, error
       cell: (row) => CellTip(row['description']),
     },
     {
-      name: 'Created at',
+      name: 'Created Date (Local)',
       selector: (row) => row['createdDateTime'],
       sortable: true,
       cell: cellDateFormatter(),

--- a/src/views/teams-share/teams/TeamChannels.js
+++ b/src/views/teams-share/teams/TeamChannels.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { faUser } from '@fortawesome/free-solid-svg-icons'
 import { TableContentCard } from 'src/components/contentcards'
 import { CLink } from '@coreui/react'
+import { CellTip, cellBooleanFormatter, cellDateFormatter } from 'src/components/tables'
 
 export default function TeamChannels({ data, className = null, isFetching, error, errorMessage }) {
   const columns = [
@@ -10,21 +11,25 @@ export default function TeamChannels({ data, className = null, isFetching, error
       name: 'Display Name',
       selector: (row) => row['displayName'],
       sortable: true,
+      cell: (row) => CellTip(row['displayName']),
     },
     {
       name: 'Description',
       selector: (row) => row['description'],
       sortable: true,
+      cell: (row) => CellTip(row['description']),
     },
     {
       name: 'Created at',
       selector: (row) => row['createdDateTime'],
       sortable: true,
+      cell: cellDateFormatter(),
     },
     {
       name: 'Favorite by default',
       selector: (row) => row['isFavoriteByDefault'],
       sortable: true,
+      cell: cellBooleanFormatter({ colourless: true }),
     },
     {
       name: 'Channel Link',
@@ -38,6 +43,13 @@ export default function TeamChannels({ data, className = null, isFetching, error
       name: 'Email',
       selector: (row) => row['email'],
       sortable: true,
+      cell: (row) => CellTip(row['email']),
+    },
+    {
+      name: 'Moderation Settings',
+      selector: (row) => row['moderationSettings'],
+      sortable: true,
+      cell: (row) => CellTip(row['moderationSettings']),
     },
   ]
 

--- a/src/views/teams-share/teams/TeamDetails.js
+++ b/src/views/teams-share/teams/TeamDetails.js
@@ -4,6 +4,9 @@ import { faUsers } from '@fortawesome/free-solid-svg-icons'
 import { ListGroupContentCard } from 'src/components/contentcards'
 import { CellBoolean } from 'src/components/tables'
 
+const formatter = (cell, warning = false, reverse = false, colourless = false) =>
+  CellBoolean({ cell, warning, reverse, colourless })
+
 export default function TeamDetails({ team, className = null, isFetching, error, errorMessage }) {
   const content = [
     {
@@ -16,7 +19,7 @@ export default function TeamDetails({ team, className = null, isFetching, error,
     },
     {
       heading: 'Archived',
-      body: CellBoolean(team.isArchived),
+      body: formatter(team['isArchived'], false, false, true),
     },
     {
       heading: 'Created',

--- a/src/views/teams-share/teams/TeamDetails.js
+++ b/src/views/teams-share/teams/TeamDetails.js
@@ -22,7 +22,7 @@ export default function TeamDetails({ team, className = null, isFetching, error,
       body: formatter(team['isArchived'], false, false, true),
     },
     {
-      heading: 'Created',
+      heading: 'Created (UTC)',
       body: team.createdDateTime,
     },
     {

--- a/src/views/teams-share/teams/TeamGuestPolicies.js
+++ b/src/views/teams-share/teams/TeamGuestPolicies.js
@@ -4,6 +4,9 @@ import { faUserFriends } from '@fortawesome/free-solid-svg-icons'
 import { ListGroupContentCard } from 'src/components/contentcards'
 import { CellBoolean } from 'src/components/tables'
 
+const formatter = (cell, warning = false, reverse = false, colourless = false) =>
+  CellBoolean({ cell, warning, reverse, colourless })
+
 export default function TeamGuestPolicies({
   guestSettings,
   className = null,
@@ -14,11 +17,11 @@ export default function TeamGuestPolicies({
   const content = [
     {
       heading: 'Guests can create channels',
-      body: CellBoolean(guestSettings.allowCreateUpdateChannels),
+      body: formatter(guestSettings.allowCreateUpdateChannels, false, false, true),
     },
     {
       heading: 'Guests can delete channels',
-      body: CellBoolean(guestSettings.allowDeleteChannels),
+      body: formatter(guestSettings.allowDeleteChannels, false, false, true),
     },
   ]
 

--- a/src/views/teams-share/teams/TeamMemberPolicies.js
+++ b/src/views/teams-share/teams/TeamMemberPolicies.js
@@ -4,6 +4,9 @@ import { faUsersCog } from '@fortawesome/free-solid-svg-icons'
 import { ListGroupContentCard } from 'src/components/contentcards'
 import { CellBoolean } from 'src/components/tables'
 
+const formatter = (cell, warning = false, reverse = false, colourless = false) =>
+  CellBoolean({ cell, warning, reverse, colourless })
+
 export default function TeamMemberPolicies({
   memberSettings,
   className = null,
@@ -14,27 +17,27 @@ export default function TeamMemberPolicies({
   const content = [
     {
       heading: 'Can edit and remove apps',
-      body: CellBoolean(memberSettings.allowAddRemoveApps),
+      body: formatter(memberSettings.allowAddRemoveApps, false, false, true),
     },
     {
       heading: 'Can create private channels',
-      body: CellBoolean(memberSettings.allowCreatePrivateChannels),
+      body: formatter(memberSettings.allowCreatePrivateChannels, false, false, true),
     },
     {
       heading: 'Can create and edit channels',
-      body: CellBoolean(memberSettings.allowCreateUpdateChannels),
+      body: formatter(memberSettings.allowCreateUpdateChannels, false, false, true),
     },
     {
       heading: 'Can create and edit connectors',
-      body: CellBoolean(memberSettings.allowCreateUpdateRemoveConnectors),
+      body: formatter(memberSettings.allowCreateUpdateRemoveConnectors, false, false, true),
     },
     {
       heading: 'Can create and edit tabs',
-      body: CellBoolean(memberSettings.allowCreateUpdateRemoveTabs),
+      body: formatter(memberSettings.allowCreateUpdateRemoveTabs, false, false, true),
     },
     {
       heading: 'Can delete channels',
-      body: CellBoolean(memberSettings.allowDeleteChannels),
+      body: formatter(memberSettings.allowDeleteChannels, false, false, true),
     },
   ]
 

--- a/src/views/teams-share/teams/TeamMembers.js
+++ b/src/views/teams-share/teams/TeamMembers.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { faUserFriends } from '@fortawesome/free-solid-svg-icons'
 import { TableContentCard } from 'src/components/contentcards'
+import { CellTip } from 'src/components/tables'
 
 export default function TeamMembers({ data, className = null, isFetching, error, errorMessage }) {
   const columns = [
@@ -9,11 +10,13 @@ export default function TeamMembers({ data, className = null, isFetching, error,
       name: 'Display Name',
       selector: (row) => row['displayName'],
       sortable: true,
+      cell: (row) => CellTip(row['displayName']),
     },
     {
       name: 'Mail',
-      selector: (row) => row['mail'],
+      selector: (row) => row['email'],
       sortable: true,
+      cell: (row) => CellTip(row['email']),
     },
   ]
 

--- a/src/views/teams-share/teams/TeamMessagingSettings.js
+++ b/src/views/teams-share/teams/TeamMessagingSettings.js
@@ -4,6 +4,9 @@ import { faBullhorn } from '@fortawesome/free-solid-svg-icons'
 import { ListGroupContentCard } from 'src/components/contentcards'
 import { CellBoolean } from 'src/components/tables'
 
+const formatter = (cell, warning = false, reverse = false, colourless = false) =>
+  CellBoolean({ cell, warning, reverse, colourless })
+
 export default function TeamMessagingSettings({
   messagingSettings,
   funSettings,
@@ -15,31 +18,31 @@ export default function TeamMessagingSettings({
   const content = [
     {
       heading: 'Allow @channel mentions',
-      body: CellBoolean(messagingSettings.allowChannelMentions),
+      body: formatter(messagingSettings.allowChannelMentions, false, false, true),
     },
     {
       heading: 'Allow @team mentions',
-      body: CellBoolean(messagingSettings.allowTeamMentions),
+      body: formatter(messagingSettings.allowTeamMentions, false, false, true),
     },
     {
       heading: 'Allow owners to delete messages',
-      body: CellBoolean(messagingSettings.allowOwnerDeleteMessages),
+      body: formatter(messagingSettings.allowOwnerDeleteMessages, false, false, true),
     },
     {
       heading: 'Allow users to delete messages',
-      body: CellBoolean(messagingSettings.allowUserDeleteMessages),
+      body: formatter(messagingSettings.allowUserDeleteMessages, false, false, true),
     },
     {
       heading: 'Allow users to edit messages',
-      body: CellBoolean(messagingSettings.allowUserEditMessages),
+      body: formatter(messagingSettings.allowUserEditMessages, false, false, true),
     },
     {
       heading: 'Allow GIFs',
-      body: CellBoolean(funSettings.allowGiphy),
+      body: formatter(funSettings.allowGiphy, false, false, true),
     },
     {
       heading: 'Allow stickers and memes',
-      body: CellBoolean(funSettings.allowStickersAndMemes),
+      body: formatter(funSettings.allowStickersAndMemes, false, false, true),
     },
     {
       heading: 'GIF content rating',

--- a/src/views/teams-share/teams/TeamOwners.js
+++ b/src/views/teams-share/teams/TeamOwners.js
@@ -12,7 +12,7 @@ export default function TeamOwners({ data, className = null, isFetching, error, 
     },
     {
       name: 'Mail',
-      selector: (row) => row['mail'],
+      selector: (row) => row['email'],
       sortable: true,
     },
   ]

--- a/src/views/teams-share/teams/TeamOwners.js
+++ b/src/views/teams-share/teams/TeamOwners.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { faUser } from '@fortawesome/free-solid-svg-icons'
 import { TableContentCard } from 'src/components/contentcards'
+import { CellTip } from 'src/components/tables'
 
 export default function TeamOwners({ data, className = null, isFetching, error, errorMessage }) {
   const columns = [
@@ -9,11 +10,13 @@ export default function TeamOwners({ data, className = null, isFetching, error, 
       name: 'Display Name',
       selector: (row) => row['displayName'],
       sortable: true,
+      cell: (row) => CellTip(row['displayName']),
     },
     {
       name: 'Mail',
       selector: (row) => row['email'],
       sortable: true,
+      cell: (row) => CellTip(row['email']),
     },
   ]
 

--- a/src/views/teams-share/teams/TeamsListTeam.js
+++ b/src/views/teams-share/teams/TeamsListTeam.js
@@ -5,6 +5,7 @@ import { faEye, faEdit } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Link } from 'react-router-dom'
 import { CippPageList } from 'src/components/layout'
+import { CellTip } from 'src/components/tables'
 
 const TeamsList = () => {
   const tenant = useSelector((state) => state.app.currentTenant)
@@ -32,12 +33,14 @@ const TeamsList = () => {
       name: 'Name',
       selector: (row) => row['displayName'],
       sortable: true,
+      cell: (row) => CellTip(row['displayName']),
       exportSelector: 'displayName',
     },
     {
       name: 'Description',
       selector: (row) => row['description'],
       sortable: true,
+      cell: (row) => CellTip(row['description']),
       exportSelector: 'description',
     },
     {
@@ -45,12 +48,15 @@ const TeamsList = () => {
       selector: (row) => row['visibility'],
       sortable: true,
       exportSelector: 'visibility',
+      maxWidth: '100px',
     },
     {
       name: 'Mail nickname',
       selector: (row) => row['mailNickname'],
       sortable: true,
+      cell: (row) => CellTip(row['mailNickname']),
       exportSelector: 'mailNickname',
+      maxWidth: '200px',
     },
     {
       name: 'ID',
@@ -60,6 +66,7 @@ const TeamsList = () => {
     {
       name: 'Actions',
       cell: Actions,
+      maxWidth: '80px',
     },
   ]
 

--- a/src/views/teams-share/teams/ViewTeamSettings.js
+++ b/src/views/teams-share/teams/ViewTeamSettings.js
@@ -71,10 +71,10 @@ const ViewTeamSettings = (props) => {
               funSettings={funSettings}
             />
           </CippMasonryItem>
-          <CippMasonryItem size="single">
+          <CippMasonryItem size="double">
             <TeamOwners data={owners} />
           </CippMasonryItem>
-          <CippMasonryItem size="single">
+          <CippMasonryItem size="triple">
             <TeamMembers data={members} />
           </CippMasonryItem>
           <CippMasonryItem size="triple">

--- a/src/views/tenant/administration/ListLicences.js
+++ b/src/views/tenant/administration/ListLicences.js
@@ -1,38 +1,46 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { CippPageList } from 'src/components/layout'
+import { CellTip } from 'src/components/tables'
 
 const columns = [
   {
     name: 'Tenant',
     selector: (row) => row['Tenant'],
     sortable: true,
+    cell: (row) => CellTip(row['Tenant']),
     wrap: true,
     exportSelector: 'Tenant',
+    maxWidth: '200px',
   },
   {
     name: 'license',
     selector: (row) => row['License'],
     sortable: true,
+    cell: (row) => CellTip(row['License']),
     exportSelector: 'License',
+    minWidth: '300px',
   },
   {
     name: 'Used',
     selector: (row) => row['CountUsed'],
     sortable: true,
     exportSelector: 'CountUsed',
+    maxWidth: '110px',
   },
   {
     name: 'Available',
     selector: (row) => row['CountAvailable'],
     sortable: true,
     exportSelector: 'CountAvailable',
+    maxWidth: '110px',
   },
   {
     name: 'Total',
     selector: (row) => row['TotalLicenses'],
     sortable: true,
     exportSelector: 'TotalLicenses',
+    maxWidth: '110px',
   },
 ]
 

--- a/src/views/tenant/administration/ListOauthApps.js
+++ b/src/views/tenant/administration/ListOauthApps.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { CippPageList } from 'src/components/layout'
+import { CellTip } from 'src/components/tables'
 
 const columns = [
   {
@@ -8,19 +9,23 @@ const columns = [
     selector: (row) => row['Tenant'],
     sortable: true,
     wrap: true,
+    cell: (row) => CellTip(row['Tenant']),
     exportSelector: 'Tenant',
+    maxWidth: '200px',
   },
   {
     name: 'Display Name',
     selector: (row) => row['Name'],
     sortable: true,
     wrap: true,
+    cell: (row) => CellTip(row['Name']),
     exportSelector: 'Name',
   },
   {
     name: 'Application ID',
     selector: (row) => row['ID'],
     sortable: true,
+    cell: (row) => CellTip(row['ID']),
     exportSelector: 'ID',
   },
   {
@@ -28,12 +33,14 @@ const columns = [
     selector: (row) => row['Scope'],
     sortable: true,
     exportSelector: 'Scope',
+    cell: (row) => CellTip(row['Scope']),
   },
   {
     name: 'Permissions Granted at',
     selector: (row) => row['StartTime'],
     sortable: true,
     exportSelector: 'StartTime',
+    cell: (row) => CellTip(row['StartTime']),
   },
 ]
 

--- a/src/views/tenant/administration/ListOauthApps.js
+++ b/src/views/tenant/administration/ListOauthApps.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { CippPageList } from 'src/components/layout'
-import { CellTip } from 'src/components/tables'
+import { CellTip, cellDateFormatter } from 'src/components/tables'
 
 const columns = [
   {
@@ -36,11 +36,11 @@ const columns = [
     cell: (row) => CellTip(row['Scope']),
   },
   {
-    name: 'Permissions Granted at',
+    name: 'Permissions Granted (Local)',
     selector: (row) => row['StartTime'],
     sortable: true,
     exportSelector: 'StartTime',
-    cell: (row) => CellTip(row['StartTime']),
+    cell: cellDateFormatter(),
   },
 ]
 

--- a/src/views/tenant/administration/Tenants.js
+++ b/src/views/tenant/administration/Tenants.js
@@ -5,19 +5,24 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCog, faEdit } from '@fortawesome/free-solid-svg-icons'
 import { CippPageList } from 'src/components/layout'
 import { Link } from 'react-router-dom'
+import { CellTip } from 'src/components/tables'
 
 const columns = [
   {
     name: 'Name',
     selector: (row) => row['displayName'],
     sortable: true,
+    cell: (row) => CellTip(row['displayName']),
     exportSelector: 'displayName',
+    minWidth: '250px',
   },
   {
     name: 'Default Domain',
     selector: (row) => row['defaultDomainName'],
     sortable: true,
+    cell: (row) => CellTip(row['defaultDomainName']),
     exportSelector: 'defaultDomainName',
+    minWidth: '250px',
   },
   {
     name: 'M365 Portal',

--- a/src/views/tenant/conditional/ConditionalAccess.js
+++ b/src/views/tenant/conditional/ConditionalAccess.js
@@ -12,6 +12,7 @@ import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { CippPageList } from 'src/components/layout'
 import { CippActionsOffcanvas } from 'src/components/utilities'
+import { CellTip } from 'src/components/tables'
 const Offcanvas = (row, rowIndex, formatExtraData) => {
   const tenant = useSelector((state) => state.app.currentTenant)
   const [ocVisible, setOCVisible] = useState(false)
@@ -85,6 +86,7 @@ const columns = [
     selector: (row) => row['displayName'],
     sortable: true,
     wrap: true,
+    cell: (row) => CellTip(row['displayName']),
     exportSelector: 'displayName',
   },
   {
@@ -103,78 +105,91 @@ const columns = [
     name: 'Client App Types',
     selector: (row) => row['clientAppTypes'],
     sortable: true,
+    cell: (row) => CellTip(row['clientAppTypes']),
     exportSelector: 'clientAppTypes',
   },
   {
-    name: 'Platform Inc',
+    name: 'Include Platforms',
     selector: (row) => row['includePlatforms'],
     sortable: true,
+    cell: (row) => CellTip(row['includePlatforms']),
     exportSelector: 'includePlatforms',
   },
   {
-    name: 'Platform Exc',
+    name: 'Exclude Platforms',
     selector: (row) => row['excludePlatforms'],
     sortable: true,
+    cell: (row) => CellTip(row['excludePlatforms']),
     exportSelector: 'excludePlatforms',
   },
   {
     name: 'Include Locations',
     selector: (row) => row['includeLocations'],
     sortable: true,
+    cell: (row) => CellTip(row['includeLocations']),
     exportSelector: 'includeLocations',
   },
   {
     name: 'Exclude Locations',
     selector: (row) => row['excludeLocations'],
     sortable: true,
+    cell: (row) => CellTip(row['excludeLocations']),
     exportSelector: 'excludeLocations',
   },
   {
     name: 'Include Users',
     selector: (row) => row['includeUsers'],
     sortable: true,
+    cell: (row) => CellTip(row['includeUsers']),
     exportSelector: 'includeUsers',
   },
   {
     name: 'Exclude Users',
     selector: (row) => row['excludeUsers'],
     sortable: true,
+    cell: (row) => CellTip(row['excludeUsers']),
     exportSelector: 'excludeUsers',
   },
   {
     name: 'Include Groups',
     selector: (row) => row['includeGroups'],
     sortable: true,
+    cell: (row) => CellTip(row['includeGroups']),
     exportSelector: 'includeGroups',
   },
   {
     name: 'Exclude Groups',
     selector: (row) => row['excludeGroups'],
     sortable: true,
+    cell: (row) => CellTip(row['excludeGroups']),
     exportSelector: 'excludeGroups',
   },
   {
     name: 'Include Applications',
     selector: (row) => row['includeApplications'],
     sortable: true,
+    cell: (row) => CellTip(row['includeApplications']),
     exportSelector: 'includeApplications',
   },
   {
     name: 'Exclude Applications',
     selector: (row) => row['excludeApplications'],
     sortable: true,
+    cell: (row) => CellTip(row['excludeApplications']),
     exportSelector: 'excludeApplications',
   },
   {
     name: 'Control Operator',
     selector: (row) => row['grantControlsOperator'],
     sortable: true,
+    cell: (row) => CellTip(row['grantControlsOperator']),
     exportSelector: 'grantControlsOperator',
   },
   {
     name: 'Built-in Controls',
     selector: (row) => row['builtInControls'],
     sortable: true,
+    cell: (row) => CellTip(row['builtInControls']),
     exportSelector: 'builtInControls',
   },
   {

--- a/src/views/tenant/conditional/ConditionalAccess.js
+++ b/src/views/tenant/conditional/ConditionalAccess.js
@@ -12,7 +12,7 @@ import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { CippPageList } from 'src/components/layout'
 import { CippActionsOffcanvas } from 'src/components/utilities'
-import { CellTip } from 'src/components/tables'
+import { cellDateFormatter, CellTip } from 'src/components/tables'
 const Offcanvas = (row, rowIndex, formatExtraData) => {
   const tenant = useSelector((state) => state.app.currentTenant)
   const [ocVisible, setOCVisible] = useState(false)
@@ -88,6 +88,7 @@ const columns = [
     wrap: true,
     cell: (row) => CellTip(row['displayName']),
     exportSelector: 'displayName',
+    minWidth: '300px',
   },
   {
     name: 'State',
@@ -96,9 +97,10 @@ const columns = [
     exportSelector: 'state',
   },
   {
-    name: 'Last Modified',
-    selector: (row) => row['modifiedDateTime'],
+    name: 'Last Modified (Local)',
+    selector: (row) => row['modifiedDateTime'].toString().trim() + 'Z',
     sortable: true,
+    cell: cellDateFormatter(),
     exportSelector: 'modifiedDateTime',
   },
   {

--- a/src/views/tenant/conditional/ListCATemplates.js
+++ b/src/views/tenant/conditional/ListCATemplates.js
@@ -16,6 +16,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useLazyGenericGetRequestQuery } from 'src/store/api/app'
 import { CippPage } from 'src/components/layout'
 import { ModalService } from 'src/components/utilities'
+import { CellTip } from 'src/components/tables'
 
 //todo: expandable with RAWJson property.
 /* eslint-disable-next-line react/prop-types */
@@ -71,6 +72,7 @@ const AutopilotListTemplates = () => {
       name: 'Display Name',
       selector: (row) => row['displayName'],
       sortable: true,
+      cell: (row) => CellTip(row['displayName']),
       exportSelector: 'displayName',
     },
     {
@@ -82,6 +84,7 @@ const AutopilotListTemplates = () => {
     {
       name: 'Actions',
       cell: Offcanvas,
+      maxWidth: '80px',
     },
   ]
 


### PR DESCRIPTION
Bugs:

* Teams View was showing incorrect values for true boolean indicators (so asserting false when true).

* The tenantID was not populating the Endpoint URL in UserDevices.js

* Various fields such as email address for owners & members of teams were incorrectly mapped, thus not showing in the UI, I squashed these as i encountered them.

UI/UX Enhancement:

* Tooltips in bulk amounts! There are many evils in this world, one such is table rows that truncate values with no method of retrieving the full value. It is super frustrating to want to know what it says, but you can't know! Damnit! I MUST KNOW WHAT IT SAYS!!!!!!!! So now I know what it says, and so do you. 👀 👀 👀

* DateTimes have been standardised to Local where I could quickly & easily do so. There are a few UTC that remain, however I have ensured that all DateTimes are now labeled as either (Local) or (UTC) so it is immediately obvious what we are working with, because it's good to not quote things 10 hours earlier than actual (or vise versa).

* Boolean indicator fixes! A sea of red crosses suggests that things are broken! But nothing is broken! So why do I have a sea of red crosses? I have removed the colour off these red devils so that I can relax and not feel like everything is broken. Red remains for things that are of actual concern like non-compliant devices and anti-virus being disabled. Things like POP being disabled, NOT RED CROSS!!!!

* Resized some columns, for e.g. the column holding the more-info/delete icons didn't need to take up two fifths of the page.

* Translated all the login error codes for the User Sign In audit box, I could find in the sign in logs of a few tenants, so for e.g instead of simply error code '50097', it now says '50097 (Device authentication required)'

* Text fields that were exceeding the bounds of their card no longer do that. Instead they remain tucked away in their card with a horizontal scroller. If you are too lazy to scroll, I also provided a tooltip so you can also mouse hover over for the full value.