### PR TITLE
Update Compliance Portal links to Purview

### DIFF
--- a/src/components/CippComponents/CippTenantSelector.jsx
+++ b/src/components/CippComponents/CippTenantSelector.jsx
@@ -228,7 +228,7 @@ export const CippTenantSelector = (props) => {
           },
           {
             label: "Compliance Portal",
-            link: `https://compliance.microsoft.com/?tid=${currentTenant?.addedFields?.customerId}`,
+            link: `https://purview.microsoft.com/?tid=${currentTenant?.addedFields?.customerId}`,
             icon: <ShieldMoon />,
           },
         ]}

--- a/src/data/portals.json
+++ b/src/data/portals.json
@@ -65,7 +65,7 @@
   {
     "label": "Compliance Portal",
     "name": "Compliance_Portal",
-    "url": "https://compliance.microsoft.com/?tid=customerId",
+    "url": "https://purview.microsoft.com/?tid=customerId",
     "variable": "customerId",
     "target": "_blank",
     "external": true,

--- a/src/pages/tenant/administration/tenants/index.js
+++ b/src/pages/tenant/administration/tenants/index.js
@@ -22,7 +22,7 @@ const Page = () => {
           portal_azure: `https://portal.azure.com/${tenant.defaultDomainName}`,
           portal_intune: `https://intune.microsoft.com/${tenant.defaultDomainName}`,
           portal_security: `https://security.microsoft.com/?tid=${tenant.customerId}`,
-          portal_compliance: `https://compliance.microsoft.com/?tid=${tenant.customerId}`,
+          portal_compliance: `https://purview.microsoft.com/?tid=${tenant.customerId}`,
           portal_sharepoint: `https://admin.microsoft.com/Partner/beginclientsession.aspx?CTID=${tenant.customerId}&CSDEST=SharePoint`,
         });
       });


### PR DESCRIPTION
Change all instances of the Compliance Portal links to direct users to the Purview portal instead, since the current link just points to a redirector page anyway.  
New links have been tested and confirmed to work with the same GDAP access method/link formating