### PR TITLE
Add Mailbox Recipient Limits standard to standards.json

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -4109,5 +4109,26 @@
         }
       }
     ]
+  },
+  {
+    "name": "standards.MailboxRecipientLimits",
+    "cat": "Exchange Standards",
+    "tag": [],
+    "helpText": "Sets the maximum number of recipients that can be specified in the To, Cc, and Bcc fields of a message for all mailboxes in the tenant.",
+    "docsDescription": "This standard configures the recipient limits for all mailboxes in the tenant. The recipient limit determines the maximum number of recipients that can be specified in the To, Cc, and Bcc fields of a message. This helps prevent spam and manage email flow.",
+    "addedComponent": [
+      {
+        "type": "number",
+        "name": "standards.MailboxRecipientLimits.RecipientLimit",
+        "label": "Recipient Limit",
+        "defaultValue": 500
+      }
+    ],
+    "label": "Set Mailbox Recipient Limits",
+    "impact": "Low Impact",
+    "impactColour": "info",
+    "addedDate": "2025-05-28",
+    "powershellEquivalent": "Set-Mailbox -RecipientLimits",
+    "recommendedBy": ["CIPP"]
   }
 ]


### PR DESCRIPTION
This update introduces a new standard for configuring the maximum number of recipients in the To, Cc, and Bcc fields for all mailboxes in the tenant. The new standard includes a default recipient limit of 500 and provides relevant documentation and PowerShell equivalent commands.