### PR TITLE
Feat: Alert on % OneDrive quota used

### DIFF
--- a/src/data/alerts.json
+++ b/src/data/alerts.json
@@ -56,6 +56,15 @@
     "recommendedRunInterval": "4h"
   },
   {
+    "name": "OneDriveQuota",
+    "label": "Alert on % OneDrive quota used",
+    "requiresInput": true,
+    "inputType": "textField",
+    "inputLabel": "Enter quota percentage (default: 90)",
+    "inputName": "OneDriveQuota",
+    "recommendedRunInterval": "4h"
+  },
+  {
     "name": "ExpiringLicenses",
     "label": "Alert on licenses expiring in 30 days",
     "recommendedRunInterval": "7d"


### PR DESCRIPTION
Just a small script alert for OneDrive quota usage. Use case explained in FR
- Resolves feature request: https://github.com/KelvinTegelaar/CIPP/issues/4237
- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1491