### PR TITLE
Update Managed folder assistant to use ExchangeGuid

### DIFF
--- a/src/pages/email/administration/mailboxes/index.js
+++ b/src/pages/email/administration/mailboxes/index.js
@@ -121,14 +121,15 @@ const Page = () => {
       url: "/api/ExecStartManagedFolderAssistant",
       icon: <PlayCircleIcon />,
       data: {
-        ID: "UPN",
+        ID: "ExchangeGuid",
+        UserPrincipalName: "UPN",
       },
       confirmText: "Are you sure you want to start the managed folder assistant for this user?",
     },
     {
       label: "Delete Mailbox",
       type: "POST",
-      icon: <TrashIcon />, // Added
+      icon: <TrashIcon />,
       url: "/api/RemoveUser",
       data: { ID: "UPN" },
       confirmText: "Are you sure you want to delete this mailbox?",


### PR DESCRIPTION
Change the mailbox API data structure to utilize ExchangeGuid, preventing failures when users have personal Microsoft accounts.
Fixes: #3709