### PR TITLE
Revert "Link to edit mailbox permissions page should pass userId not userEmail."

### DIFF
--- a/src/views/identity/administration/UserActions.jsx
+++ b/src/views/identity/administration/UserActions.jsx
@@ -32,7 +32,7 @@ export default function UserActions({ tenantDomain, userId, userEmail, className
   }
 
   const editLink = `/identity/administration/users/edit?tenantDomain=${tenantDomain}&userId=${userId}`
-  const editMailboxLink = `/email/administration/edit-mailbox-permissions?tenantDomain=${tenantDomain}&userId=${userId}`
+  const editMailboxLink = `/email/administration/edit-mailbox-permissions?tenantDomain=${tenantDomain}&userId=${userEmail}`
 
   const actions = [
     {


### PR DESCRIPTION
Reverts KelvinTegelaar/CIPP#1902

userId is returning GUID for all users/mailbox types, and not UPN
Breaks calendar permissions and mailbox forwardning tabs