### PR TITLE
"recipientType" does not exist, conditional enable/disable device

### DIFF
--- a/src/pages/identity/administration/devices/index.js
+++ b/src/pages/identity/administration/devices/index.js
@@ -27,6 +27,7 @@ const Page = () => {
       },
       confirmText: "Are you sure you want to enable this device?",
       multiPost: false,
+      condition: (row) => !row.accountEnabled,
       icon: <CheckCircleOutline />,
     },
     {
@@ -39,6 +40,7 @@ const Page = () => {
       },
       confirmText: "Are you sure you want to disable this device?",
       multiPost: false,
+      condition: (row) => row.accountEnabled,
       icon: <Block />,
     },
     {
@@ -80,7 +82,7 @@ const Page = () => {
       simpleColumns={[
         "displayName",
         "accountEnabled",
-        "recipientType",
+        "trustType",
         "enrollmentType",
         "manufacturer",
         "model",


### PR DESCRIPTION
In the returned data "recipientType" does not exist, so this has been removed, I suspect this was left over from copying the layout from the users page

Added the trustType as a default column as this shows if the device is AD, Entra or Personally joined device.

Added conditions to the enable and disable device buttons so not to try disable a device that is already disabled