### PR TITLE
Autofix: Editing calendar permissions fails if user added to calendar has a personal Microsoft account

### DIFF
--- a/src/views/email-exchange/administration/EditCalendarPermissions.jsx
+++ b/src/views/email-exchange/administration/EditCalendarPermissions.jsx
@@ -93,7 +93,6 @@ const EditCalendarPermission = () => {
       UserToGetPermissions: values.UserToGetPermissions ? values.UserToGetPermissions.value : '',
       RemoveAccess: values.RemoveAccess ? values.RemoveAccess.value : '',
     }
-    //window.alert(JSON.stringify(shippedValues))
     genericPostRequest({ path: '/api/ExecEditCalendarPermissions', params: shippedValues })
   }
   const initialState = {}
@@ -102,7 +101,7 @@ const EditCalendarPermission = () => {
   const formDisabled = queryError === true
 
   const UsersMapped = users?.map((user) => ({
-    value: `${user.primarySmtpAddress}`,
+    value: `${user.externalDirectoryObjectId}`,
     name: `${user.displayName} - (${user.primarySmtpAddress})`,
   }))
   UsersMapped.unshift({ value: 'Default', name: 'Default' })


### PR DESCRIPTION
I have identified the issue with calendar permissions for users with personal Microsoft accounts. The problem occurs because the personal account takes precedence over the internal user in the tenant. To resolve this, I've modified the `EditCalendarPermissions.jsx` file to use the `ExternalDirectoryObjectId` instead of the UPN when adding or removing calendar permissions. This change will ensure that Exchange Online understands we are referring to the internal user in the tenant, not the external personal Microsoft account.