### PR TITLE
Added default int value support to standards number type

### DIFF
--- a/src/views/tenant/standards/ListAppliedStandards.jsx
+++ b/src/views/tenant/standards/ListAppliedStandards.jsx
@@ -491,6 +491,7 @@ const ApplyNewStandard = () => {
                                                   className="mb-3"
                                                   name={component.name}
                                                   label={component.label}
+                                                  hiddenValue={component.default ?? 0}
                                                 />
                                               )}
                                               {component.type === 'boolean' && (


### PR DESCRIPTION
This is a quick little PR which adds a default int variable that can be used for setting the default number of a setting.
This can and should be used in a few places already

```json
"addedComponent": [
      {
        "type": "number",
        "label": "Phishing email threshold. (Default 1)",
        "name": "standards.AntiPhishPolicy.PhishThresholdLevel",
        "default": 1
      },
```