### PR TITLE
Update user selection in CippExchangeSettingsForm to include default option

### DIFF
--- a/src/components/CippFormPages/CippExchangeSettingsForm.jsx
+++ b/src/components/CippFormPages/CippExchangeSettingsForm.jsx
@@ -244,12 +244,13 @@ const CippExchangeSettingsForm = (props) => {
             label="Add Access"
             name="calendar.UserToGetPermissions"
             isFetching={isFetching || usersList.isFetching}
-            options={
-              usersList?.data?.Results?.map((user) => ({
+            options={[
+              { value: "Default", label: "Default (Default)" },
+              ...(usersList?.data?.Results?.map((user) => ({
                 value: user.userPrincipalName,
                 label: `${user.displayName} (${user.userPrincipalName})`,
-              })) || []
-            }
+              })) || []),
+            ]}
             multiple={false}
             formControl={formControl}
           />


### PR DESCRIPTION
Add a default option to the user selection calendar permission dropdown.
Resolves #3215