### PR TITLE
Fix: Mailboxes page crash by updating icon import

### DIFF
--- a/src/components/CippComponents/CippExchangeActions.jsx
+++ b/src/components/CippComponents/CippExchangeActions.jsx
@@ -14,7 +14,7 @@ import {
   Outbox,
   NotificationImportant,
   DataUsage,
-  MailLockIcon,
+  MailLock,
 } from "@mui/icons-material";
 
 export const CippExchangeActions = () => {
@@ -194,7 +194,7 @@ export const CippExchangeActions = () => {
       url: "/api/ExecSetRetentionHold",
       data: { UPN: "UPN", Identity: "Id" },
       confirmText: "What do you want to set Retention Hold to?",
-      icon: <MailLockIcon />,
+      icon: <MailLock />,
       fields: [
         {
           type: "switch",


### PR DESCRIPTION
Remove 'icon' from the icon import to prevent a crash on the page.