### PR TITLE
Added Boolean switch to standards lists

### DIFF
--- a/src/views/tenant/standards/ListAppliedStandards.jsx
+++ b/src/views/tenant/standards/ListAppliedStandards.jsx
@@ -493,6 +493,13 @@ const ApplyNewStandard = () => {
                                                   label={component.label}
                                                 />
                                               )}
+                                              {component.type === 'boolean' && (
+                                                <RFFCFormSwitch
+                                                  name={component.name}
+                                                  label={component.label}
+                                                  initialValue={component.default}
+                                                />
+                                              )}
                                               {component.type === 'AdminRolesMultiSelect' && (
                                                 <RFFSelectSearch
                                                   multi={true}


### PR DESCRIPTION
This adds a Boolean switch to the Standards list.
![image](https://github.com/KelvinTegelaar/CIPP/assets/15158490/e28f82fc-abac-4928-a4c2-465d80f025fd)
