### PR TITLE
Add startup message and support for allowed senders in SpoofWarn standard

### DIFF
--- a/Tools/Start-CippDevEmulators.ps1
+++ b/Tools/Start-CippDevEmulators.ps1
@@ -1,6 +1,7 @@
 Get-Command wt -ErrorAction Stop | Out-Null
 Get-Process node -ErrorAction SilentlyContinue | Stop-Process -ErrorAction SilentlyContinue
 $Path = (Get-Item $PSScriptRoot).Parent.Parent.FullName
+Write-Host "CIPP Dev Emulators starting in $Path" -ForegroundColor Green
 
 pwsh -file (Join-Path $PSScriptRoot 'Start-CippDevInstallation.ps1')
 
@@ -11,8 +12,7 @@ if (Test-Path (Join-Path $Path 'CIPP-API-Processor')) {
 }
 
 if ($Process -eq 'y') {
-    wt --title CIPP`; new-tab --title 'Azurite' -d $Path pwsh -c azurite`; new-tab --title 'FunctionApp' -d $Path\CIPP-API pwsh -c func start`; new-tab --title 'CIPP Frontend' -d $Path\CIPP pwsh -c npm run dev`; new-tab --title 'SWA' -d $Path\CIPP pwsh -c npm run start-swa`; new-tab --title 'CIPP-API-Processor' -d $Path\CIPP-API-Processor pwsh -c func start --port 7072
+  wt --title CIPP`; new-tab --title 'Azurite' -d $Path pwsh -c azurite`; new-tab --title 'FunctionApp' -d $Path\CIPP-API pwsh -c func start`; new-tab --title 'CIPP Frontend' -d $Path\CIPP pwsh -c npm run dev`; new-tab --title 'SWA' -d $Path\CIPP pwsh -c npm run start-swa`; new-tab --title 'CIPP-API-Processor' -d $Path\CIPP-API-Processor pwsh -c func start --port 7072
 } else {
-    wt --title CIPP`; new-tab --title 'Azurite' -d $Path pwsh -c azurite`; new-tab --title 'FunctionApp' -d $Path\CIPP-API pwsh -c func start`; new-tab --title 'CIPP Frontend' -d $Path\CIPP pwsh -c npm run dev`; new-tab --title 'SWA' -d $Path\CIPP pwsh -c npm run start-swa
+  wt --title CIPP`; new-tab --title 'Azurite' -d $Path pwsh -c azurite`; new-tab --title 'FunctionApp' -d $Path\CIPP-API pwsh -c func start`; new-tab --title 'CIPP Frontend' -d $Path\CIPP pwsh -c npm run dev`; new-tab --title 'SWA' -d $Path\CIPP pwsh -c npm run start-swa
 }
-

--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -1150,6 +1150,13 @@
             "value": "disabled"
           }
         ]
+      },
+      {
+        "type": "autoComplete",
+        "multiple": true,
+        "creatable": true,
+        "label": "Enter allowed senders(domain.com, *.domain.com or test@domain.com)",
+        "name": "standards.SpoofWarn.AllowListAdd"
       }
     ],
     "label": "Enable or disable 'external' warning in Outlook",
@@ -1189,6 +1196,7 @@
       {
         "type": "autoComplete",
         "multiple": false,
+        "creatable": false,
         "label": "Select value",
         "name": "standards.TeamsMeetingsByDefault.state",
         "options": [


### PR DESCRIPTION
Introduce a startup message for CIPP Dev Emulators and add functionality for specifying allowed senders in the configuration.
Resolves: #3769