### PR TITLE
Fix: Global Quaratine Policy not updating with tenant select

### DIFF
--- a/src/pages/email/spamfilter/list-quarantine-policies/index.js
+++ b/src/pages/email/spamfilter/list-quarantine-policies/index.js
@@ -30,7 +30,7 @@ const Page = () => {
   const GlobalQuarantinePolicy = ApiGetCall({
     url: "/api/ListQuarantinePolicy",
     data: { tenantFilter: currentTenant, type: "GlobalQuarantinePolicy" },
-    queryKey: "GlobalQuarantinePolicy",
+    queryKey: `GlobalQuarantinePolicy-${currentTenant}`,
   });
 
   // Get the policy data regardless of array or object
@@ -304,7 +304,7 @@ const Page = () => {
   const infoBarData = [
     {
       icon: <AccessTime />,
-      data: globalQuarantineData?.EndUserSpamNotificationFrequency,
+      data: globalQuarantineData?.EndUserSpamNotificationFrequency ?? "n/a",
       name: "Notification Frequency",
     },
     {
@@ -390,7 +390,7 @@ const Page = () => {
             Name: "Name",
             Identity: "Guid",
           },
-          relatedQueryKeys: ["GlobalQuarantinePolicy"],
+          relatedQueryKeys: [`GlobalQuarantinePolicy-${currentTenant}`],
           confirmText:
             "Are you sure you want to update Global Quarantine settings?",
         }}


### PR DESCRIPTION
- Resolved issue where the Global Quarantine policy information was not updated when the tenant selector was changed. 
It would still show info from the first tenant the page was loaded on