### PR TITLE
FIX: typo in AppCertificateExpiry alert

### DIFF
--- a/src/data/alerts.json
+++ b/src/data/alerts.json
@@ -92,7 +92,7 @@
     "recommendedRunInterval": "30d"
   },
   {
-    "name": "AppCertificateExpiry ",
+    "name": "AppCertificateExpiry",
     "label": "Alert on expiring application certificates",
     "recommendedRunInterval": "1d"
   },


### PR DESCRIPTION
Creates this wonderful error:
Task Failed: The term 'Get-CIPPAlertAppCertificateExpiry ' is not recognized as a name of a cmdlet, function, script file, or executable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.