### PR TITLE
Fix: Fix loading bug when switching between device pages

### DIFF
--- a/src/pages/endpoint/MEM/devices/index.js
+++ b/src/pages/endpoint/MEM/devices/index.js
@@ -320,6 +320,7 @@ const Page = () => {
       title={pageTitle}
       apiUrl="/api/ListDevices"
       actions={actions}
+      queryKey={`MEMDevices-${tenantFilter}`}
       offCanvas={offCanvas}
       simpleColumns={[
         "deviceName",

--- a/src/pages/identity/administration/devices/index.js
+++ b/src/pages/identity/administration/devices/index.js
@@ -78,6 +78,7 @@ const Page = () => {
         $count: true,
       }}
       apiDataKey="Results"
+      queryKey={`EntraDevices-${tenantFilter}`}
       actions={actions}
       simpleColumns={[
         "displayName",


### PR DESCRIPTION
Add `queryKey` for both device pages to resolve a loading issue encountered when navigating directly between them.