### PR TITLE
Remove redundant Legal Hold card, Addition of Retention Hold action

### DIFF
--- a/src/components/CippCards/CippExchangeInfoCard.jsx
+++ b/src/components/CippCards/CippExchangeInfoCard.jsx
@@ -171,17 +171,6 @@ export const CippExchangeInfoCard = (props) => {
             )
           }
         />
-        <PropertyListItem
-          divider
-          label="Litigation Hold"
-          value={
-            isLoading ? (
-              <Skeleton variant="text" width={60} />
-            ) : (
-              getCippFormatting(exchangeData?.LitigationHold, "LitigationHold")
-            )
-          }
-        />
         {/* Combine all mailbox hold types into a single PropertyListItem */}
         <PropertyListItem
           divider

--- a/src/components/CippComponents/CippExchangeActions.jsx
+++ b/src/components/CippComponents/CippExchangeActions.jsx
@@ -14,6 +14,7 @@ import {
   Outbox,
   NotificationImportant,
   DataUsage,
+  MailLockIcon,
 } from "@mui/icons-material";
 
 export const CippExchangeActions = () => {
@@ -184,6 +185,21 @@ export const CippExchangeActions = () => {
           name: "days",
           label: "Hold Duration (Days)",
           placeholder: "Blank or 0 for indefinite",
+        },
+      ],
+    },
+    {
+      label: "Set Retention Hold",
+      type: "POST",
+      url: "/api/ExecSetRetentionHold",
+      data: { UPN: "UPN", Identity: "Id" },
+      confirmText: "What do you want to set Retention Hold to?",
+      icon: <MailLockIcon />,
+      fields: [
+        {
+          type: "switch",
+          name: "disable",
+          label: "Disable Retention Hold",
         },
       ],
     },


### PR DESCRIPTION
Remove redundant Legal Hold card as it has been replaced with the new list items that contains multiple hold types including Legal Hold
Addition of Retention Hold action for mailbox actions