### PR TITLE
Improved information density along with improvements to useability for forwarding

### DIFF
--- a/src/components/CippCards/CippExchangeInfoCard.jsx
+++ b/src/components/CippCards/CippExchangeInfoCard.jsx
@@ -14,7 +14,7 @@ import { PropertyListItem } from "/src/components/property-list-item";
 import { getCippFormatting } from "../../utils/get-cipp-formatting";
 import { Check as CheckIcon, Close as CloseIcon, Sync } from "@mui/icons-material";
 import { LinearProgressWithLabel } from "../linearProgressWithLabel";
-import { Stack } from "@mui/system";
+import { Stack, Grid } from "@mui/system";
 
 export const CippExchangeInfoCard = (props) => {
   const { exchangeData, isLoading = false, isFetching = false, handleRefresh, ...other } = props;
@@ -63,12 +63,36 @@ export const CippExchangeInfoCard = (props) => {
       <PropertyList>
         <PropertyListItem
           divider
-          label="Mailbox Type"
           value={
             isLoading ? (
-              <Skeleton variant="text" width={120} />
+              <Skeleton variant="text" width={200} />
             ) : (
-              exchangeData?.RecipientTypeDetails || "N/A"
+              <Grid container spacing={2}>
+                <Grid size={{ xs: 12, md: 4 }}>
+                  <Typography variant="inherit" color="text.primary" gutterBottom>
+                    Mailbox Type:
+                  </Typography>
+                  <Typography variant="inherit">
+                    {exchangeData?.RecipientTypeDetails || "N/A"}
+                  </Typography>
+                </Grid>
+                <Grid size={{ xs: 12, md: 4 }}>
+                  <Typography variant="inherit" color="text.primary" gutterBottom>
+                    Hidden from GAL:
+                  </Typography>
+                  <Typography variant="inherit">
+                    {getCippFormatting(exchangeData?.HiddenFromAddressLists, "HiddenFromAddressLists")}
+                  </Typography>
+                </Grid>
+                <Grid size={{ xs: 12, md: 4 }}>
+                  <Typography variant="inherit" color="text.primary" gutterBottom>
+                    Blocked For Spam:
+                  </Typography>
+                  <Typography variant="inherit">
+                    {getCippFormatting(exchangeData?.BlockedForSpam, "BlockedForSpam")}
+                  </Typography>
+                </Grid>
+              </Grid>
             )
           }
         />
@@ -100,82 +124,119 @@ export const CippExchangeInfoCard = (props) => {
         />
         <PropertyListItem
           divider
-          label="Hidden From Address Lists"
           value={
             isLoading ? (
-              <Skeleton variant="text" width={60} />
-            ) : (
-              getCippFormatting(exchangeData?.HiddenFromAddressLists, "HiddenFromAddressLists")
-            )
+              <Skeleton variant="text" width={200} />
+            ) : (() => {
+                const forwardingAddress = exchangeData?.ForwardingAddress;
+                const forwardAndDeliver = exchangeData?.ForwardAndDeliver;
+                
+                // Determine forwarding type and clean address
+                let forwardingType = "None";
+                let cleanAddress = "";
+                
+                if (forwardingAddress) {
+                  if (forwardingAddress.startsWith("smtp:")) {
+                    forwardingType = "External";
+                    cleanAddress = forwardingAddress.replace("smtp:", "");
+                  } else {
+                    forwardingType = "Internal";
+                    cleanAddress = forwardingAddress;
+                  }
+                }
+                
+                return (
+                  <Grid container spacing={2}>
+                    <Grid size={{ xs: 12, md: 6 }}>
+                      <Typography variant="inherit" color="text.primary" gutterBottom>
+                        Forwarding Status:
+                      </Typography>
+                      <Typography variant="inherit">
+                        {forwardingType === "None" 
+                          ? getCippFormatting(false, "ForwardingStatus")
+                          : `${forwardingType} Forwarding`
+                        }
+                      </Typography>
+                    </Grid>
+                    {forwardingType !== "None" && (
+                      <>
+                        <Grid size={{ xs: 12, md: 6 }}>
+                          <Typography variant="inherit" color="text.primary" gutterBottom>
+                            Keep Copy in Mailbox:
+                          </Typography>
+                          <Typography variant="inherit">
+                            {getCippFormatting(forwardAndDeliver, "ForwardAndDeliver")}
+                          </Typography>
+                        </Grid>
+                        <Grid size={{ xs: 12, md: 12 }}>
+                          <Typography variant="inherit" color="text.primary" gutterBottom>
+                            Forwarding Address:
+                          </Typography>
+                          <Typography variant="inherit">
+                            {cleanAddress}
+                          </Typography>
+                        </Grid>
+                      </>
+                    )}
+                  </Grid>
+                );
+              })()
           }
         />
-        <PropertyListItem
-          label="Forward and Deliver"
-          value={
-            isLoading ? (
-              <Skeleton variant="text" width={60} />
-            ) : (
-              getCippFormatting(exchangeData?.ForwardAndDeliver, "ForwardAndDeliver")
-            )
-          }
-        />
+        
+        {/* Archive section - always show status */}
         <PropertyListItem
           divider
-          label="Forwarding Address"
           value={
             isLoading ? (
-              <Skeleton variant="text" width={180} />
+              <Skeleton variant="text" width={200} />
             ) : (
-              exchangeData?.ForwardingAddress || "N/A"
+              <Grid container spacing={2}>
+                <Grid size={{ xs: 12, md: 6 }}>
+                  <Typography variant="inherit" color="text.primary" gutterBottom>
+                    Archive Mailbox Enabled:
+                  </Typography>
+                  <Typography variant="inherit">
+                    {getCippFormatting(exchangeData?.ArchiveMailBox, "ArchiveMailBox")}
+                  </Typography>
+                </Grid>
+                {exchangeData?.ArchiveMailBox && (
+                  <>
+                    <Grid size={{ xs: 12, md: 6 }}>
+                      <Typography variant="inherit" color="text.primary" gutterBottom>
+                        Auto Expanding Archive:
+                      </Typography>
+                      <Typography variant="inherit">
+                        {getCippFormatting(exchangeData?.AutoExpandingArchive, "AutoExpandingArchive")}
+                      </Typography>
+                    </Grid>
+                    <Grid size={{ xs: 12, md: 6 }}>
+                      <Typography variant="inherit" color="text.primary" gutterBottom>
+                        Total Archive Item Size:
+                      </Typography>
+                      <Typography variant="inherit">
+                        {exchangeData?.TotalArchiveItemSize != null
+                          ? `${exchangeData.TotalArchiveItemSize} GB`
+                          : "N/A"}
+                      </Typography>
+                    </Grid>
+                    <Grid size={{ xs: 12, md: 6 }}>
+                      <Typography variant="inherit" color="text.primary" gutterBottom>
+                        Total Archive Item Count:
+                      </Typography>
+                      <Typography variant="inherit">
+                        {exchangeData?.TotalArchiveItemCount != null
+                          ? exchangeData.TotalArchiveItemCount
+                          : "N/A"}
+                      </Typography>
+                    </Grid>
+                  </>
+                )}
+              </Grid>
             )
           }
         />
-        <PropertyListItem
-          label="Archive Mailbox Enabled"
-          value={
-            isLoading ? (
-              <Skeleton variant="text" width={60} />
-            ) : (
-              getCippFormatting(exchangeData?.ArchiveMailBox, "ArchiveMailBox")
-            )
-          }
-        />
-        <PropertyListItem
-          label="Auto Expanding Archive"
-          value={
-            isLoading ? (
-              <Skeleton variant="text" width={80} />
-            ) : (
-              getCippFormatting(exchangeData?.AutoExpandingArchive, "AutoExpandingArchive")
-            )
-          }
-        />
-        <PropertyListItem
-          label="Total Archive Item Size"
-          value={
-            isLoading ? (
-              <Skeleton variant="text" width={80} />
-            ) : exchangeData?.TotalArchiveItemSize != null ? (
-              `${exchangeData.TotalArchiveItemSize} GB`
-            ) : (
-              "N/A"
-            )
-          }
-        />
-        <PropertyListItem
-          divider
-          label="Total Archive Item Count"
-          value={
-            isLoading ? (
-              <Skeleton variant="text" width={80} />
-            ) : exchangeData?.TotalArchiveItemCount != null ? (
-              exchangeData.TotalArchiveItemCount
-            ) : (
-              "N/A"
-            )
-          }
-        />
-        {/* Combine all mailbox hold types into a single PropertyListItem */}
+
         <PropertyListItem
           divider
           label="Mailbox Holds"
@@ -199,7 +260,6 @@ export const CippExchangeInfoCard = (props) => {
             )
           }
         />
-        {/* Combine protocols into a single PropertyListItem */}
         <PropertyListItem
           divider
           label="Mailbox Protocols"
@@ -220,17 +280,6 @@ export const CippExchangeInfoCard = (props) => {
                   />
                 ))}
               </div>
