### PR TITLE
Feat: Enhance group editing and add hide/show M365 group in outlook

### DIFF
--- a/src/pages/identity/administration/groups/edit.jsx
+++ b/src/pages/identity/administration/groups/edit.jsx
@@ -18,6 +18,7 @@ const EditGroup = () => {
   const [groupIdReady, setGroupIdReady] = useState(false);
   const [showMembershipTable, setShowMembershipTable] = useState(false);
   const [combinedData, setCombinedData] = useState([]);
+  const [initialValues, setInitialValues] = useState({});
   const tenantFilter = useSettings().currentTenant;
 
   const groupInfo = ApiGetCall({
@@ -65,8 +66,8 @@ const EditGroup = () => {
         ];
         setCombinedData(combinedData);
 
-        // Reset the form with all values
-        formControl.reset({
+        // Create initial values object
+        const formValues = {
           tenantFilter: tenantFilter,
           mail: group.mail,
           mailNickname: group.mailNickname || "",
@@ -103,10 +104,36 @@ const EditGroup = () => {
           RemoveOwner: [],
           AddContact: [],
           RemoveContact: [],
+        };
+
+        // Store initial values for comparison
+        setInitialValues({
+          allowExternal: groupInfo?.data?.allowExternal,
+          sendCopies: groupInfo?.data?.sendCopies,
         });
+
+        // Reset the form with all values
+        formControl.reset(formValues);
       }
     }
   }, [groupInfo.isSuccess, router.query, groupInfo.isFetching]);
+
+  // Custom data formatter to only send changed values
+  const customDataFormatter = (formData) => {
+    const cleanedData = { ...formData };
+
+    // Only include allowExternal if it has changed from the initial value
+    if (formData.allowExternal === initialValues.allowExternal) {
+      delete cleanedData.allowExternal;
+    }
+
+    // Only include sendCopies if it has changed from the initial value
+    if (formData.sendCopies === initialValues.sendCopies) {
+      delete cleanedData.sendCopies;
+    }
+
+    return cleanedData;
+  };
 
   return (
     <>
@@ -117,6 +144,7 @@ const EditGroup = () => {
         formPageType="Edit"
         backButtonTitle="Group Overview"
         postUrl="/api/EditGroup"
+        customDataformatter={customDataFormatter}
         titleButton={
           <>
             <Button

--- a/src/pages/identity/administration/groups/edit.jsx
+++ b/src/pages/identity/administration/groups/edit.jsx
@@ -124,20 +124,14 @@ const EditGroup = () => {
   const customDataFormatter = (formData) => {
     const cleanedData = { ...formData };
 
-    // Only include allowExternal if it has changed from the initial value
-    if (formData.allowExternal === initialValues.allowExternal) {
-      delete cleanedData.allowExternal;
-    }
+    // Properties that should only be sent if they've changed from initial values
+    const changeDetectionProperties = ["allowExternal", "sendCopies", "hideFromOutlookClients"];
 
-    // Only include sendCopies if it has changed from the initial value
-    if (formData.sendCopies === initialValues.sendCopies) {
-      delete cleanedData.sendCopies;
-    }
-
-    // Only include hideFromOutlookClients if it has changed from the initial value
-    if (formData.hideFromOutlookClients === initialValues.hideFromOutlookClients) {
-      delete cleanedData.hideFromOutlookClients;
-    }
+    changeDetectionProperties.forEach((property) => {
+      if (formData[property] === initialValues[property]) {
+        delete cleanedData[property];
+      }
+    });
 
     return cleanedData;
   };

--- a/src/pages/identity/administration/groups/edit.jsx
+++ b/src/pages/identity/administration/groups/edit.jsx
@@ -73,6 +73,7 @@ const EditGroup = () => {
           mailNickname: group.mailNickname || "",
           allowExternal: groupInfo?.data?.allowExternal,
           sendCopies: groupInfo?.data?.sendCopies,
+          hideFromOutlookClients: groupInfo?.data?.hideFromOutlookClients,
           displayName: group.displayName,
           description: group.description || "",
           membershipRules: group.membershipRule || "",
@@ -110,6 +111,7 @@ const EditGroup = () => {
         setInitialValues({
           allowExternal: groupInfo?.data?.allowExternal,
           sendCopies: groupInfo?.data?.sendCopies,
+          hideFromOutlookClients: groupInfo?.data?.hideFromOutlookClients,
         });
 
         // Reset the form with all values
@@ -130,6 +132,11 @@ const EditGroup = () => {
     // Only include sendCopies if it has changed from the initial value
     if (formData.sendCopies === initialValues.sendCopies) {
       delete cleanedData.sendCopies;
+    }
+
+    // Only include hideFromOutlookClients if it has changed from the initial value
+    if (formData.hideFromOutlookClients === initialValues.hideFromOutlookClients) {
+      delete cleanedData.hideFromOutlookClients;
     }
 
     return cleanedData;
@@ -353,6 +360,19 @@ const EditGroup = () => {
                     type="switch"
                     label="Send Copies of team emails and events to team members inboxes"
                     name="sendCopies"
+                    formControl={formControl}
+                    isFetching={groupInfo.isFetching}
+                    disabled={groupInfo.isFetching}
+                  />
+                </Grid>
+              )}
+
+              {groupType === "Microsoft 365" && (
+                <Grid size={{ xs: 12 }}>
+                  <CippFormComponent
+                    type="switch"
+                    label="Hide group mailbox from Outlook"
+                    name="hideFromOutlookClients"
                     formControl={formControl}
                     isFetching={groupInfo.isFetching}
                     disabled={groupInfo.isFetching}


### PR DESCRIPTION
Introduce initial value tracking for form submission and implement a custom data formatter to send only changed values for specific fields. Update form reset logic for improved state management.

- API PR 1: https://github.com/KelvinTegelaar/CIPP-API/pull/1529
- API PR 2: https://github.com/KelvinTegelaar/CIPP-API/pull/1538
- Resolves https://github.com/KelvinTegelaar/CIPP/issues/4360