### PR TITLE
feat: TeamsGlobalMeetingPolicy AllowExternalParticipantGiveRequestControl switch

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -2749,6 +2749,11 @@
             "value": "Disabled"
           }
         ]
+      },
+      {
+        "type": "switch",
+        "name": "standards.TeamsGlobalMeetingPolicy.AllowExternalParticipantGiveRequestControl",
+        "label": "External participants can give or request control"
       }
     ],
     "label": "Define Global Meeting Policy for Teams",


### PR DESCRIPTION
* Resolves https://github.com/KelvinTegelaar/CIPP/issues/3628