### PR TITLE
Add Quad9 to DNS Resolver Options

### DIFF
--- a/docs/user/usingcipp/settings/settings.mdx
+++ b/docs/user/usingcipp/settings/settings.mdx
@@ -34,7 +34,7 @@ If your tenant access checks are failing please see the [Troubleshooting](/troub
 
 ### Domain Name System Resolver
 
-You can switch providers to either Google or Cloudflare for your domain analyser results.
+You can switch providers to either Google, Cloudflare or Quad9 for your domain analyser results.
 
 ### Excluded Tenants
 


### PR DESCRIPTION
Line 37 add Quad9 to options for Domain Name System Resolvers.