### PR TITLE
change Create OneDrive Shortcut dropdown to only show valid URL's

### DIFF
--- a/src/views/identity/administration/Users.jsx
+++ b/src/views/identity/administration/Users.jsx
@@ -607,7 +607,7 @@ const Users = (row) => {
               modalMessage:
                 'Select a SharePoint URL to create a OneDrive shortcut for and press continue.',
               modalDropdown: {
-                url: `/api/listSites?TenantFilter=${tenant.defaultDomainName}&type=SharePointSiteUsage`,
+                url: `/api/listSites?TenantFilter=${tenant.defaultDomainName}&type=SharePointSiteUsage&URLOnly=true`,
                 labelField: 'URL',
                 valueField: 'URL',
               },


### PR DESCRIPTION
this removes blank URL's from dropdown on 'Create OneDrive Shortcut' 
this change already present on related modal
'Add OneDrive Shortcut'


