### PR TITLE
Feat: Add more actions for managing named locations

### DIFF
--- a/src/pages/tenant/conditional/list-named-locations/index.js
+++ b/src/pages/tenant/conditional/list-named-locations/index.js
@@ -2,7 +2,13 @@ import { Layout as DashboardLayout } from "/src/layouts/index.js";
 import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx";
 import { Button } from "@mui/material";
 import Link from "next/link";
-import { MinusIcon, PlusIcon, PencilIcon } from "@heroicons/react/24/outline";
+import {
+  MinusIcon,
+  PlusIcon,
+  PencilIcon,
+  ShieldCheckIcon,
+  ShieldExclamationIcon,
+} from "@heroicons/react/24/outline";
 import { LocationOn } from "@mui/icons-material";
 
 const Page = () => {
@@ -20,6 +26,31 @@ const Page = () => {
       },
       fields: [{ type: "textField", name: "input", label: "New Name" }],
       confirmText: "Enter the new name for this named location.",
+    },
+    {
+      label: "Mark as Trusted",
+      type: "POST",
+      url: "/api/ExecNamedLocation",
+      icon: <ShieldCheckIcon />,
+      data: {
+        namedLocationId: "id",
+        change: "!setTrusted",
+      },
+      confirmText: "Are you sure you want to mark this IP location as trusted?",
+      condition: (row) =>
+        row["@odata.type"] == "#microsoft.graph.ipNamedLocation" && !row.isTrusted,
+    },
+    {
+      label: "Mark as Untrusted",
+      type: "POST",
+      url: "/api/ExecNamedLocation",
+      icon: <ShieldExclamationIcon />,
+      data: {
+        namedLocationId: "id",
+        change: "!setUntrusted",
+      },
+      confirmText: "Are you sure you want to mark this IP location as untrusted?",
+      condition: (row) => row["@odata.type"] == "#microsoft.graph.ipNamedLocation" && row.isTrusted,
     },
     {
       label: "Add location to named location",

--- a/src/pages/tenant/conditional/list-named-locations/index.js
+++ b/src/pages/tenant/conditional/list-named-locations/index.js
@@ -2,7 +2,7 @@ import { Layout as DashboardLayout } from "/src/layouts/index.js";
 import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx";
 import { Button } from "@mui/material";
 import Link from "next/link";
-import { MinusIcon, PlusIcon } from "@heroicons/react/24/outline";
+import { MinusIcon, PlusIcon, PencilIcon } from "@heroicons/react/24/outline";
 import { LocationOn } from "@mui/icons-material";
 
 const Page = () => {
@@ -10,13 +10,25 @@ const Page = () => {
 
   const actions = [
     {
+      label: "Rename named location",
+      type: "POST",
+      url: "/api/ExecNamedLocation",
+      icon: <PencilIcon />,
+      data: {
+        namedLocationId: "id",
+        change: "!rename",
+      },
+      fields: [{ type: "textField", name: "input", label: "New Name" }],
+      confirmText: "Enter the new name for this named location.",
+    },
+    {
       label: "Add location to named location",
       type: "POST",
       url: "/api/ExecNamedLocation",
       icon: <PlusIcon />,
       data: {
         namedLocationId: "id",
-        change: "addLocation",
+        change: "!addLocation",
       },
       fields: [{ type: "textField", name: "input", label: "Country Code" }],
       confirmText: "Enter a two-letter country code, e.g., US.",
@@ -29,7 +41,7 @@ const Page = () => {
       icon: <MinusIcon />,
       data: {
         namedLocationId: "id",
-        change: "removeLocation",
+        change: "!removeLocation",
       },
       fields: [{ type: "textField", name: "input", label: "Country Code" }],
       confirmText: "Enter a two-letter country code, e.g., US.",
@@ -42,7 +54,7 @@ const Page = () => {
       icon: <PlusIcon />,
       data: {
         namedLocationId: "id",
-        change: "addIp",
+        change: "!addIp",
       },
       fields: [{ type: "textField", name: "input", label: "IP" }],
       confirmText: "Enter an IP in CIDR format, e.g., 1.1.1.1/32.",
@@ -55,7 +67,7 @@ const Page = () => {
       icon: <MinusIcon />,
       data: {
         namedLocationId: "id",
-        change: "removeIp",
+        change: "!removeIp",
       },
       fields: [{ type: "textField", name: "input", label: "IP" }],
       confirmText: "Enter an IP in CIDR format, e.g., 1.1.1.1/32.",

--- a/src/pages/tenant/conditional/list-named-locations/index.js
+++ b/src/pages/tenant/conditional/list-named-locations/index.js
@@ -8,6 +8,7 @@ import {
   PencilIcon,
   ShieldCheckIcon,
   ShieldExclamationIcon,
+  TrashIcon,
 } from "@heroicons/react/24/outline";
 import { LocationOn } from "@mui/icons-material";
 
@@ -104,19 +105,26 @@ const Page = () => {
       confirmText: "Enter an IP in CIDR format, e.g., 1.1.1.1/32.",
       condition: (row) => row["@odata.type"] == "#microsoft.graph.ipNamedLocation",
     },
+    {
+      label: "Delete named location",
+      type: "POST",
+      url: "/api/ExecNamedLocation",
+      icon: <TrashIcon />,
+      data: {
+        namedLocationId: "id",
+        change: "!delete",
+      },
+      confirmText:
+        "Are you sure you want to delete this named location? This action cannot be undone.",
+      color: "error",
+    },
   ];
-
-  const offCanvas = {
-    extendedInfoFields: ["displayName", "rangeOrLocation"],
-    actions: actions,
-  };
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListNamedLocations"
       actions={actions}
-      offCanvas={offCanvas}
       cardButton={
         <>
           <Button component={Link} href="list-named-locations/add" startIcon={<LocationOn />}>


### PR DESCRIPTION
Introduce rename, trusted/untrusted, and delete actions for named locations, enhancing user interaction with confirmation prompts and streamlined management. Remove redundant offcanvas component.

- Resolves #4206
- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1501