### PR TITLE
Change style of "Sharepoint" to "SharePoint" in the portals dropdown and various standard descriptions

### DIFF
--- a/src/components/CippComponents/CippTenantSelector.jsx
+++ b/src/components/CippComponents/CippTenantSelector.jsx
@@ -217,7 +217,7 @@ export const CippTenantSelector = (props) => {
             icon: <Laptop />,
           },
           {
-            label: "Sharepoint Portal",
+            label: "SharePoint Portal",
             link: `https://admin.microsoft.com/Partner/beginclientsession.aspx?CTID=${currentTenant?.addedFields?.customerId}&CSDEST=SharePoint`,
             icon: <Share />,
           },

--- a/src/components/CippComponents/CippTranslations.jsx
+++ b/src/components/CippComponents/CippTranslations.jsx
@@ -35,7 +35,7 @@ export const CippTranslations = {
   portal_intune: "Intune Portal",
   portal_security: "Security Portal",
   portal_compliance: "Compliance Portal",
-  portal_sharepoint: "Sharepoint Portal",
+  portal_sharepoint: "SharePoint Portal",
   "@odata.type": "Type",
   roleDefinitionId: "GDAP Role",
   FromIP: "From IP",

--- a/src/data/CIPPDefaultGDAPRoles.json
+++ b/src/data/CIPPDefaultGDAPRoles.json
@@ -32,7 +32,7 @@
     "value": "69091246-20e8-4a56-aa4d-066075b2a7a8"
   },
   {
-    "label": "Sharepoint Administrator",
+    "label": "SharePoint Administrator",
     "value": "f28a1f50-f6e7-4571-818b-6a12f2af6b6c"
   },
   {

--- a/src/data/portals.json
+++ b/src/data/portals.json
@@ -72,8 +72,8 @@
     "icon": "shield-alt"
   },
   {
-    "label": "Sharepoint Admin",
-    "name": "Sharepoint_Admin",
+    "label": "SharePoint Admin",
+    "name": "SharePoint_Admin",
     "url": "https://admin.microsoft.com/Partner/beginclientsession.aspx?CTID=customerId&CSDEST=SharePoint",
     "variable": "customerId",
     "target": "_blank",

--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -498,7 +498,7 @@
     "name": "standards.DisableM365GroupUsers",
     "cat": "Entra (AAD) Standards",
     "tag": ["lowimpact"],
-    "helpText": "Restricts M365 group creation to certain admin roles. This disables the ability to create Teams, Sharepoint sites, Planner, etc",
+    "helpText": "Restricts M365 group creation to certain admin roles. This disables the ability to create Teams, SharePoint sites, Planner, etc",
     "docsDescription": "Users by default are allowed to create M365 groups. This restricts M365 group creation to certain admin roles. This disables the ability to create Teams, SharePoint sites, Planner, etc",
     "addedComponent": [],
     "label": "Disable M365 Group creation by users",
@@ -1682,7 +1682,7 @@
     "name": "standards.AtpPolicyForO365",
     "cat": "Defender Standards",
     "tag": ["lowimpact", "CIS"],
-    "helpText": "This creates a Atp policy that enables Defender for Office 365 for Sharepoint, OneDrive and Microsoft Teams.",
+    "helpText": "This creates a Atp policy that enables Defender for Office 365 for SharePoint, OneDrive and Microsoft Teams.",
     "addedComponent": [
       {
         "type": "switch",
@@ -2360,7 +2360,7 @@
     "name": "standards.sharingCapability",
     "cat": "SharePoint Standards",
     "tag": ["highimpact", "CIS"],
-    "helpText": "Sets the default sharing level for OneDrive and Sharepoint. This is a tenant wide setting and overrules any settings set on the site level",
+    "helpText": "Sets the default sharing level for OneDrive and SharePoint. This is a tenant wide setting and overrules any settings set on the site level",
     "addedComponent": [
       {
         "type": "autoComplete",
@@ -2387,7 +2387,7 @@
         ]
       }
     ],
-    "label": "Set Sharing Level for OneDrive and Sharepoint",
+    "label": "Set Sharing Level for OneDrive and SharePoint",
     "impact": "High Impact",
     "impactColour": "danger",
     "powershellEquivalent": "Update-MgBetaAdminSharepointSetting",


### PR DESCRIPTION
Fix for issue #3306 