### PR TITLE
FEAT: Add alert for Entra ID license over-utilization

### DIFF
--- a/src/data/alerts.json
+++ b/src/data/alerts.json
@@ -82,6 +82,15 @@
     "recommendedRunInterval": "7d"
   },
   {
+    "name": "EntraLicenseUtilization",
+    "label": "Alert on Entra ID P1/P2 license over-utilization",
+    "recommendedRunInterval": "7d",
+    "requiresInput": true,
+    "inputType": "textField",
+    "inputLabel": "Alert when utilization exceeds % (default: 110)",
+    "inputName": "EntraLicenseUtilizationThreshold"
+  },
+  {
     "name": "AppSecretExpiry",
     "label": "Alert on expiring application secrets",
     "recommendedRunInterval": "1d"


### PR DESCRIPTION
Introduce an alert for monitoring over-utilization of Entra ID P1/P2 licenses, allowing users to set a threshold for notifications.

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1298