### PR TITLE
Change device actions to POST and add stale device cleanup standard

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -645,6 +645,30 @@
     "recommendedBy": []
   },
   {
+    "name": "standards.StaleEntraDevices",
+    "cat": "Entra (AAD) Standards",
+    "tag": ["highimpact", "CIS"],
+    "helpText": "Cleans up Entra devices that have not connected/signed in for the specified number of days.",
+    "docsDescription": "Cleans up Entra devices that have not connected/signed in for the specified number of days. First disables and later deletes the devices. More info can be found in the [Microsoft documentation](https://learn.microsoft.com/en-us/entra/identity/devices/manage-stale-devices)",
+    "addedComponent": [
+      {
+        "type": "number",
+        "name": "standards.StaleEntraDevices.deviceAgeThreshold",
+        "label": "Days before stale(Dont set below 30)"
+      }
+    ],
+    "disabledFeatures": {
+      "report": false,
+      "warn": false,
+      "remediate": true
+    },
+    "label": "Cleanup stale Entra devices",
+    "impact": "High Impact",
+    "impactColour": "danger",
+    "powershellEquivalent": "Remove-MgDevice, Update-MgDevice or Graph API",
+    "recommendedBy": []
+  },
+  {
     "name": "standards.UndoOauth",
     "cat": "Entra (AAD) Standards",
     "tag": ["highimpact"],

--- a/src/pages/identity/administration/devices/index.js
+++ b/src/pages/identity/administration/devices/index.js
@@ -4,46 +4,45 @@ import { Layout as DashboardLayout } from "/src/layouts/index.js"; // had to add
 const Page = () => {
   const pageTitle = "Devices";
   const actions = [
-    // these are currently GET requests that should be converted to POST requests.
     {
       label: "Enable Device",
-      type: "GET",
+      type: "POST",
       url: "/api/ExecDeviceDelete",
       data: {
         ID: "id",
-        Action: "!Enable",
+        action: "Enable",
       },
       confirmText: "Are you sure you want to enable this device?",
       multiPost: false,
     },
     {
       label: "Disable Device",
-      type: "GET",
+      type: "POST",
       url: "/api/ExecDeviceDelete",
       data: {
         ID: "id",
-        Action: "!Disable",
+        action: "Disable",
       },
       confirmText: "Are you sure you want to disable this device?",
       multiPost: false,
     },
     {
-      label: "Retrieve Bitlocker Keys",
+      label: "Retrieve BitLocker Keys",
       type: "GET",
       url: "/api/ExecGetRecoveryKey",
       data: {
         GUID: "id",
       },
-      confirmText: "Are you sure you want to retrieve the Bitlocker keys?",
+      confirmText: "Are you sure you want to retrieve the BitLocker keys?",
       multiPost: false,
     },
     {
       label: "Delete Device",
-      type: "GET",
+      type: "POST",
       url: "/api/ExecDeviceDelete",
       data: {
         ID: "id",
-        Action: "!Delete",
+        action: "Delete",
       },
       confirmText: "Are you sure you want to delete this device?",
       multiPost: false,
@@ -51,7 +50,20 @@ const Page = () => {
   ];
 
   const offCanvas = {
-    extendedInfoFields: ["createdDateTime", "displayName", "id"],
+    extendedInfoFields: [
+      "accountEnabled",
+      "displayName",
+      "id",
+      "recipientType",
+      "enrollmentType",
+      "manufacturer",
+      "model",
+      "operatingSystem",
+      "operatingSystemVersion",
+      "profileType",
+      "createdDateTime",
+      "approximateLastSignInDateTime",
+    ],
     actions: actions,
   };
 
@@ -77,6 +89,7 @@ const Page = () => {
         "operatingSystem",
         "operatingSystemVersion",
         "profileType",
+        "approximateLastSignInDateTime",
       ]}
     />
   );

--- a/src/pages/identity/administration/devices/index.js
+++ b/src/pages/identity/administration/devices/index.js
@@ -10,7 +10,7 @@ const Page = () => {
       url: "/api/ExecDeviceDelete",
       data: {
         ID: "id",
-        action: "Enable",
+        action: "!Enable",
       },
       confirmText: "Are you sure you want to enable this device?",
       multiPost: false,
@@ -21,7 +21,7 @@ const Page = () => {
       url: "/api/ExecDeviceDelete",
       data: {
         ID: "id",
-        action: "Disable",
+        action: "!Disable",
       },
       confirmText: "Are you sure you want to disable this device?",
       multiPost: false,
@@ -42,30 +42,12 @@ const Page = () => {
       url: "/api/ExecDeviceDelete",
       data: {
         ID: "id",
-        action: "Delete",
+        action: "!Delete",
       },
       confirmText: "Are you sure you want to delete this device?",
       multiPost: false,
     },
   ];
-
-  const offCanvas = {
-    extendedInfoFields: [
-      "accountEnabled",
-      "displayName",
-      "id",
-      "recipientType",
-      "enrollmentType",
-      "manufacturer",
-      "model",
-      "operatingSystem",
-      "operatingSystemVersion",
-      "profileType",
-      "createdDateTime",
-      "approximateLastSignInDateTime",
-    ],
-    actions: actions,
-  };
 
   return (
     <CippTablePage
@@ -78,7 +60,6 @@ const Page = () => {
       }}
       apiDataKey="Results"
       actions={actions}
-      offCanvas={offCanvas}
       simpleColumns={[
         "displayName",
         "accountEnabled",


### PR DESCRIPTION
Update device action requests from GET to POST for consistency and introduce a new standard for cleaning up stale Entra devices with a configurable age threshold.
API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1247