### PR TITLE
Add block sign-in button to Shared Mailbox with Enabled Account report

### DIFF
--- a/src/views/email-exchange/reports/SharedMailboxEnabledAccount.jsx
+++ b/src/views/email-exchange/reports/SharedMailboxEnabledAccount.jsx
@@ -1,7 +1,47 @@
 import React from 'react'
+import { CButton } from '@coreui/react'
+import { faBan } from '@fortawesome/free-solid-svg-icons'
 import { useSelector } from 'react-redux'
 import { CellTip, cellBooleanFormatter } from 'src/components/tables'
 import { CippPageList } from 'src/components/layout'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { ModalService } from 'src/components/utilities'
+import { useLazyGenericGetRequestQuery } from 'src/store/api/app'
+
+const DisableSharedMailbox = (userId) => {
+  const tenant = useSelector((state) => state.app.currentTenant)
+  const [genericGetRequest, getResults] = useLazyGenericGetRequestQuery()
+  const handleModal = (modalMessage, modalUrl) => {
+    ModalService.confirm({
+      body: (
+        <div style={{ overflow: 'visible' }}>
+          <div>{modalMessage}</div>
+        </div>
+      ),
+      title: 'Confirm',
+      onConfirm: () => genericGetRequest({ path: modalUrl }),
+    })
+  }
+
+  return (
+    <>
+      <CButton
+        color="danger"
+        variant="ghost"
+        onClick={() => {
+          ModalService.confirm(
+            handleModal(
+              'Are you sure you want to block this user from signing in?',
+              `/api/ExecDisableUser?TenantFilter=${tenant?.defaultDomainName}&ID=${userId}`,
+            ),
+          )
+        }}
+      >
+        <FontAwesomeIcon icon={faBan} />
+      </CButton>
+    </>
+  )
+}
 
 const columns = [
   {
@@ -42,6 +82,11 @@ const columns = [
     sortable: true,
     cell: (row) => CellTip(row['accountEnabled']),
     exportSelector: 'accountEnabled',
+  },
+  {
+    name: 'Block sign-in',
+    cell: (row) => DisableSharedMailbox(row['id']),
+    minWidth: '100px',
   },
 ]
 


### PR DESCRIPTION
Adds the feature requested in #1938 