### PR TITLE
Feat: Add allTenants support for transport rules page

### DIFF
--- a/src/pages/email/transport/list-rules/index.js
+++ b/src/pages/email/transport/list-rules/index.js
@@ -65,12 +65,21 @@ const Page = () => {
     actions: actions,
   };
 
-  const simpleColumns = ["Name", "State", "Mode", "RuleErrorAction", "WhenChanged", "Comments"];
+  const simpleColumns = [
+    "Name",
+    "State",
+    "Mode",
+    "RuleErrorAction",
+    "WhenChanged",
+    "Comments",
+    "Tenant",
+  ];
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListTransportRules"
+      apiDataKey="Results"
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={simpleColumns}
@@ -101,5 +110,5 @@ const Page = () => {
   );
 };
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>;
 export default Page;

--- a/src/pages/security/incidents/list-incidents/index.js
+++ b/src/pages/security/incidents/list-incidents/index.js
@@ -99,6 +99,6 @@ const Page = () => {
   );
 };
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>;
 
 export default Page;


### PR DESCRIPTION
- Introduce support for all tenants in the transport rules page by adding a new column and updating the layout component accordingly.
- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1444