### PR TITLE
New standard: Phofile photo

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -50,6 +50,36 @@
     "recommendedBy": ["CIS"]
   },
   {
+    "name": "standards.ProfilePhotos",
+    "cat": "Global Standards",
+    "tag": ["lowimpact"],
+    "helpText": "Controls whether users can set their own profile photos in Microsoft 365.",
+    "docsDescription": "Controls whether users can set their own profile photos in Microsoft 365. When disabled, only User and Global administrators can update profile photos for users.",
+    "addedComponent": [
+      {
+        "type": "select",
+        "multiple": false,
+        "label": "Select value",
+        "name": "standards.ProfilePhotos.state",
+        "options": [
+          {
+            "label": "Enabled",
+            "value": "enabled"
+          },
+          {
+            "label": "Disabled",
+            "value": "disabled"
+          }
+        ]
+      }
+    ],
+    "label": "Allow users to set profile photos",
+    "impact": "Low Impact",
+    "impactColour": "info",
+    "powershellEquivalent": "Set-OrganizationConfig -ProfilePhotoOptions EnablePhotos and Update-MgBetaAdminPeople",
+    "recommendedBy": []
+  },
+  {
     "name": "standards.PhishProtection",
     "cat": "Global Standards",
     "tag": ["lowimpact"],

--- a/src/pages/tenant/administration/app-consent-requests/index.js
+++ b/src/pages/tenant/administration/app-consent-requests/index.js
@@ -52,6 +52,7 @@ const Page = () => {
 
   return (
     <CippTablePage
+      // FIXME: This tableFilter does nothing. It does not change the table data at all, like the code makes it seem like it should. -Bobby
       tableFilter={
         <Accordion expanded={expanded} onChange={() => setExpanded(!expanded)}>
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
@@ -95,7 +96,7 @@ const Page = () => {
         // Filter for showing only pending requests
         {
           filterName: "Pending requests",
-          value: [{ id: "requestStatus", value: "Pending" }],
+          value: [{ id: "requestStatus", value: "InProgress" }],
           type: "column",
         },
       ]}


### PR DESCRIPTION
New standard for managing if users are able to set profile photos themselves in Microsoft 365.

Also fixes a preset filter to actually work

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1243

