### PR TITLE
Fix displayName labelField to displayName to comply with API output

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -3030,7 +3030,7 @@
         "label": "Select Group Template",
         "api": {
           "url": "/api/ListGroupTemplates",
-          "labelField": "displayName",
+          "labelField": "Displayname",
           "valueField": "GUID",
           "queryKey": "ListGroupTemplates"
         }


### PR DESCRIPTION
Output casing of Displayname does not match front-ends expectations. Other template labelFields have similar casing deviations from standard, so changing this to follow suit.

Fixes the below for group templates in standards:
![image](https://github.com/user-attachments/assets/f6f4eed4-352b-4bc5-934a-a78ba34f0677)
