### PR TITLE
Fixes query key for GroupTemplatesList beeing incorrect, should be ListGroupTemplates

### DIFF
--- a/src/pages/identity/administration/group-templates/edit.jsx
+++ b/src/pages/identity/administration/group-templates/edit.jsx
@@ -82,7 +82,7 @@ const Page = () => {
     <>
       <CippFormPage
         resetForm={false}
-        queryKey={[`GroupTemplatesList`, `GroupTemplate-${id}`]}
+        queryKey={[`ListGroupTemplates`, `GroupTemplate-${id}`]}
         formControl={formControl}
         title="Edit Group Template"
         backButtonTitle="Group Overview"

--- a/src/pages/identity/administration/group-templates/index.js
+++ b/src/pages/identity/administration/group-templates/index.js
@@ -110,7 +110,7 @@ const Page = () => {
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListGroupTemplates"
-      queryKey="GroupTemplatesList"
+      queryKey="ListGroupTemplates"
       tenantInTitle={false}
       actions={actions}
       cardButton={


### PR DESCRIPTION
I think vscode had a fir with CRLF on that one