### PR TITLE
fixed small % values in OneDrive usage report being shown as no data

### DIFF
--- a/src/components/tables/CellProgressBar.js
+++ b/src/components/tables/CellProgressBar.js
@@ -24,7 +24,7 @@ export const CellProgressBar = ({ value, reverse = false }) => {
       color = 'success'
     }
   }
-  if (value) {
+  if (value > 0) {
     return (
       <div style={{ width: '100%' }}>
         <CProgress>

--- a/src/views/identity/administration/UserOneDriveUsage.js
+++ b/src/views/identity/administration/UserOneDriveUsage.js
@@ -25,7 +25,7 @@ export default function UserOneDriveUsage({ userUPN, tenantDomain, className = n
     {
       heading: 'Percent',
       body: CellProgressBar({
-        value: Math.round((usage[0]?.UsedGB / usage[0]?.Allocated) * 100),
+        value: ((usage[0]?.UsedGB / usage[0]?.Allocated) * 100).toFixed(2),
         reverse: true,
       }),
     },


### PR DESCRIPTION
Self explanatory, see #cipp-issues in Discord for discussion