### PR TITLE
Update MFAReport.jsx

### DIFF
--- a/src/views/identity/reports/MFAReport.jsx
+++ b/src/views/identity/reports/MFAReport.jsx
@@ -139,11 +139,15 @@ const MFAList = () => {
           {
             filterName: 'Enabled, licensed non-guest users missing MFA',
             filter:
-              'Complex: UPN notlike #EXT#; IsLicensed eq true; accountEnabled eq true; MFARegistration eq false',
+              'Complex: UPN notlike #EXT#; IsLicensed eq true; accountEnabled eq true; MFARegistration ne true',
           },
           {
             filterName: 'No MFA methods registered',
-            filter: 'Complex: MFARegistration eq false',
+            filter: 'Complex: MFARegistration ne true',
+          },
+          {
+            filterName: 'MFA methods registered',
+            filter: 'Complex: MFARegistration eq true',
           },
         ],
         columns: tenant.defaultDomainName === 'AllTenants' ? Altcolumns : columns,


### PR DESCRIPTION
MFARegistration can return null which isn't captured within "MFARegistration eq false"; Instead proposing use of "MFARegistration ne true" to filter accounts without MFA registration.