### PR TITLE
Add Global Address List report page and update API methods to POST

### DIFF
--- a/src/layouts/config.js
+++ b/src/layouts/config.js
@@ -377,6 +377,10 @@ export const nativeMenuItems = [
             title: "Shared Mailbox with Enabled Account",
             path: "/email/reports/SharedMailboxEnabledAccount",
           },
+          {
+            title: "Global Address List",
+            path: "/email/reports/global-address-list",
+          },
         ],
       },
     ],

--- a/src/pages/email/administration/mailboxes/index.js
+++ b/src/pages/email/administration/mailboxes/index.js
@@ -47,7 +47,7 @@ const Page = () => {
     },
     {
       label: "Hide from Global Address List",
-      type: "GET",
+      type: "POST",
       url: "/api/ExecHideFromGAL",
       data: {
         ID: "UPN",
@@ -58,7 +58,7 @@ const Page = () => {
     },
     {
       label: "Unhide from Global Address List",
-      type: "GET",
+      type: "POST",
       url: "/api/ExecHideFromGAL",
       data: {
         ID: "UPN",

--- a/src/pages/email/reports/global-address-list/index.js
+++ b/src/pages/email/reports/global-address-list/index.js
@@ -1,0 +1,81 @@
+﻿import { Layout as DashboardLayout } from "/src/layouts/index.js";
+import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx";
+
+const Page = () => {
+  const actions = [
+    {
+      label: "Unhide from Global Address List",
+      type: "POST",
+      url: "/api/ExecHideFromGAL",
+      data: {
+        HideFromGAL: false,
+        ID: "PrimarySmtpAddress",
+      },
+      confirmText: "Are you sure you want to show this mailbox in the Global Address List?",
+    },
+    {
+      label: "Hide from Global Address List",
+      type: "POST",
+      url: "/api/ExecHideFromGAL",
+      data: {
+        HideFromGAL: true,
+        ID: "PrimarySmtpAddress",
+      },
+      confirmText: "Are you sure you want to hide this mailbox from the Global Address List?",
+    },
+  ];
+
+  const offCanvas = {
+    extendedInfoFields: [
+      "HiddenFromAddressListsEnabled",
+      "ExternalDirectoryObjectId",
+      "DisplayName",
+      "PrimarySmtpAddress",
+      "RecipientType",
+      "RecipientTypeDetails",
+      "IsDirSynced",
+      "SKUAssigned",
+      "EmailAddresses",
+    ],
+    actions: actions,
+  };
+
+  const filters = [
+    {
+      filterName: "Hidden from GAL",
+      value: [{ id: "HiddenFromAddressListsEnabled", value: "Yes" }],
+      type: "column",
+    },
+    {
+      filterName: "Shown in GAL",
+      value: [{ id: "HiddenFromAddressListsEnabled", value: "No" }],
+      type: "column",
+    },
+    {
+      filterName: "Able to be hidden from GAL via CIPP",
+      value: [{ id: "IsDirSynced", value: "No" }],
+      type: "column",
+    },
+  ];
+
+  return (
+    <CippTablePage
+      title="Global Address List"
+      apiUrl="/api/ListGlobalAddressList"
+      actions={actions}
+      offCanvas={offCanvas}
+      filters={filters}
+      simpleColumns={[
+        "HiddenFromAddressListsEnabled",
+        "DisplayName",
+        "PrimarySmtpAddress",
+        "RecipientTypeDetails",
+        "IsDirSynced",
+      ]}
+    />
+  );
+};
+
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default Page;

--- a/src/pages/email/reports/global-address-list/index.js
+++ b/src/pages/email/reports/global-address-list/index.js
@@ -52,7 +52,7 @@ const Page = () => {
       type: "column",
     },
     {
-      filterName: "Able to be hidden from GAL via CIPP",
+      filterName: "Cloud only mailboxes",
       value: [{ id: "IsDirSynced", value: "No" }],
       type: "column",
     },


### PR DESCRIPTION
API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1245

Add page for viewing the GAL and to easlily hide stuff from the GAL.
Can also be used to easily find where an email address is used, if it's not on any normal user or resource accounts
Resolves #2944