### PR TITLE
Feat: Re-add functionality to remove users from groups in edit user

### DIFF
--- a/src/components/CippFormPages/CippAddEditUser.jsx
+++ b/src/components/CippFormPages/CippAddEditUser.jsx
@@ -384,7 +384,7 @@ const CippAddEditUser = (props) => {
         </Grid>
       )}
       {formType === "edit" && (
-        <Grid item xs={12}>
+        <Grid item size={{ xs: 12 }}>
           <CippFormComponent
             type="autoComplete"
             label="Remove from Groups"


### PR DESCRIPTION
- Restore the ability to remove users from groups while in edit mode, enhancing user management capabilities. ~~Cant make it only show the groups the user is a member of, as the graph API only returns the first 20 members... :(~~ Thanks @Zacgoose for the code making this possible!
- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1449