### PR TITLE
Less ambiguous wording for mailbox usage

### DIFF
--- a/src/components/CippCards/CippExchangeInfoCard.jsx
+++ b/src/components/CippCards/CippExchangeInfoCard.jsx
@@ -82,7 +82,7 @@ export const CippExchangeInfoCard = (props) => {
               <LinearProgressWithLabel
                 sx={{ width: "100%" }}
                 variant="determinate"
-                addedLabel={`(${Math.round(exchangeData.TotalItemSize)}/${Math.round(
+                addedLabel={`(${Math.round(exchangeData.TotalItemSize)} GB of ${Math.round(
                   exchangeData?.ProhibitSendReceiveQuota
                 )}GB)`}
                 value={

--- a/src/components/linearProgressWithLabel.jsx
+++ b/src/components/linearProgressWithLabel.jsx
@@ -6,7 +6,7 @@ export const LinearProgressWithLabel = (props) => {
       <Box sx={{ width: "100%", mr: 1 }}>
         <LinearProgress variant="determinate" {...props} />
       </Box>
-      <Box sx={{ minWidth: 100 }}>{`${Math.round(props.value)}% ${props?.addedLabel ?? ""}`}</Box>
+      <Box sx={{ minWidth: 135 }}>{`${Math.round(props.value)}% ${props?.addedLabel ?? ""}`}</Box>
     </Box>
   );
 };


### PR DESCRIPTION
Also increased the size of the allocated space for the label so the longer wording does not wrap over multiple lines