### PR TITLE
fix: add missing apiData to Risk Detection report

### DIFF
--- a/src/components/CippFormPages/CippAddEditUser.jsx
+++ b/src/components/CippFormPages/CippAddEditUser.jsx
@@ -3,7 +3,7 @@ import CippFormComponent from "/src/components/CippComponents/CippFormComponent"
 import { CippFormCondition } from "/src/components/CippComponents/CippFormCondition";
 import { CippFormDomainSelector } from "/src/components/CippComponents/CippFormDomainSelector";
 import { CippFormUserSelector } from "/src/components/CippComponents/CippFormUserSelector";
-import countryList from "/src/data/CountryList.json";
+import countryList from "/src/data/countryList.json";
 import { CippFormLicenseSelector } from "/src/components/CippComponents/CippFormLicenseSelector";
 import Grid from "@mui/material/Grid";
 

--- a/src/components/CippWizard/CippWizardBulkOptions.jsx
+++ b/src/components/CippWizard/CippWizardBulkOptions.jsx
@@ -1,7 +1,7 @@
 import { Grid, Stack } from "@mui/material";
 import CippWizardStepButtons from "./CippWizardStepButtons";
 import CippFormComponent from "../CippComponents/CippFormComponent";
-import countryList from "/src/data/CountryList.json";
+import countryList from "/src/data/countryList.json";
 import { CippFormLicenseSelector } from "../CippComponents/CippFormLicenseSelector";
 export const CippWizardBulkOptions = (props) => {
   const { postUrl, formControl, onPreviousStep, onNextStep, currentStep } = props;

--- a/src/pages/identity/reports/risk-detections/index.js
+++ b/src/pages/identity/reports/risk-detections/index.js
@@ -66,6 +66,7 @@ const Page = () => {
         Endpoint: "identityProtection/riskDetections",
         manualPagination: true,
         $count: true,
+        NoPagination: true,
         $top: 999,
       }}
       apiDataKey="Results"

--- a/src/pages/identity/reports/risk-detections/index.js
+++ b/src/pages/identity/reports/risk-detections/index.js
@@ -8,7 +8,7 @@ const Page = () => {
   const actions = [
     {
       label: "Research Compromised Account",
-      link: "/identity/administration/ViewBec?userId=[userId]&tenantDomain=[tenantDomain]&ID=[userPrincipalName]",
+      link: "/identity/administration/users/user/bec?userId=[userId]&tenantFilter=[Tenant]",
       color: "info",
     },
   ];


### PR DESCRIPTION
Quite a few things missing here, but atleast now we can view the page/data