### PR TITLE
Feat: Add "Microsoft managed" option to standards.json

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -554,6 +554,10 @@
           {
             "label": "Disabled",
             "value": "disabled"
+          },
+          {
+            "label": "Microsoft managed",
+            "value": "default"
           }
         ]
       }


### PR DESCRIPTION
Introduce a new option labeled "Microsoft managed" in the standards.json configuration file.

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1497