### PR TITLE
Feat: Add rename device and edit group tag features to Autopilot Devices

### DIFF
--- a/src/pages/endpoint/autopilot/list-devices/index.js
+++ b/src/pages/endpoint/autopilot/list-devices/index.js
@@ -43,15 +43,6 @@ const Page = () => {
       color: "info",
     },
     {
-      label: "Delete Device",
-      icon: <Delete />,
-      type: "POST",
-      url: "/api/RemoveAPDevice",
-      data: { ID: "id" },
-      confirmText: "Are you sure you want to delete this device?",
-      color: "danger",
-    },
-    {
       label: "Rename Device",
       icon: <Edit />,
       type: "POST",
@@ -88,6 +79,15 @@ const Page = () => {
         },
       ],
       color: "secondary",
+    },
+    {
+      label: "Delete Device",
+      icon: <Delete />,
+      type: "POST",
+      url: "/api/RemoveAPDevice",
+      data: { ID: "id" },
+      confirmText: "Are you sure you want to delete this device?",
+      color: "danger",
     },
   ];
 

--- a/src/pages/endpoint/autopilot/list-devices/index.js
+++ b/src/pages/endpoint/autopilot/list-devices/index.js
@@ -2,7 +2,7 @@ import { Layout as DashboardLayout } from "/src/layouts/index.js";
 import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx";
 import { CippApiDialog } from "/src/components/CippComponents/CippApiDialog.jsx";
 import { Button } from "@mui/material";
-import { PersonAdd, Delete, Sync, Add } from "@mui/icons-material";
+import { PersonAdd, Delete, Sync, Add, Edit } from "@mui/icons-material";
 import { useDialog } from "../../../../hooks/use-dialog";
 import Link from "next/link";
 import { useState } from "react";
@@ -50,6 +50,44 @@ const Page = () => {
       data: { ID: "id" },
       confirmText: "Are you sure you want to delete this device?",
       color: "danger",
+    },
+    {
+      label: "Rename Device",
+      icon: <Edit />,
+      type: "POST",
+      url: "/api/ExecRenameAPDevice",
+      data: {
+        deviceId: "id",
+        serialNumber: "serialNumber",
+      },
+      confirmText: "Enter the new display name for the device.",
+      fields: [
+        {
+          type: "textField",
+          name: "displayName",
+          label: "New Display Name",
+          required: true,
+          validate: (value) => {
+            if (!value) {
+              return "Display name is required.";
+            }
+            if (value.length > 15) {
+              return "Display name must be 15 characters or less.";
+            }
+            if (/\s/.test(value)) {
+              return "Display name cannot contain spaces.";
+            }
+            if (!/^[a-zA-Z0-9-]+$/.test(value)) {
+              return "Display name can only contain letters, numbers, and hyphens.";
+            }
+            if (/^[0-9]+$/.test(value)) {
+              return "Display name cannot contain only numbers.";
+            }
+            return true; // Indicates validation passed
+          },
+        },
+      ],
+      color: "secondary",
     },
   ];
 

--- a/src/pages/endpoint/autopilot/list-devices/index.js
+++ b/src/pages/endpoint/autopilot/list-devices/index.js
@@ -2,7 +2,7 @@ import { Layout as DashboardLayout } from "/src/layouts/index.js";
 import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx";
 import { CippApiDialog } from "/src/components/CippComponents/CippApiDialog.jsx";
 import { Button } from "@mui/material";
-import { PersonAdd, Delete, Sync, Add, Edit } from "@mui/icons-material";
+import { PersonAdd, Delete, Sync, Add, Edit, Sell } from "@mui/icons-material";
 import { useDialog } from "../../../../hooks/use-dialog";
 import Link from "next/link";
 import { useState } from "react";
@@ -75,6 +75,31 @@ const Page = () => {
               return "Display name cannot contain only numbers.";
             }
             return true; // Indicates validation passed
+          },
+        },
+      ],
+      color: "secondary",
+    },
+    {
+      label: "Edit Group Tag",
+      icon: <Sell />,
+      type: "POST",
+      url: "/api/ExecSetAPDeviceGroupTag",
+      data: {
+        deviceId: "id",
+        serialNumber: "serialNumber",
+      },
+      confirmText: "Enter the new group tag for the device.",
+      fields: [
+        {
+          type: "textField",
+          name: "groupTag",
+          label: "Group Tag",
+          validate: (value) => {
+            if (value && value.length > 128) {
+              return "Group tag cannot exceed 128 characters.";
+            }
+            return true; // Validation passed
           },
         },
       ],


### PR DESCRIPTION
Implement a feature that allows administrators to rename Autopilot devices from the CIPP interface, including validation for display names. This addresses GitHub issue #3909.