### PR TITLE
feat: Added DoNotRewriteUrls and AllowedSenderDomains

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -2352,6 +2352,14 @@
         "required": false,
         "name": "standards.SpamFilterPolicy.RegionBlockList",
         "label": "Regions to block (uppercase ISO 3166-1 two-letter)"
+      },
+      {
+        "type": "autoComplete",
+        "multiple": true,
+        "creatable": true,
+        "required": false,
+        "name": "standards.SpamFilterPolicy.AllowedSenderDomains",
+        "label": "Allowed sender domains"
       }
     ],
     "label": "Default Spam Filter Policy",

--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -1691,6 +1691,14 @@
         "type": "switch",
         "label": "EnableOrganizationBranding",
         "name": "standards.SafeLinksPolicy.EnableOrganizationBranding"
+      },
+      {
+        "type": "autoComplete",
+        "multiple": true,
+        "creatable": true,
+        "required": false,
+        "name": "standards.SafeLinksPolicy.DoNotRewriteUrls",
+        "label": "Do not rewrite the following URLs in email"
       }
     ],
     "label": "Default SafeLinks Policy",


### PR DESCRIPTION
* UI for https://github.com/KelvinTegelaar/CIPP-API/pull/1345

This is so the CIPP standard policy can do this
* [Allowlist Phishing Emails in Microsoft Office 365 Defender Basic and Advanced](https://support.huntress.io/hc/en-us/articles/10962584987795-Allowlist-Phishing-Emails-in-Microsoft-Office-365-Defender-Basic-and-Advanced)
* [Allowlist Phish Emails in Microsoft Active Threat Protection (Safelinks)](https://support.huntress.io/hc/en-us/articles/10962581248147-Allowlist-Phish-Emails-in-Microsoft-Active-Threat-Protection-Safelinks)