### PR TITLE
Update language label to include geographic area in AutopilotProfileForm

### DIFF
--- a/src/pages/endpoint/autopilot/list-profiles/add.jsx
+++ b/src/pages/endpoint/autopilot/list-profiles/add.jsx
@@ -68,9 +68,9 @@ const AutopilotProfileForm = () => {
             type="autoComplete"
             label="Language"
             name="languages"
-            options={languageList.map(({ language, tag }) => ({
+            options={languageList.map(({ language, tag, "Geographic area": geographicArea }) => ({
               value: tag,
-              label: language,
+              label: `${language} - ${geographicArea}`, // Format as "language - geographic area" for display
             }))}
             formControl={formControl}
             multiple={false}


### PR DESCRIPTION
Enhance the language label in the AutopilotProfileForm to display both the language and its geographic area for better clarity.

- Resolves #4162