### PR TITLE
Update calendar permissions

### DIFF
--- a/src/views/email-exchange/administration/EditCalendarPermissions.jsx
+++ b/src/views/email-exchange/administration/EditCalendarPermissions.jsx
@@ -174,6 +174,8 @@ const EditCalendarPermission = () => {
                                     { value: 'PublishingAuthor', name: 'Publishing Author' },
                                     { value: 'PublishingEditor', name: 'Publishing Editor' },
                                     { value: 'Reviewer', name: 'Reviewer' },
+                                    { value: 'LimitedDetails', name: 'Limited Details' },
+                                    { value: 'AvailabilityOnly', name: 'Availability Only' },
                                   ]}
                                   placeholder="Select a permission level"
                                   name="Permissions"

--- a/src/views/email-exchange/administration/EditMailboxPermissions.jsx
+++ b/src/views/email-exchange/administration/EditMailboxPermissions.jsx
@@ -531,6 +531,8 @@ const CalendarPermissions = () => {
                                   name: 'Publishing Editor',
                                 },
                                 { value: 'Reviewer', name: 'Reviewer' },
+                                { value: 'LimitedDetails', name: 'Limited Details' },
+                                { value: 'AvailabilityOnly', name: 'Availability Only' },
                               ]}
                               placeholder="Select a permission level"
                               name="Permissions"


### PR DESCRIPTION
Add LimitedDetails and AvailabilityOnly to calendar permissions dropdown
Couldnt find a place where EditCalendarPermissions.jsx was bing used, but i added the options to it anyway.