### PR TITLE
Fix Switch defaultValue

### DIFF
--- a/src/components/forms/RFFComponents.jsx
+++ b/src/components/forms/RFFComponents.jsx
@@ -102,9 +102,16 @@ export const RFFCFormSwitch = ({
   disabled = false,
   initialValue,
   onClick,
+  defaultValue,
 }) => {
   return (
-    <Field initialValue={initialValue} name={name} type="checkbox" validate={validate}>
+    <Field
+      defaultValue={defaultValue}
+      initialValue={initialValue}
+      name={name}
+      type="checkbox"
+      validate={validate}
+    >
       {({ meta, input }) => (
         <ConditionWrapper
           condition={helpText}

--- a/src/views/tenant/standards/ListAppliedStandards.jsx
+++ b/src/views/tenant/standards/ListAppliedStandards.jsx
@@ -498,7 +498,7 @@ const ApplyNewStandard = () => {
                                                 <RFFCFormSwitch
                                                   name={component.name}
                                                   label={component.label}
-                                                  initialValue={component.default}
+                                                  defaultValue={component.default}
                                                 />
                                               )}
                                               {component.type === 'AdminRolesMultiSelect' && (


### PR DESCRIPTION
Currently the boolean switch always shows whats defined in default, you can see the issue by reopening the Standard where you've disabled a setting. This makes it show the actual initialValue on reload.