### PR TITLE
Added TenantDefaultTimezone

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -1173,5 +1173,21 @@
     "label": "Only allow users to sync OneDrive from AAD joined devices",
     "impact": "High Impact",
     "impactColour": "danger"
+  },
+  {
+    "name": "standards.TenantDefaultTimezone",
+    "cat": "SharePoint Standards",
+    "tag": ["lowimpact"],
+    "helpText": "Sets the default timezone for the tenant. This will be used for all new users and sites.",
+    "addedComponent": [
+      {
+        "type": "input",
+        "name": "standards.TenantDefaultTimezone.Timezone",
+        "label": "Timezone"
+      }
+    ],
+    "label": "Set Default Timezone for Tenant",
+    "impact": "Low Impact",
+    "impactColour": "info"
   }
 ]


### PR DESCRIPTION
UI for https://github.com/KelvinTegelaar/CIPP-API/pull/753

The Input/Output is similar to https://github.com/open-networks/go-msgraph/blob/dd4cea7265c7e244f97c2979127fafed63142e04/supportedTimeZones.go#L82-L240
However i did notice `(UTC-08:00) Pacific Time (US & Canada)` is not accepted since its `(UTC-08:00) Pacific Time (US and Canada)`

You CAN use `UTC`, but the output is `(UTC) Coordinated Universal Time` which would result in the script trying to update the timezone every 3 hours.

I made Copilot create a Select for the list, but then i realized its 150 objects, which i'm not sure if we should include in the standards.json
(Maybe we should have a TimeZone list which we can query since it most likely accepts the same input?)