### PR TITLE
Feat: Add Default user option for calendar permissions dropdown

### DIFF
--- a/src/pages/identity/administration/users/user/exchange.jsx
+++ b/src/pages/identity/administration/users/user/exchange.jsx
@@ -320,6 +320,13 @@ const Page = () => {
   const combinedOptions = useMemo(() => {
     const options = [];
   
+    // Add special system users for calendar permissions
+    options.push({
+      value: 'Default',
+      label: 'Default',
+      type: 'system'
+    });
+  
     // Add users
     if (usersList?.data?.Results) {
       usersList.data.Results.forEach((user) => {
@@ -342,8 +349,12 @@ const Page = () => {
       });
     }
   
-    // Sort alphabetically by label
-    return options.sort((a, b) => a.label.localeCompare(b.label));
+    // Sort alphabetically by label, but keep system users at the top
+    return options.sort((a, b) => {
+      if (a.type === 'system' && b.type !== 'system') return -1;
+      if (b.type === 'system' && a.type !== 'system') return 1;
+      return a.label.localeCompare(b.label);
+    });
   }, [usersList?.data?.Results, groupsList?.data?.Results]);
 
   const isUserGroupLoading = usersList.isFetching || groupsList.isFetching;


### PR DESCRIPTION
Reintroduce the Default user in the calendar permissions dropdown and ensure system users are prioritized in the sorting.