### PR TITLE
Feat: Add new standard for SharePoint default sharing link configuration and deprecate SPDirectSharing

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -3616,6 +3616,40 @@
     "recommendedBy": ["CIS", "CIPP"]
   },
   {
+    "name": "standards.DefaultSharingLink",
+    "cat": "SharePoint Standards",
+    "tag": ["CIS M365 5.0 (7.2.7)", "CIS M365 5.0 (7.2.11)", "CISA (MS.SPO.1.4v1)"],
+    "helpText": "Configure the SharePoint default sharing link type and permission. This setting controls both the type of sharing link created by default and the permission level assigned to those links.",
+    "docsDescription": "Sets the default sharing link type (Direct or Internal) and permission (View) in SharePoint and OneDrive. Direct sharing means links only work for specific people, while Internal sharing means links work for anyone in the organization. Setting the view permission as the default ensures that users must deliberately select the edit permission when sharing a link, reducing the risk of unintentionally granting edit privileges.",
+    "executiveText": "Configures SharePoint default sharing links to implement the principle of least privilege for document sharing. This security measure reduces the risk of accidental data modification while maintaining collaboration functionality, requiring users to explicitly select Edit permissions when necessary. The sharing type setting controls whether links are restricted to specific recipients or available to the entire organization. This reduces the risk of accidental data exposure through link sharing.",
+    "addedComponent": [
+      {
+        "type": "autoComplete",
+        "multiple": false,
+        "creatable": false,
+        "required": true,
+        "label": "Default Sharing Link Type",
+        "name": "standards.DefaultSharingLink.SharingLinkType",
+        "options": [
+          {
+            "label": "Direct - Only the people the user specifies",
+            "value": "Direct"
+          },
+          {
+            "label": "Internal - Only people in your organization",
+            "value": "Internal"
+          }
+        ]
+      }
+    ],
+    "label": "Set Default Sharing Link Settings",
+    "impact": "Low Impact",
+    "impactColour": "info",
+    "addedDate": "2025-06-13",
+    "powershellEquivalent": "Set-SPOTenant -DefaultSharingLinkType [Direct|Internal] -DefaultLinkPermission View",
+    "recommendedBy": ["CIS", "CIPP"]
+  },
+  {
     "name": "standards.DisableAddShortcutsToOneDrive",
     "cat": "SharePoint Standards",
     "tag": [],

--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -3564,8 +3564,8 @@
   {
     "name": "standards.SPDirectSharing",
     "cat": "SharePoint Standards",
-    "tag": ["CIS M365 5.0 (7.2.7)", "CISA (MS.SPO.1.4v1)"],
-    "helpText": "Ensure default link sharing is set to Direct in SharePoint and OneDrive",
+    "tag": [],
+    "helpText": "This standard has been deprecated in favor of the Default Sharing Link standard. ",
     "executiveText": "Configures SharePoint and OneDrive to share files directly with specific people rather than creating anonymous links, improving security by ensuring only intended recipients can access shared documents. This reduces the risk of accidental data exposure through link sharing.",
     "addedComponent": [],
     "label": "Default sharing to Direct users",


### PR DESCRIPTION
Introduce a new standard for configuring the default sharing link type and permissions in SharePoint, enhancing security and control over document sharing. Deprecate the existing SPDirectSharing standard to streamline sharing practices.

- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1539
- Resolves https://github.com/KelvinTegelaar/CIPP/issues/4234