### PR TITLE
Update standards.json - fixed "restirct" typo

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -2341,7 +2341,7 @@
             "value": "none"
           },
           {
-            "label": "Restirct sharing to specific domains",
+            "label": "Restrict sharing to specific domains",
             "value": "allowList"
           },
           {


### PR DESCRIPTION
Fixed "restirct" typos in the Standards screen