### PR TITLE
Add Welsh to language list

### DIFF
--- a/src/data/languageList.json
+++ b/src/data/languageList.json
@@ -238,5 +238,11 @@
     "Geographic area": "Vietnam",
     "tag": "vi-VN",
     "LCID": "1066"
+  },
+  {
+    "language": "Welsh",
+    "Geographic area": "Wales"
+    "tag": "cy-GB",
+    "LCID": "1106"
   }
 ]


### PR DESCRIPTION
I'm assuming that this is what populates the language select for Office app deployment - we need Welsh for this and current have to add it in a rather specific way to the list (by language code) which is easy for folks to forget / get wrong.

The language is present in the Intune wizard - this brings the list in CIPP closer to what Intune allows.