### PR TITLE
FEAT: Add disable forwarding functionality in CippWizardOffboarding

### DIFF
--- a/src/components/CippWizard/CippWizardOffboarding.jsx
+++ b/src/components/CippWizard/CippWizardOffboarding.jsx
@@ -13,6 +13,7 @@ export const CippWizardOffboarding = (props) => {
   const selectedUsers = useWatch({ control: formControl.control, name: "user" });
   const [showAlert, setShowAlert] = useState(false);
   const userSettingsDefaults = useSettings().userSettingsDefaults;
+  const disableForwarding = useWatch({ control: formControl.control, name: "disableForwarding" });
 
   useEffect(() => {
     if (selectedUsers.length >= 4) {
@@ -28,6 +29,13 @@ export const CippWizardOffboarding = (props) => {
       });
     }
   }, [userSettingsDefaults]);
+
+  useEffect(() => {
+    if (disableForwarding) {
+      formControl.setValue("forward", null);
+      formControl.setValue("keepCopy", false);
+    }
+  }, [disableForwarding, formControl]);
 
   return (
     <Stack spacing={4}>
@@ -210,36 +218,50 @@ export const CippWizardOffboarding = (props) => {
                 Email Forwarding
               </Typography>
               <CippFormComponent
-                sx={{ m: 1 }}
-                name="forward"
-                label="Forward Email To"
-                type="autoComplete"
-                placeholder="Leave blank if not needed"
-                formControl={formControl}
-                multiple={false}
-                api={{
-                  tenantFilter: currentTenant ? currentTenant.value : undefined,
-                  labelField: (option) => `${option.displayName} (${option.userPrincipalName})`,
-                  valueField: "id",
-                  url: "/api/ListGraphRequest",
-                  dataKey: "Results",
-                  data: {
-                    Endpoint: "users",
-                    manualPagination: true,
-                    $select: "id,userPrincipalName,displayName",
-                    $count: true,
-                    $orderby: "displayName",
-                    $top: 999,
-                  },
-                }}
-              />
-
-              <CippFormComponent
-                name="keepCopy"
-                label="Keep a copy of forwarded mail"
+                name="disableForwarding"
+                label="Disable Email Forwarding"
                 type="switch"
                 formControl={formControl}
               />
+
+              <CippFormCondition
+                formControl={formControl}
+                field={"disableForwarding"}
+                compareType="isNot"
+                compareValue={true}
+              >
+                <CippFormComponent
+                  sx={{ m: 1 }}
+                  name="forward"
+                  label="Forward Email To"
+                  type="autoComplete"
+                  placeholder="Leave blank if not needed"
+                  formControl={formControl}
+                  multiple={false}
+                  api={{
+                    tenantFilter: currentTenant ? currentTenant.value : undefined,
+                    labelField: (option) => `${option.displayName} (${option.userPrincipalName})`,
+                    valueField: "id",
+                    url: "/api/ListGraphRequest",
+                    dataKey: "Results",
+                    data: {
+                      Endpoint: "users",
+                      manualPagination: true,
+                      $select: "id,userPrincipalName,displayName",
+                      $count: true,
+                      $orderby: "displayName",
+                      $top: 999,
+                    },
+                  }}
+                />
+
+                <CippFormComponent
+                  name="keepCopy"
+                  label="Keep a copy of forwarded mail"
+                  type="switch"
+                  formControl={formControl}
+                />
+              </CippFormCondition>
               <CippFormComponent
                 name="OOO"
                 label="Out of Office Message"
@@ -303,7 +325,12 @@ export const CippWizardOffboarding = (props) => {
                   type="switch"
                   formControl={formControl}
                 />
-                <CippFormComponent name="postExecution.psa" label="PSA" type="switch" formControl={formControl} />
+                <CippFormComponent
+                  name="postExecution.psa"
+                  label="PSA"
+                  type="switch"
+                  formControl={formControl}
+                />
               </Grid>
             </CippFormCondition>
           </Grid>


### PR DESCRIPTION
Introduce a new feature that allows users to disable email forwarding within the CippWizardOffboarding component, ensuring that related fields are cleared when this option is selected.

Resolves: #3702