### PR TITLE
fix: Exchange Permission userId use UPN instead of Id

### DIFF
--- a/src/pages/email/administration/mailboxes/index.js
+++ b/src/pages/email/administration/mailboxes/index.js
@@ -10,7 +10,7 @@ const Page = () => {
   const actions = [
     {
       label: "Edit permissions",
-      link: "/identity/administration/users/user/exchange?userId=[Id]",
+      link: "/identity/administration/users/user/exchange?userId=[UPN]",
       color: "info",
     },
     {


### PR DESCRIPTION
Id returns the Fullname instead of the actual ID..