### PR TITLE
Fix: Set default value for "Enable Automapping" permission to true

### DIFF
--- a/src/components/CippComponents/CippMailboxPermissionsDialog.jsx
+++ b/src/components/CippComponents/CippMailboxPermissionsDialog.jsx
@@ -48,6 +48,7 @@ const CippMailboxPermissionsDialog = ({ formHook }) => {
             label="Enable Automapping"
             name="permissions.AutoMap"
             formControl={formHook}
+            defaultValue={true}
             sx={{ ml: 1.5, mt: 0, mb: 0 }}
           />
         </Box>


### PR DESCRIPTION
Change the default setting for the "Enable Automapping" permission to true in the permissions dialog.

Certified tiny PR