### PR TITLE
fix: Scripted CIPP Alert multi select

### DIFF
--- a/src/pages/tenant/administration/alert-configuration/alert.jsx
+++ b/src/pages/tenant/administration/alert-configuration/alert.jsx
@@ -474,7 +474,7 @@ const AlertWizard = () => {
                           </Typography>
                           <CippFormTenantSelector
                             allTenants={true}
-                            multiple={false}
+                            multiple={true}
                             formControl={formControl}
                           />
                         </CippButtonCard>


### PR DESCRIPTION
I think this is intended? or can't Scripted CIPP Alert run in multiple?