### PR TITLE
Fixed GranularDelegetedAdminPrivileges spelling mistake

### DIFF
--- a/src/views/cipp/CIPPSettings.js
+++ b/src/views/cipp/CIPPSettings.js
@@ -656,7 +656,7 @@ const ExcludedTenantsSettings = () => {
         if (cell === 'delegatedAndGranularDelegetedAdminPrivileges') {
           return <CellBadge color="info" label="GDAP & DAP" />
         }
-        if (cell === 'GranularDelegetedAdminPrivileges') {
+        if (cell === 'granularDelegatedAdminPrivileges') {
           return <CellBadge color="info" label="GDAP" />
         }
         return <CellBadge color="info" label="Unknown" />


### PR DESCRIPTION
Fixed spelling mistake as mentioned in https://github.com/KelvinTegelaar/CIPP/issues/1443

Left the spelling mistake in delegatedAndGranularDelegetedAdminPrivileges because Microsoft misspelled it in Graph itself.