-            )
-          }
-        />
-        <PropertyListItem
-          divider
-          label="Blocked For Spam"
-          value={
-            isLoading ? (
-              <Skeleton variant="text" width={60} />
-            ) : (
-              getCippFormatting(exchangeData?.BlockedForSpam, "BlockedForSpam")
             )
           }
         />

--- a/src/components/CippComponents/CippForwardingSection.jsx
+++ b/src/components/CippComponents/CippForwardingSection.jsx
@@ -1,0 +1,98 @@
+import { Stack, Button } from "@mui/material";
+import CippFormComponent from "./CippFormComponent";
+import { CippFormCondition } from "./CippFormCondition";
+import { Grid } from "@mui/system";
+import { CippApiResults } from "./CippApiResults";
+import { getCippValidator } from "/src/utils/get-cipp-validator";
+
+const CippForwardingSection = ({ formControl, usersList, contactsList, postRequest, handleSubmit }) => {
+
+  const internalAddressOptions = [
+    // Add users
+    ...(usersList?.data?.Results?.map((user) => ({
+      value: user.userPrincipalName,
+      label: `${user.displayName} (${user.userPrincipalName}) - User`,
+    })) || []),
+    // Add contacts
+    ...(contactsList?.data?.Results?.map((contact) => ({
+      value: contact.mail || contact.emailAddress,
+      label: `${contact.displayName} (${contact.mail || contact.emailAddress}) - Contact`,
+    })) || [])
+  ];
+
+  return (
+    <Stack spacing={2}>
+      <CippFormComponent
+        type="radio"
+        name="forwarding.forwardOption"
+        formControl={formControl}
+        options={[
+          { label: "Forward to Internal Address", value: "internalAddress" },
+          {
+            label: "Forward to External Address (Tenant must allow this)",
+            value: "ExternalAddress",
+          },
+          { label: "Disable Email Forwarding", value: "disabled" },
+        ]}
+      />
+
+      <CippFormCondition
+        formControl={formControl}
+        field="forwarding.forwardOption"
+        compareType="is"
+        compareValue="internalAddress"
+      >
+        <CippFormComponent
+          type="autoComplete"
+          label="Select User"
+          name="forwarding.ForwardInternal"
+          multiple={false}
+          options={internalAddressOptions}
+          formControl={formControl}
+          creatable={false}
+        />
+      </CippFormCondition>
+
+      <CippFormCondition
+        formControl={formControl}
+        field="forwarding.forwardOption"
+        compareType="is"
+        compareValue="ExternalAddress"
+      >
+        <CippFormComponent
+          type="textField"
+          label="External Email Address"
+          name="forwarding.ForwardExternal"
+          formControl={formControl}
+          validators={{
+            required: "Email is required",
+            validate: (value) => getCippValidator(value, "email"),
+          }}
+        />
+      </CippFormCondition>
+
+      <CippFormComponent
+        type="switch"
+        label="Keep a Copy of the Forwarded Mail in the Source Mailbox"
+        name="forwarding.KeepCopy"
+        formControl={formControl}
+      />
+      
+      <Grid item size={12}>
+        <CippApiResults apiObject={postRequest} />
+      </Grid>
+      
+      <Grid>
+        <Button
+          onClick={() => handleSubmit("forwarding")}
+          variant="contained"
+          disabled={!formControl.formState.isValid || postRequest.isPending}
+        >
+          Submit
+        </Button>
+      </Grid>
+    </Stack>
+  );
+};
+
+export default CippForwardingSection;

