### PR TITLE
Fix casing for displayName in CippWizardGroupTemplates and standards UI

### DIFF
--- a/src/components/CippWizard/CippWizardGroupTemplates.jsx
+++ b/src/components/CippWizard/CippWizardGroupTemplates.jsx
@@ -42,7 +42,7 @@ export const CippWizardGroupTemplates = (props) => {
               excludeTenantFilter: true,
               url: "/api/ListGroupTemplates",
               queryKey: "ListGroupTemplates",
-              labelField: (option) => `${option.Displayname} (${option.groupType})`,
+              labelField: (option) => `${option.displayName} (${option.groupType})`,
               valueField: "GUID",
               addedField: {
                 groupType: "groupType",

--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -4319,7 +4319,7 @@
         "label": "Select Group Template",
         "api": {
           "url": "/api/ListGroupTemplates",
-          "labelField": "Displayname",
+          "labelField": "displayName",
           "valueField": "GUID",
           "queryKey": "ListGroupTemplates"
         }


### PR DESCRIPTION
Group names not displaying in Group Template Deployment Wizard and Standards Group Template UIs.

Fixes...

![Screenshot 2025-05-24 115623](https://github.com/user-attachments/assets/4b315efe-7ea3-438a-8dd3-58829a142409)
![Screenshot 2025-05-24 115701](https://github.com/user-attachments/assets/cf871a0f-d3a4-41fb-9125-23d8bd4a136b)
