### PR TITLE
Correct client Azure portal link

### DIFF
--- a/src/views/home/Home.js
+++ b/src/views/home/Home.js
@@ -115,7 +115,7 @@ const Home = () => {
     },
     {
       label: 'Azure',
-      link: `https://portal.azure.com/?tid=${currentTenant.defaultDomainName}`,
+      link: `https://portal.azure.com/#@${currentTenant.customerId}`,
       icon: faServer,
     },
     {


### PR DESCRIPTION
The Azure portal link on the Dashboard always redirects to our Azure tenant instead of the client's. This corrects the link to use the client's tenant ID instead of the default domain.