### PR TITLE
Update helptext and add sortable quota selectors

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -531,7 +531,7 @@
     "name": "standards.EnableMailboxAuditing",
     "cat": "Exchange Standards",
     "tag": ["lowimpact", "CIS"],
-    "helpText": "Enables Mailbox auditing for all mailboxes and on tenant level. By default Microsoft does not enable mailbox auditing for Resource Mailboxes, Public Folder Mailboxes and DiscoverySearch Mailboxes. Unified Audit Log needs to be enabled for this standard to function.",
+    "helpText": "Enables Mailbox auditing for all mailboxes and on tenant level. Disables audit bypass on all mailboxes. Unified Audit Log needs to be enabled for this standard to function.",
     "addedComponent": [],
     "label": "Enable Mailbox auditing",
     "impact": "Low Impact",

--- a/src/views/email-exchange/reports/MailboxStatisticsList.jsx
+++ b/src/views/email-exchange/reports/MailboxStatisticsList.jsx
@@ -75,6 +75,12 @@ const MailboxStatsList = () => {
       exportSelector: 'QuotaGB',
     },
     {
+      selector: (row) => Math.round((row.UsedGB / row.QuotaGB) * 100 * 10) / 10,
+      name: 'Quota Used(%)',
+      sortable: true,
+      exportSelector: 'QuotaUsed',
+    },
+    {
       selector: (row) => row['ItemCount'],
       name: 'Item Count (Total)',
       sortable: true,

--- a/src/views/teams-share/onedrive/OneDriveList.jsx
+++ b/src/views/teams-share/onedrive/OneDriveList.jsx
@@ -113,6 +113,12 @@ const OneDriveList = () => {
       exportSelector: 'Allocated',
     },
     {
+      selector: (row) => Math.round((row.UsedGB / row.Allocated) * 100 * 10) / 10,
+      name: 'Quota Used(%)',
+      sortable: true,
+      exportSelector: 'QuotaUsed',
+    },
+    {
       name: 'URL',
       selector: (row) => row['url'],
       sortable: true,


### PR DESCRIPTION
- Helptext change to reflect the updated mailbox auditing standard.

- Addition of sortable quota selectors for OneDrive and email reports.
