### PR TITLE
Autopilot Profile Device Name Template not required

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -4145,7 +4145,8 @@
       {
         "type": "textField",
         "name": "standards.AutopilotProfile.DeviceNameTemplate",
-        "label": "Unique Device Name Template"
+        "label": "Unique Device Name Template",
+        "required": false
       },
       {
         "type": "autoComplete",


### PR DESCRIPTION
Currently, the Autopilot Profile Standard requires a value in the Unique Device Name Template field.

However, this value is not required by Autopilot itself, nor is it required when profiles are manually created using CIPP.

This field should be optional, not mandatory.

Thank you.