### PR TITLE
Update standards.mdx

### DIFF
--- a/docs/user/usingcipp/tenantadministration/standards.mdx
+++ b/docs/user/usingcipp/tenantadministration/standards.mdx
@@ -71,7 +71,7 @@ Changes which have a user impact mitigated with a little communication.
 
 
 :::danger High Impact
-Changes which should be require thought and planning. Should ideally co-ordinate deployment with customers - may have significant impacts on how users interact with Microsoft 365.
+Changes which should require thought and planning. Should ideally co-ordinate deployment with customers - may have significant impacts on how users interact with Microsoft 365.
 :::
 
 | Set Sharing Level for OneDrive and Sharepoint                    | Portal Only                                                                                                                                                                                          | Sets the sharing level for OneDrive allowed by users                                                                                                                                                                                                                                                          |


### PR DESCRIPTION
Updated the wording on the "High Impact" notice. Changed "Changes which should be require thought and planning." to "Changes which should require thought and planning." 

Just removed "be"