### PR TITLE
FEAT: Add creatable properties and new AuthMethodsSettings standard

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -59,6 +59,7 @@
       {
         "type": "select",
         "multiple": false,
+        "creatable": false,
         "label": "Select value",
         "name": "standards.ProfilePhotos.state",
         "options": [
@@ -225,6 +226,7 @@
       {
         "type": "select",
         "multiple": false,
+        "creatable": false,
         "label": "Select value",
         "name": "standards.ActivityBasedTimeout.timeout",
         "options": [
@@ -256,6 +258,64 @@
     "impactColour": "warning",
     "powershellEquivalent": "Portal or Graph API",
     "recommendedBy": ["CIS"]
+  },
+  {
+    "name": "standards.AuthMethodsSettings",
+    "cat": "Entra (AAD) Standards",
+    "tag": ["lowimpact"],
+    "helpText": "Configures the report suspicious activity settings and system credential preferences in the authentication methods policy.",
+    "docsDescription": "Controls the authentication methods policy settings for reporting suspicious activity and system credential preferences. These settings help enhance the security of authentication in your organization.",
+    "addedComponent": [
+      {
+        "type": "autoComplete",
+        "multiple": false,
+        "creatable": false,
+        "required": false,
+        "name": "standards.AuthMethodsSettings.ReportSuspiciousActivity",
+        "label": "Report Suspicious Activity Settings",
+        "options": [
+          {
+            "label": "Microsoft managed",
+            "value": "default"
+          },
+          {
+            "label": "Enabled",
+            "value": "enabled"
+          },
+          {
+            "label": "Disabled",
+            "value": "disabled"
+          }
+        ]
+      },
+      {
+        "type": "autoComplete",
+        "multiple": false,
+        "creatable": false,
+        "required": false,
+        "name": "standards.AuthMethodsSettings.SystemCredential",
+        "label": "System Credential Preferences",
+        "options": [
+          {
+            "label": "Microsoft managed",
+            "value": "default"
+          },
+          {
+            "label": "Enabled",
+            "value": "enabled"
+          },
+          {
+            "label": "Disabled",
+            "value": "disabled"
+          }
+        ]
+      }
+    ],
+    "label": "Configure Authentication Methods Policy Settings",
+    "impact": "Low Impact",
+    "impactColour": "info",
+    "powershellEquivalent": "Update-MgBetaPolicyAuthenticationMethodPolicy",
+    "recommendedBy": []
   },
   {
     "name": "standards.AppDeploy",
@@ -325,6 +385,7 @@
       {
         "type": "select",
         "multiple": false,
+        "creatable": false,
         "label": "Select value",
         "name": "standards.PWcompanionAppAllowedState.state",
         "options": [
@@ -394,6 +455,7 @@
       {
         "type": "select",
         "multiple": false,
+        "creatable": false,
         "label": "Select TAP Lifetime",
         "name": "standards.TAP.config",
         "options": [
@@ -436,6 +498,7 @@
       {
         "type": "select",
         "multiple": false,
+        "creatable": false,
         "label": "Select value",
         "name": "standards.ExternalMFATrusted.state",
         "options": [
@@ -498,6 +561,7 @@
       {
         "type": "select",
         "multiple": false,
+        "creatable": false,
         "label": "Select value",
         "name": "standards.NudgeMFA.state",
         "options": [
@@ -647,6 +711,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "label": "Who can send invites?",
         "name": "standards.GuestInvite.allowInvitesFrom",
         "options": [
@@ -1886,6 +1951,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "label": "Spam Action",
         "name": "standards.SpamFilterPolicy.SpamAction",
         "options": [
@@ -1903,6 +1969,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "label": "Spam Quarantine Tag",
         "name": "standards.SpamFilterPolicy.SpamQuarantineTag",
         "options": [
@@ -1924,6 +1991,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "label": "High Confidence Spam Action",
         "name": "standards.SpamFilterPolicy.HighConfidenceSpamAction",
         "options": [
@@ -1941,6 +2009,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "label": "High Confidence Spam Quarantine Tag",
         "name": "standards.SpamFilterPolicy.HighConfidenceSpamQuarantineTag",
         "options": [
@@ -1962,6 +2031,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "label": "Bulk Spam Action",
         "name": "standards.SpamFilterPolicy.BulkSpamAction",
         "options": [
@@ -1979,6 +2049,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "label": "Bulk Quarantine Tag",
         "name": "standards.SpamFilterPolicy.BulkQuarantineTag",
         "options": [
@@ -2000,6 +2071,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "label": "Phish Spam Action",
         "name": "standards.SpamFilterPolicy.PhishSpamAction",
         "options": [
@@ -2017,6 +2089,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "label": "Phish Quarantine Tag",
         "name": "standards.SpamFilterPolicy.PhishQuarantineTag",
         "options": [
@@ -2038,6 +2111,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "label": "High Confidence Phish Quarantine Tag",
         "name": "standards.SpamFilterPolicy.HighConfidencePhishQuarantineTag",
         "options": [
@@ -2162,6 +2236,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "name": "standards.IntuneComplianceSettings.secureByDefault",
         "label": "Mark devices with no compliance policy as",
         "options": [
@@ -2397,6 +2472,7 @@
       {
         "type": "autoComplete",
         "multiple": false,
+        "creatable": false,
         "label": "Add Shortcuts To OneDrive button state",
         "name": "standards.DisableAddShortcutsToOneDrive.state",
         "options": [
@@ -2426,6 +2502,7 @@
       {
         "type": "autoComplete",
         "multiple": false,
+        "creatable": false,
         "label": "SharePoint Sync Button state",
         "name": "standards.SPSyncButtonState.state",
         "options": [
@@ -2613,6 +2690,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "name": "standards.TeamsGlobalMeetingPolicy.DesignatedPresenterRoleMode",
         "label": "Default value of the `Who can present?`",
         "options": [
@@ -2643,6 +2721,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "name": "standards.TeamsGlobalMeetingPolicy.MeetingChatEnabledType",
         "label": "Meeting chat policy",
         "options": [
@@ -2735,6 +2814,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "name": "standards.TeamsEnrollUser.EnrollUserOverride",
         "label": "Voice and Face Enrollment",
         "options": [
@@ -2805,6 +2885,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "name": "standards.TeamsFederationConfiguration.DomainControl",
         "label": "Communication Mode",
         "options": [
@@ -2874,6 +2955,7 @@
         "type": "autoComplete",
         "required": true,
         "multiple": false,
+        "creatable": false,
         "name": "standards.TeamsMessagingPolicy.ReadReceiptsEnabledType",
         "label": "Read Receipts Enabled Type",
         "options": [
@@ -3023,6 +3105,7 @@
       {
         "type": "autoComplete",
         "multiple": false,
+        "creatable": false,
         "name": "standards.AutopilotProfile.Languages",
         "label": "Languages",
         "api": {
@@ -3107,6 +3190,7 @@
       {
         "type": "autoComplete",
         "multiple": false,
+        "creatable": false,
         "name": "TemplateList",
         "label": "Select Intune Template",
         "api": {


### PR DESCRIPTION
New standard and add creatable=false properties to most autoCompletes and selects
Resolves: https://github.com/KelvinTegelaar/CIPP/issues/3609

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1300