### PR TITLE
Fix Dashboard domain name rows

### DIFF
--- a/src/views/home/Home.jsx
+++ b/src/views/home/Home.jsx
@@ -289,7 +289,7 @@ const TenantDashboard = () => {
                     {organization.verifiedDomains?.slice(0, 3).map((item, idx) => (
                       <li key={idx}>{item.name}</li>
                     ))}
-                    {organization.verifiedDomains?.length > 5 && (
+                    {organization.verifiedDomains?.length > 3 && (
                       <>
                         <CCollapse visible={domainVisible}>
                           {organization.verifiedDomains?.slice(3).map((item, idx) => (


### PR DESCRIPTION
Domains 4 and 5 would be hidden unless more than 5 were returned