### PR TITLE
Assign and manage mail enabled security groups in mailbox and calendar permissions

### DIFF
--- a/src/components/CippComponents/CippCalendarPermissionsDialog.jsx
+++ b/src/components/CippComponents/CippCalendarPermissionsDialog.jsx
@@ -1,45 +1,14 @@
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { Box, Stack, Tooltip } from "@mui/material";
 import CippFormComponent from "./CippFormComponent";
 import { useWatch } from "react-hook-form";
 
-const CippCalendarPermissionsDialog = ({ formHook, groupsList, usersList }) => {
+const CippCalendarPermissionsDialog = ({ formHook, combinedOptions, isUserGroupLoading }) => {
   const permissionLevel = useWatch({
     control: formHook.control,
     name: "Permissions",
   });
 
-  // Combine users and groups into a single options array
-  const combinedOptions = useMemo(() => {
-    const options = [];
-    
-    // Add users (from parent)
-    if (usersList?.data?.Results) {
-      usersList.data.Results.forEach((user) => {
-        options.push({
-          value: user.userPrincipalName,
-          label: `${user.displayName} (${user.userPrincipalName})`,
-          type: 'user'
-        });
-      });
-    }
-    
-    // Add mail-enabled security groups (from parent)
-    if (groupsList?.data?.Results) {
-      groupsList.data.Results.forEach((group) => {
-        options.push({
-          value: group.mail,
-          label: `${group.displayName} (${group.mail})`,
-          type: 'group'
-        });
-      });
-    }
-    
-    // Sort alphabetically by label
-    return options.sort((a, b) => a.label.localeCompare(b.label));
-  }, [usersList?.data?.Results, groupsList?.data?.Results]);
-
-  const isLoading = usersList.isFetching || groupsList.isFetching;
   const isEditor = permissionLevel?.value === "Editor";
 
   useEffect(() => {
@@ -57,7 +26,7 @@ const CippCalendarPermissionsDialog = ({ formHook, groupsList, usersList }) => {
           name="UserToGetPermissions"
           multiple={false}
           formControl={formHook}
-          isFetching={isLoading}
+          isFetching={isUserGroupLoading}
           options={combinedOptions}
           creatable={false}
           required={true}

--- a/src/components/CippComponents/CippMailboxPermissionsDialog.jsx
+++ b/src/components/CippComponents/CippMailboxPermissionsDialog.jsx
@@ -1,45 +1,12 @@
 import { Box, Stack } from "@mui/material";
 import CippFormComponent from "./CippFormComponent";
 import { useWatch } from "react-hook-form";
-import { useMemo } from "react";
 
-const CippMailboxPermissionsDialog = ({ formHook, groupsList, usersList }) => {
+const CippMailboxPermissionsDialog = ({ formHook, combinedOptions, isUserGroupLoading }) => {
   const fullAccess = useWatch({
     control: formHook.control,
     name: "permissions.AddFullAccess",
   });
-
-  // Combine users and groups into a single options array
-  const combinedOptions = useMemo(() => {
-    const options = [];
-    
-    // Add users (from parent)
-    if (usersList?.data?.Results) {
-      usersList.data.Results.forEach((user) => {
-        options.push({
-          value: user.userPrincipalName,
-          label: `${user.displayName} (${user.userPrincipalName})`,
-          type: 'user'
-        });
-      });
-    }
-    
-    // Add mail-enabled security groups (from parent)
-    if (groupsList?.data?.Results) {
-      groupsList.data.Results.forEach((group) => {
-        options.push({
-          value: group.mail,
-          label: `${group.displayName} (${group.mail})`,
-          type: 'group'
-        });
-      });
-    }
-    
-    // Sort alphabetically by label
-    return options.sort((a, b) => a.label.localeCompare(b.label));
-  }, [usersList?.data?.Results, groupsList?.data?.Results]);
-
-  const isLoading = usersList.isFetching || groupsList.isFetching;
 
   return (
     <Stack spacing={2} sx={{ mt: 1 }}>
@@ -49,7 +16,7 @@ const CippMailboxPermissionsDialog = ({ formHook, groupsList, usersList }) => {
           label="Add Full Access"
           name="permissions.AddFullAccess"
           formControl={formHook}
-          isFetching={isLoading}
+          isFetching={isUserGroupLoading}
           creatable={false}
           options={combinedOptions}
         />
@@ -70,7 +37,7 @@ const CippMailboxPermissionsDialog = ({ formHook, groupsList, usersList }) => {
           label="Add Send-as Permissions"
           name="permissions.AddSendAs"
           formControl={formHook}
-          isFetching={isLoading}
+          isFetching={isUserGroupLoading}
           creatable={false}
           options={combinedOptions}
         />
@@ -81,7 +48,7 @@ const CippMailboxPermissionsDialog = ({ formHook, groupsList, usersList }) => {
           label="Add Send On Behalf Permissions"
           name="permissions.AddSendOnBehalf"
           formControl={formHook}
-          isFetching={isLoading}
+          isFetching={isUserGroupLoading}
           creatable={false}
           options={combinedOptions}
         />

--- a/src/components/CippFormPages/CippExchangeSettingsForm.jsx
+++ b/src/components/CippFormPages/CippExchangeSettingsForm.jsx
@@ -161,6 +161,7 @@ const CippExchangeSettingsForm = (props) => {
                 label="Auto Reply State"
                 multiple={false}
                 formControl={formControl}
+                creatable={false}
                 options={[
                   { label: "Enabled", value: "Enabled" },
                   { label: "Disabled", value: "Disabled" },

--- a/src/pages/identity/administration/users/user/exchange.jsx
+++ b/src/pages/identity/administration/users/user/exchange.jsx
@@ -26,7 +26,7 @@ import { Box, Stack } from "@mui/system";
 import { Grid } from "@mui/system";
 import { CippBannerListCard } from "../../../../../components/CippCards/CippBannerListCard";
 import { CippExchangeInfoCard } from "../../../../../components/CippCards/CippExchangeInfoCard";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import CippExchangeSettingsForm from "../../../../../components/CippFormPages/CippExchangeSettingsForm";
 import { useForm } from "react-hook-form";
 import { Alert, Button, Collapse, CircularProgress, Typography } from "@mui/material";
@@ -315,6 +315,38 @@ const Page = () => {
   }, [userRequest.isSuccess, userRequest.dataUpdatedAt, formControl]);
 
   const title = graphUserRequest.isSuccess ? graphUserRequest.data?.[0]?.displayName : "Loading...";
+
+  // Combine users and groups into a single options array
+  const combinedOptions = useMemo(() => {
+    const options = [];
+  
+    // Add users
+    if (usersList?.data?.Results) {
+      usersList.data.Results.forEach((user) => {
+        options.push({
+          value: user.userPrincipalName,
+          label: `${user.displayName} (${user.userPrincipalName})`,
+          type: 'user'
+        });
+      });
+    }
+  
+    // Add mail-enabled security groups
+    if (groupsList?.data?.Results) {
+      groupsList.data.Results.forEach((group) => {
+        options.push({
+          value: group.mail,
+          label: `${group.displayName} (${group.mail})`,
+          type: 'group'
+        });
+      });
+    }
+  
+    // Sort alphabetically by label
+    return options.sort((a, b) => a.label.localeCompare(b.label));
+  }, [usersList?.data?.Results, groupsList?.data?.Results]);
+
+  const isUserGroupLoading = usersList.isFetching || groupsList.isFetching;
 
   const subtitle = graphUserRequest.isSuccess
     ? [
@@ -946,8 +978,8 @@ const Page = () => {
         {({ formHook }) => (
           <CippMailboxPermissionsDialog
             formHook={formHook}
-            groupsList={groupsList}
-            usersList={usersList}
+            combinedOptions={combinedOptions}
+            isUserGroupLoading={isUserGroupLoading}
           />
         )}
       </CippApiDialog>
@@ -962,8 +994,8 @@ const Page = () => {
         {({ formHook }) => (
           <CippCalendarPermissionsDialog
             formHook={formHook}
-            groupsList={groupsList}
-            usersList={usersList}
+            combinedOptions={combinedOptions}
+            isUserGroupLoading={isUserGroupLoading}
           />
         )}
       </CippApiDialog>


### PR DESCRIPTION
There is a bit of trickery at play here, lets get started:
1: Removed users call from the mailbox and calendar pages as it was redundant
2: Combine both users and the mail enabled security groups into combinedOptions and pass that to the child component
3: Existing API to add/remove/list permissions already handles these changes!
4: Do some clean-up on the group names as EXO sometimes stores a timestamp in the name... weird, but use the original name in the API requests
5: Update some creatable sctions
6: Add (ui side) a column to indicate the user type (user, group or system)

Addresses: https://github.com/KelvinTegelaar/CIPP/issues/3976