--- a/src/components/CippWizard/CippWizardOffboarding.jsx
+++ b/src/components/CippWizard/CippWizardOffboarding.jsx
@@ -33,7 +33,7 @@ export const CippWizardOffboarding = (props) => {
   useEffect(() => {
     if (disableForwarding) {
       formControl.setValue("forward", null);
-      formControl.setValue("keepCopy", false);
+      formControl.setValue("KeepCopy", false);
     }
   }, [disableForwarding, formControl]);
 
@@ -260,7 +260,7 @@ export const CippWizardOffboarding = (props) => {
                 />
 
                 <CippFormComponent
-                  name="keepCopy"
+                  name="KeepCopy"
                   label="Keep a copy of forwarded mail"
                   type="switch"
                   formControl={formControl}

--- a/src/pages/cipp/preferences.js
+++ b/src/pages/cipp/preferences.js
@@ -216,7 +216,7 @@ const Page = () => {
                           value: (
                             <CippFormComponent
                               type="switch"
-                              name="offboardingDefaults.keepCopy"
+                              name="offboardingDefaults.KeepCopy"
                               formControl={formcontrol}
                             />
                           ),


### PR DESCRIPTION
Little tidy up, moving the forwarding component to its own file
Improved layout of information card to allow for still readable but much better info density
Allow for selecting contacts as a forwarding destination
Hide archive and forwarding sections if disabled and only show that they are disabled
Removed un-used imports
API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1505