### PR TITLE
Fix flyout extended information and incorrect wording

### DIFF
--- a/src/views/email-exchange/connectors/ConnectorList.jsx
+++ b/src/views/email-exchange/connectors/ConnectorList.jsx
@@ -20,44 +20,46 @@ const Offcanvas = (row, rowIndex, formatExtraData) => {
       <CippActionsOffcanvas
         title="Extended Information"
         extendedInfo={[
-          { label: 'Created by', value: `${row.CreatedBy}` },
-          { label: 'Last edit by', value: `${row.LastModifiedBy}` },
-          { label: 'Description', value: `${row.Description}` },
+          { label: 'Name', value: `${row.Name}` },
+          { label: 'Comment', value: `${row.Comment}` },
+          { label: 'State', value: `${row.Enabled}` },
+          { label: 'Direction', value: `${row.cippconnectortype}` },
+          { label: 'Connector Type', value: `${row.ConnectorType}` },
         ]}
         actions={[
           {
-            label: 'Create template based on rule',
+            label: 'Create template based on connector',
             color: 'info',
             modal: true,
             icon: <FontAwesomeIcon icon={faBook} className="me-2" />,
             modalBody: row,
             modalType: 'POST',
             modalUrl: `/api/AddExConnectorTemplate`,
-            modalMessage: 'Are you sure you want to create a template based on this rule?',
+            modalMessage: 'Are you sure you want to create a template based on this connector?',
           },
           {
-            label: 'Enable Rule',
+            label: 'Enable Connector',
             color: 'info',
             icon: <FontAwesomeIcon icon={faCheck} className="me-2" />,
             modal: true,
             modalUrl: `/api/EditExConnector?State=Enable&TenantFilter=${tenant.defaultDomainName}&GUID=${row.Guid}&Type=${row.cippconnectortype}`,
-            modalMessage: 'Are you sure you want to enable this rule?',
+            modalMessage: 'Are you sure you want to enable this connector?',
           },
           {
-            label: 'Disable Rule',
+            label: 'Disable Connector',
             color: 'info',
             icon: <FontAwesomeIcon icon={faBan} className="me-2" />,
             modal: true,
             modalUrl: `/api/EditExConnector?State=Disable&TenantFilter=${tenant.defaultDomainName}&GUID=${row.Guid}&Type=${row.cippconnectortype}`,
-            modalMessage: 'Are you sure you want to disable this rule?',
+            modalMessage: 'Are you sure you want to disable this connector?',
           },
           {
-            label: 'Delete Rule',
+            label: 'Delete Connector',
             color: 'danger',
             modal: true,
             icon: <FontAwesomeIcon icon={faTrash} className="me-2" />,
             modalUrl: `/api/RemoveExConnector?TenantFilter=${tenant.defaultDomainName}&GUID=${row.Guid}&Type=${row.cippconnectortype}`,
-            modalMessage: 'Are you sure you want to delete this rule?',
+            modalMessage: 'Are you sure you want to delete this connector?',
           },
         ]}
         placement="end"


### PR DESCRIPTION
Flyout extended information was pulling the incorrect columns, so all info was showing as 'undefined' .

Updated all references to "rule" and replaced with "connector".