### PR TITLE
FEAT: Add clear immutable ID option to offboarding wizard

### DIFF
--- a/src/components/CippComponents/CippUserActions.jsx
+++ b/src/components/CippComponents/CippUserActions.jsx
@@ -284,7 +284,7 @@ export const CippUserActions = () => {
     },
     {
       label: "Clear Immutable ID",
-      type: "GET",
+      type: "POST",
       icon: <Clear />,
       url: "/api/ExecClrImmId",
       data: {

--- a/src/components/CippWizard/CippWizardOffboarding.jsx
+++ b/src/components/CippWizard/CippWizardOffboarding.jsx
@@ -98,6 +98,12 @@ export const CippWizardOffboarding = (props) => {
                 formControl={formControl}
               />
               <CippFormComponent
+                name="ClearImmutableId"
+                label="Clear Immutable ID"
+                type="switch"
+                formControl={formControl}
+              />
+              <CippFormComponent
                 name="ResetPass"
                 label="Reset Password"
                 type="switch"


### PR DESCRIPTION
Introduce a new option in the offboarding wizard to clear the immutable ID, changing the request type to POST for the associated API call.

Resolves: https://github.com/KelvinTegelaar/CIPP/issues/3603