### PR TITLE
Firefox e.actionsSelect is undefined fix

### DIFF
--- a/src/components/utilities/CippActionsOffcanvas.jsx
+++ b/src/components/utilities/CippActionsOffcanvas.jsx
@@ -345,7 +345,7 @@ export default function CippActionsOffcanvas(props) {
   }
   let actionsSelectorsContent
   try {
-    actionsSelectorsContent = props.actionsSelect.map((action, index) => (
+    actionsSelectorsContent = props?.actionsSelect?.map((action, index) => (
       <CListGroupItem className="" component="label" color={action.color} key={index}>
         {action.label}
         <CListGroupItem


### PR DESCRIPTION
Fixes this error in the console for Firefox users
```
An error occurred building OCanvas selectorsTypeError: e.actionsSelect is undefined
```
![image](https://github.com/KelvinTegelaar/CIPP/assets/15158490/87dc7a85-0013-46b4-bb4c-87c103efb9c3)
