### PR TITLE
Fix Edit Mailbox Permisions button

### DIFF
--- a/src/views/identity/administration/UserActions.js
+++ b/src/views/identity/administration/UserActions.js
@@ -31,7 +31,7 @@ export default function UserActions({ tenantDomain, userId, userEmail, className
   }
 
   const editLink = `/identity/administration/users/edit?tenantDomain=${tenantDomain}&userId=${userId}`
-  const editMailboxLink = `/email/administration/edit-mailbox-permissions?tenantDomain=${tenantDomain}&userId=${userId}`
+  const editMailboxLink = `/email/administration/edit-mailbox-permissions?tenantDomain=${tenantDomain}&userId=${userEmail}`
 
   const actions = [
     {


### PR DESCRIPTION
Used the ID variable instead of email one that should have been used.