### PR TITLE
feat: nodejs 22 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "AGPL-3.0",
   "engines": {
-    "node": "^20.18.1"
+    "node": "^22.13.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This should work as the previous error we got includes 22.13.0
```
Detecting platforms...
Error: Platform 'nodejs' version '^20.18.2' is unsupported. Supported versions: 12.19.0, 12.20.0, 12.21.0, 12.22.0, 12.22.11, 12.22.12, 12.22.4, 12.22.6, 12.22.9, 14.15.0, 14.15.1, 14.16.0, 14.17.0, 14.17.4, 14.17.6, 14.18.3, 14.19.1, 14.20.1, 14.21.2, 14.21.3, 16.13.1, 16.13.2, 16.14.0, 16.14.2, 16.18.0, 16.19.0, 16.20.0, 16.20.1, 16.20.2, 16.5.0, 16.6.1, 16.8.0, 18.0.0, 18.1.0, 18.12.0, 18.12.1, 18.14.0, 18.15.0, 18.16.0, 18.16.1, 18.17.1, 18.19.0, 18.19.1, 18.2.0, 18.20.3, 18.20.4, 18.20.5, 20.11.0, 20.11.1, 20.14.0, 20.15.1, 20.17.0, 20.18.0, 20.18.1, 20.9.0, 22.13.0, 22.9.0, 12.19.0, 12.20.0, 12.21.0, 12.22.0, 12.22.11, 12.22.12, 12.22.4, 12.22.6, 12.22.9, 14.15.0, 14.15.1, 14.16.0, 14.17.0, 14.17.4, 14.17.6, 14.18.3, 14.19.1, 14.20.1, 14.21.2, 14.21.3, 16.13.1, 16.13.2, 16.14.0, 16.14.2, 16.18.0, 16.19.0, 16.20.0, 16.20.1, 16.20.2, 16.5.0, 16.6.1, 16.8.0, 18.0.0, 18.1.0, 18.12.0, 18.12.1, 18.14.0, 18.15.0, 18.16.0, 18.16.1, 18.17.1, 18.19.0, 18.19.1, 18.2.0, 18.20.3, 18.20.4, 18.20.5, 20.11.0, 20.11.1, 20.14.0, 20.15.1, 20.17.0, 20.18.0, 20.18.1, 20.9.0, 22.13.0, 22.9.0
```