### PR TITLE
Link to edit mailbox permissions page should pass userId not userEmail.

### DIFF
--- a/src/views/identity/administration/UserActions.jsx
+++ b/src/views/identity/administration/UserActions.jsx
@@ -32,7 +32,7 @@ export default function UserActions({ tenantDomain, userId, userEmail, className
   }
 
   const editLink = `/identity/administration/users/edit?tenantDomain=${tenantDomain}&userId=${userId}`
-  const editMailboxLink = `/email/administration/edit-mailbox-permissions?tenantDomain=${tenantDomain}&userId=${userEmail}`
+  const editMailboxLink = `/email/administration/edit-mailbox-permissions?tenantDomain=${tenantDomain}&userId=${userId}`
 
   const actions = [
     {


### PR DESCRIPTION
Fixes the link to the Edit Mailbox Permissions page - this passes userId (UPN) instead of userEmail - which was preventing this link working correctly for shared mailboxes.