### PR TITLE
Feat: Add Custom Quarantine Policies (Additional PR)

### DIFF
--- a/src/components/CippCards/CippInfoBar.jsx
+++ b/src/components/CippCards/CippInfoBar.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Box, Card, Stack, SvgIcon, Typography, Skeleton } from "@mui/material";
+import { Box, Card, Stack, SvgIcon, Typography, Skeleton, Tooltip } from "@mui/material";
 import Grid from "@mui/material/Grid";
 import { CippOffCanvas } from "../CippComponents/CippOffCanvas";
 import { CippPropertyListCard } from "./CippPropertyListCard";
@@ -45,20 +45,39 @@ export const CippInfoBar = ({ data, isFetching }) => {
                     {item.icon}
                   </SvgIcon>
                 )}
-                <Box
-                  sx={() => {
-                    if (!item?.icon) {
-                      return { pl: 2 };
-                    }
-                  }}
-                >
-                  <Typography color="text.secondary" variant="overline">
-                    {item.name}
-                  </Typography>
-                  <Typography variant="h6">
-                    {isFetching ? <Skeleton width={"100%"} /> : item.data}
-                  </Typography>
-                </Box>
+                {item?.toolTip ? (
+                  <Tooltip title={item.toolTip}>
+                    <Box
+                      sx={() => {
+                        if (!item?.icon) {
+                          return { pl: 2 };
+                        }
+                      }}
+                    >
+                      <Typography color="text.secondary" variant="overline">
+                        {item.name}
+                      </Typography>
+                      <Typography variant="h6">
+                        {isFetching ? <Skeleton width={"100%"} /> : item.data}
+                      </Typography>
+                    </Box>
+                  </Tooltip>
+                ) : (
+                  <Box
+                    sx={() => {
+                      if (!item?.icon) {
+                        return { pl: 2 };
+                      }
+                    }}
+                  >
+                    <Typography color="text.secondary" variant="overline">
+                      {item.name}
+                    </Typography>
+                    <Typography variant="h6">
+                      {isFetching ? <Skeleton width={"100%"} /> : item.data}
+                    </Typography>
+                  </Box>
+                )}
               </Stack>
             </Grid>
             {item.offcanvas && (

--- a/src/layouts/config.js
+++ b/src/layouts/config.js
@@ -342,6 +342,10 @@ export const nativeMenuItems = [
             title: "Connection filter templates",
             path: "/email/spamfilter/list-connectionfilter-templates",
           },
+          {
+            title: "Quarantine Policies",
+            path: "/email/spamfilter/list-quarantine-policies",
+          },
         ],
       },
       {

--- a/src/pages/email/spamfilter/list-quarantine-policies/add.jsx
+++ b/src/pages/email/spamfilter/list-quarantine-policies/add.jsx
@@ -1,0 +1,148 @@
+import React, { useEffect } from "react";
+import { Grid, Divider } from "@mui/material";
+import { useForm, useWatch } from "react-hook-form";
+import { Layout as DashboardLayout } from "/src/layouts/index.js";
+import CippFormPage from "/src/components/CippFormPages/CippFormPage";
+import CippFormComponent from "/src/components/CippComponents/CippFormComponent";
+import { CippFormTenantSelector } from "/src/components/CippComponents/CippFormTenantSelector";
+
+const AddPolicy = () => {
+  const formControl = useForm({
+    mode: "onChange",
+    defaultValues: {
+      selectedTenants: [],
+      TemplateList: null,
+      PowerShellCommand: "",
+    },
+  });
+
+  const templateListVal = useWatch({ control: formControl.control, name: "TemplateList" });
+
+  useEffect(() => {
+    if (templateListVal?.value) {
+      formControl.setValue("PowerShellCommand", JSON.stringify(templateListVal?.value));
+    }
+  }, [templateListVal, formControl]);
+
+  // Watch the value of QuarantineNotification
+  const quarantineNotification = useWatch({
+    control: formControl.control,
+    name: "QuarantineNotification",
+  });
+
+  return (
+    <CippFormPage
+      formControl={formControl}
+      queryKey="AddQuarantinePolicy"
+      title="Quarantine Policy"
+      backButtonTitle="Overview"
+      postUrl="/api/AddQuarantinePolicy"
+    >
+      <Grid container spacing={2} columnSpacing={{ xs: 1, sm: 2, md: 3 }}>
+        <Grid item xs={12}>
+          <CippFormTenantSelector
+            label="Select Tenants"
+            formControl={formControl}
+            name="selectedTenants"
+            type="multiple"
+            allTenants={true}
+            validators={{ required: "At least one tenant must be selected" }}
+          />
+        </Grid>
+
+        {/* <Divider sx={{ my: 2, width: "100%" }} /> */}
+
+        {/* TemplateList, can be added later. But did not seem necessary with so few settings */}
+        {/* <Grid item xs={12} md={12}>
+          <CippFormComponent
+            type="autoComplete"
+            label="Select a template (optional)"
+            name="TemplateList"
+            formControl={formControl}
+            multiple={false}
+            api={{
+              queryKey: `TemplateListSpamFilterTransport`,
+              labelField: "name",
+              valueField: (option) => option,
+              url: "/api/ListSpamFilterTemplates",
+            }}
+            placeholder="Select a template or enter PowerShell JSON manually"
+          />
+        </Grid> */}
+
+        <Divider sx={{ my: 2, width: "100%" }} />
+          <Grid item xs={6} >
+            <CippFormComponent
+              type="textField"
+              label="Policy Name"
+              name="Name"
+              placeholder="Enter policy name"
+              formControl={formControl}
+              required={true}
+            />
+            <Divider sx={{ my: 2, width: "100%" }} />
+            <CippFormComponent
+              type="autoComplete"
+              label="Release Action Preference"
+              name="ReleaseActionPreference"
+              placeholder="Select release action preference"
+              formControl={formControl}
+              required={true}
+              multiple={false}
+              options={[
+                { label: "Release", value: "Release" },
+                { label: "Request Release", value: "RequestRelease" },
+              ]}
+            />
+          </Grid>
+
+          <Grid item xs={2}>
+            
+            <CippFormComponent
+              type="switch"
+              label="Delete"
+              name="Delete"
+              formControl={formControl}
+            />
+            <CippFormComponent
+              type="switch"
+              label="Preview"
+              name="Preview"
+              formControl={formControl}
+            />
+            <CippFormComponent
+              type="switch"
+              label="Block Sender"
+              name="BlockSender"
+              formControl={formControl}
+            />
+            <CippFormComponent
+              type="switch"
+              label="Allow Sender"
+              name="AllowSender"
+              formControl={formControl}
+            />
+          </Grid>
+          <Grid item xs={4}>
+            <CippFormComponent
+              type="switch"
+              label="Quarantine Notification"
+              name="QuarantineNotification"
+              formControl={formControl}
+            />
+            <CippFormComponent
+              type="switch"
+              label="Include Messages From Blocked Sender Address"
+              name="IncludeMessagesFromBlockedSenderAddress"
+              formControl={formControl}
+              disabled={!quarantineNotification}
+            />
+          </Grid>
+      </Grid>
+    </CippFormPage>
+  );
+};
+
+AddPolicy.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default AddPolicy;

--- a/src/pages/email/spamfilter/list-quarantine-policies/index.js
+++ b/src/pages/email/spamfilter/list-quarantine-policies/index.js
@@ -1,0 +1,436 @@
+import { Layout as DashboardLayout } from "/src/layouts/index.js";
+import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx";
+import CippButtonCard from "/src/components/CippCards/CippButtonCard";
+import { CippInfoBar } from "/src/components/CippCards/CippInfoBar";
+import { CippApiDialog } from "/src/components/CippComponents/CippApiDialog.jsx";
+import { Alert, Typography, Stack, Tooltip, IconButton, SvgIcon, Button } from "@mui/material";
+import { Grid } from "@mui/system";
+import Link from "next/link";
+import {
+  AccessTime,
+  CorporateFare,
+  AlternateEmail,
+  Language,
+  Sync,
+  RocketLaunch,
+  Edit,
+  Delete,
+} from "@mui/icons-material";
+import { useSettings } from "/src/hooks/use-settings";
+import { useDialog } from "/src/hooks/use-dialog";
+import { ApiGetCall } from "/src/api/ApiCall";
+import { useState, useRef } from "react";
+
+const Page = () => {
+  const pageTitle = "Quarantine Policies";
+  const { currentTenant } = useSettings();
+  
+  const createDialog = useDialog();
+
+  // Use ApiGetCall directly as a hook
+  const GlobalQuarantinePolicy = ApiGetCall({
+    url: "/api/ListQuarantinePolicy",
+    data: { tenantFilter: currentTenant, type: "GlobalQuarantinePolicy" },
+    queryKey: "GlobalQuarantinePolicy",
+  });
+
+  // Get the policy data regardless of array or object
+  const globalQuarantineData = Array.isArray(GlobalQuarantinePolicy.data)
+    ? GlobalQuarantinePolicy.data[0]
+    : GlobalQuarantinePolicy.data;
+
+  const hasGlobalQuarantinePolicyData = !!globalQuarantineData;
+
+
+  if (hasGlobalQuarantinePolicyData) {
+    globalQuarantineData.EndUserSpamNotificationFrequency =
+      globalQuarantineData?.EndUserSpamNotificationFrequency === "P1D"
+        ? "Daily"
+        : globalQuarantineData?.EndUserSpamNotificationFrequency === "P7D"
+        ? "Weekly"
+        : globalQuarantineData?.EndUserSpamNotificationFrequency === "PT4H"
+        ? "4 hours"
+        : globalQuarantineData?.EndUserSpamNotificationFrequency
+  }
+
+  const multiLanguagePropertyItems = hasGlobalQuarantinePolicyData
+  ? (
+      Array.isArray(globalQuarantineData?.MultiLanguageSetting) && globalQuarantineData.MultiLanguageSetting.length > 0
+        ? globalQuarantineData.MultiLanguageSetting.map((language, idx) => ({
+            language: language == "Default" ? "English_USA" 
+              : language == "English" ? "English_GB"
+              : language,
+            senderDisplayName:
+              globalQuarantineData.MultiLanguageSenderName[idx] &&
+              globalQuarantineData.MultiLanguageSenderName[idx].trim() !== ""
+                ? globalQuarantineData.MultiLanguageSenderName[idx]
+                : "None",
+            subject:
+              globalQuarantineData.EsnCustomSubject[idx] &&
+              globalQuarantineData.EsnCustomSubject[idx].trim() !== ""
+                ? globalQuarantineData.EsnCustomSubject[idx]
+                : "None",
+            disclaimer:
+              globalQuarantineData.MultiLanguageCustomDisclaimer[idx] &&
+              globalQuarantineData.MultiLanguageCustomDisclaimer[idx].trim() !== ""
+                ? globalQuarantineData.MultiLanguageCustomDisclaimer[idx]
+                : "None",
+          }))
+        : [
+            {
+              language: "None",
+              senderDisplayName: "None",
+              subject: "None",
+              disclaimer: "None",
+            },
+          ]
+    )
+  : [];
+
+  const buttonCardActions = [
+    <>
+      <Button onClick={createDialog.handleOpen} startIcon={<Edit />}>
+        Edit Settings
+      </Button>
+      <Tooltip title="Refresh Data">
+          <IconButton
+            className="MuiIconButton"
+            disabled={
+              GlobalQuarantinePolicy?.isLoading ||
+              GlobalQuarantinePolicy?.isFetching
+            }
+            onClick={() => {
+              GlobalQuarantinePolicy.refetch();
+            }}
+          >
+            <SvgIcon
+              fontSize="small"
+              sx={{
+                animation:
+                  GlobalQuarantinePolicy?.isFetching
+                    ? "spin 1s linear infinite"
+                    : "none",
+                "@keyframes spin": {
+                  "0%": { transform: "rotate(0deg)" },
+                  "100%": { transform: "rotate(360deg)" },
+                },
+              }}
+            >
+              <Sync />
+            </SvgIcon>
+          </IconButton>
+      </Tooltip>
+    </>
+  ];
+
+  // Actions to perform (Delete Policy)
+  const actions = [
+    {
+      label: "Edit Policy",
+      type: "POST",
+      url: "/api/EditQuarantinePolicy?type=QuarantinePolicy",
+      setDefaultValues: true,
+      fields: [
+        {
+          type: "textField",
+          name: "Name",
+          label: "Policy Name",
+          disabled: true,
+        },
+        {
+          type: "autoComplete",
+          name: "ReleaseActionPreference",
+          label: "Select release action preference",
+          multiple : false,
+          creatable : false,
+          options: [
+            { label: "Release", value: "Release" },
+            { label: "Request Release", value: "RequestRelease" },
+          ],
+        },
+        {
+          type: "switch",
+          name: "Delete",
+          label: "Delete",
+        },
+        {
+          type: "switch",
+          name: "Preview",
+          label: "Preview",
+        },        
+        {
+          type: "switch",
+          name: "BlockSender",
+          label: "Block Sender",
+        },
+        {
+          type: "switch",
+          name: "AllowSender",
+          label: "Allow Sender",
+        },
+        {
+          type: "switch",
+          name: "QuarantineNotification",
+          label: "Quarantine Notification",
+        },
+        {
+          type: "switch",
+          name: "IncludeMessagesFromBlockedSenderAddress",
+          label: "Include Messages From Blocked Sender Address",
+        },
+      ],
+      data: { Identity: "Guid", Action: "!Edit" },
+      confirmText: "Update Quarantine Policy '[Name]'? Policy Name cannot be changed.",
+      multiPost: false,
+      icon: <Edit />,
+      color: "info",
+      condition: (row) => row.Guid != "00000000-0000-0000-0000-000000000000",
+    },
+    {
+      label: "Delete Policy",
+      type: "POST",
+      icon: <Delete />,
+      url: "/api/RemoveQuarantinePolicy",
+      data: {
+        Name: "Name",
+        Identity: "Guid",
+      },
+      confirmText: (
+        <>
+          <Typography variant="body1">
+            Are you sure you want to delete this policy?
+          </Typography>
+          <Typography variant="body2">
+            <strong>Note:</strong> This will delete the Quarantine policy, even if it is currently in use.<br />
+            Removing the Admin and User Access it applies to emails.
+          </Typography>
+          <Alert severity="warning">
+            Confirm the Quarantine is not applied in any of the following policies:
+            <ul style={{ paddingLeft: "15px" }}>
+              <li>Anti-phishing</li>
+              <li>Anti-spam</li>
+              <li>Anti-malware</li>
+              <li>Safe Attachments</li>
+            </ul>
+          </Alert>
+        </>
+      ),
+      condition: (row) => row.Guid != "00000000-0000-0000-0000-000000000000",
+    },
+  ];
+
+  // Off-canvas structure: displays extended details and includes actions (Enable/Disable Rule)
+  const offCanvas = {
+    extendedInfoFields: [
+      "Id", // Policy Name/Id
+      "Name", // Policy Name
+      "EndUserQuarantinePermissions",
+      "Guid", 
+      "Builtin",
+      "WhenCreated", // Creation Date
+      "WhenChanged", // Last Modified Date
+    ],
+    actions: actions,
+  };
+
+  const filterList = [
+    {
+      filterName: "Custom Policies",
+      value: [{ id: "Builtin", value: "No" }],
+      type: "column",
+    },
+    {
+      filterName: "Built-in Policies",
+      value: [{ id: "Builtin", value: "Yes" }],
+      type: "column",
+    },
+  ];
+
+
+  const customLanguageOffcanvas =
+    multiLanguagePropertyItems && multiLanguagePropertyItems.length > 0
+      ? {
+          offcanvas: {
+            title: "Custom Language Settings",
+            propertyItems: multiLanguagePropertyItems.map((item, idx) => ({
+              label: "",
+              value: (
+                <CippButtonCard
+                  title={
+                    <div style={{ display: "flex", alignItems: "center" }}>
+                      <Language style={{ marginRight: "8px" }} />
+                      {item.language}
+                    </div>
+                  }
+                  cardSx={{ mb: 2 }}
+                >
+                  <Stack spacing={2}>
+                    {Object.entries(item)
+                      .filter(([key]) => key !== "language")
+                      .map(([key, value]) => (
+                        <Stack spacing={0.5} key={key}>
+                          <Typography variant="subtitle2" color="text.secondary">
+                            {key.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase())}
+                          </Typography>
+                          <Typography variant="body2">
+                            {value}
+                          </Typography>
+                        </Stack>
+                      ))}
+                  </Stack>
+                </CippButtonCard>
+              ),
+            })),
+          }
+        }
+      : {};
+
+    // Simplified columns for the table
+  const simpleColumns = [
+    "Name",
+    "ReleaseActionPreference",
+    "Delete",
+    "Preview",
+    "BlockSender",
+    "AllowSender",
+    "QuarantineNotification",
+    "IncludeMessagesFromBlockedSenderAddress",
+    "WhenCreated",
+    "WhenChanged",
+  ];
+
+
+
+  // Prepare data for CippInfoBar as a const to clean up the code
+  const infoBarData = [
+    {
+      icon: <AccessTime />,
+      data: globalQuarantineData?.EndUserSpamNotificationFrequency,
+      name: "Notification Frequency",
+    },
+    {
+      icon: <CorporateFare />,
+      data: hasGlobalQuarantinePolicyData
+        ? (globalQuarantineData?.OrganizationBrandingEnabled 
+            ? "Enabled" 
+            : "Disabled"
+          ) 
+        : "n/a",
+      name: "Branding",
+    },
+    {
+      icon: <AlternateEmail />,
+      data: hasGlobalQuarantinePolicyData 
+        ? (globalQuarantineData?.EndUserSpamNotificationCustomFromAddress
+            ? globalQuarantineData?.EndUserSpamNotificationCustomFromAddress
+            : "None") 
+        : "n/a" ,
+      name: "Custom Sender Address",
+    },
+    {
+      icon: <Language />,
+      toolTip: "More Info",
+      data: hasGlobalQuarantinePolicyData
+        ? (
+            multiLanguagePropertyItems.length > 0
+              ? multiLanguagePropertyItems.map(item => item.language).join(", ")
+              : "None"
+          )
+        : "n/a",
+      name: "Custom Language",
+      ...customLanguageOffcanvas,
+    },
+  ];
+
+  return (
+    <>
+      <Stack spacing={2} sx={{ p: 3, mt: 1 }}>
+        <CippButtonCard
+          component="card"
+          title={`Global Quarantine Settings - ${currentTenant}`}
+          cardActions={buttonCardActions}
+        >
+          <Grid container spacing={2}>
+            <Grid size={12}>
+              <CippInfoBar
+                isFetching={GlobalQuarantinePolicy.isFetching}
+                data={infoBarData}
+              />
+            </Grid>
+          </Grid>
+        </CippButtonCard> 
+      </Stack> 
+      <CippTablePage
+        title={pageTitle}
+        apiUrl="/api/ListQuarantinePolicy"
+        apiData={{ tenantFilter: currentTenant, type: "QuarantinePolicy" }}
+        actions={actions}
+        offCanvas={offCanvas}
+        filters={filterList}
+        simpleColumns={simpleColumns}
+        cardButton={
+        <>
+          <Button
+            component={Link}
+            href="/email/reports/quarantine-policy/add"
+            startIcon={<RocketLaunch />}
+          >
+            Deploy Custom Policy
+          </Button>
+        </>
+      }
+      />
+      <CippApiDialog
+        title="Edit - Global Quarantine Settings"
+        createDialog={createDialog}
+        api={{
+          type: "POST",
+          url: "/api/EditQuarantinePolicy?type=GlobalQuarantinePolicy",
+          setDefaultValues: true,
+          data: {
+            Name: "Name",
+            Identity: "Guid",
+          },
+          relatedQueryKeys: ["GlobalQuarantinePolicy"],
+          confirmText:
+            "Are you sure you want to update Global Quarantine settings?",
+        }}
+        // row={globalQuarantineData}
+        row={globalQuarantineData}
+        setDefaultValues={true}
+        fields={[
+          {
+            type: "autoComplete",
+            name: "EndUserSpamNotificationFrequency",
+            label: "Notification Frequency",
+            multiple : false,
+            creatable : false,
+            required: true,
+            options: [
+              { label: "4 hours", value: "PT4H" },
+              { label: "Daily", value: "P1D" },
+              { label: "Weekly", value: "P7D" },
+            ],
+          },
+          {
+            type: "textField",
+            name: "EndUserSpamNotificationCustomFromAddress",
+            label: "Custom Sender Address (Optional)",
+            placeholder: "Enter custom sender address",
+            required: false,
+          },
+          {
+            type: "switch",
+            name: "OrganizationBrandingEnabled",
+            label: "Organization Branding",
+          },
+        ]}
+      />
+    </>
+  );
+};
+
+// Layout configuration: ensure page uses DashboardLayout
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default Page;

--- a/src/pages/email/spamfilter/list-quarantine-policies/index.js
+++ b/src/pages/email/spamfilter/list-quarantine-policies/index.js
@@ -19,7 +19,6 @@ import {
 import { useSettings } from "/src/hooks/use-settings";
 import { useDialog } from "/src/hooks/use-dialog";
 import { ApiGetCall } from "/src/api/ApiCall";
-import { useState, useRef } from "react";
 
 const Page = () => {
   const pageTitle = "Quarantine Policies";


### PR DESCRIPTION
### Additional PR for feature request https://github.com/KelvinTegelaar/CIPP/issues/4053 and previous PR https://github.com/KelvinTegelaar/CIPP/pull/4107

- Added page for managing Custom Quarantine Policies and Global Quarantine Policy
- List all Quarantine Policies and Global Quarantine Policy settings
- Supports adding new and editing existing Custom Quarantine Policies
- Supports editing Global Quarantine Policy settings (Notification frequency, BrandingEnabled and customSendFromAdress

- Added support for tooltip to CippInfoBar component 
- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1450