### PR TITLE
feat: Add Teams Meeting Recording Expiration standard

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -3405,6 +3405,27 @@
     "recommendedBy": []
   },
   {
+    "name": "standards.TeamsMeetingRecordingExpiration",
+    "cat": "Teams Standards",
+    "tag": [],
+    "helpText": "Sets the default number of days after which Teams meeting recordings automatically expire. Valid values are -1 (Never Expire) or between 1 and 99999. The default value is 120 days.",
+    "docsDescription": "Allows administrators to configure a default expiration period (in days) for Teams meeting recordings. Recordings older than this period will be automatically moved to the recycle bin. This setting helps manage storage consumption and enforce data retention policies.",
+    "addedComponent": [
+      {
+        "type": "number",
+        "name": "standards.TeamsMeetingRecordingExpiration.ExpirationDays",
+        "label": "Recording Expiration Days (e.g., 365)",
+        "required": true
+      }
+    ],
+    "label": "Set Teams Meeting Recording Expiration",
+    "impact": "Medium Impact",
+    "impactColour": "warning",
+    "addedDate": "2025-04-17",
+    "powershellEquivalent": "Set-CsTeamsMeetingPolicy -Identity Global -MeetingRecordingExpirationDays <days>",
+    "recommendedBy": []
+  },
+  {
     "name": "standards.TeamsMessagingPolicy",
     "cat": "Teams Standards",
     "tag": [],


### PR DESCRIPTION
Introduce a standard for configuring the expiration period of Teams meeting recordings, allowing administrators to set a default duration after which recordings will automatically expire. This helps manage storage and enforce data retention policies.

- Resolves #3963