### PR TITLE
fix: Skype Consumer Interoperability with Teams is no longer supported

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -3379,11 +3379,6 @@
       },
       {
         "type": "switch",
-        "name": "standards.TeamsExternalAccessPolicy.EnablePublicCloudAccess",
-        "label": "Allow user to communicate with Skype users"
-      },
-      {
-        "type": "switch",
         "name": "standards.TeamsExternalAccessPolicy.EnableTeamsConsumerAccess",
         "label": "Allow communication with unmanaged Teams accounts"
       }
@@ -3406,11 +3401,6 @@
         "type": "switch",
         "name": "standards.TeamsFederationConfiguration.AllowTeamsConsumer",
         "label": "Allow users to communicate with other organizations"
-      },
-      {
-        "type": "switch",
-        "name": "standards.TeamsFederationConfiguration.AllowPublicUsers",
-        "label": "Allow users to communicate with Skype Users"
       },
       {
         "type": "autoComplete",


### PR DESCRIPTION
* Resolves https://discord.com/channels/905453405936447518/1199069319850639410/1372839098280050778
* Frontend for https://github.com/KelvinTegelaar/CIPP-API/pull/1435