### PR TITLE
Fix: Script Edit not working 

### DIFF
--- a/src/pages/endpoint/MEM/list-scripts/index.jsx
+++ b/src/pages/endpoint/MEM/list-scripts/index.jsx
@@ -118,7 +118,7 @@ const Page = () => {
       };
 
       const response = await fetch("/api/EditIntuneScript", {
-        method: "PATCH",
+        method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(patchData),
       });


### PR DESCRIPTION
Edit intune script was not working. Frontend called endpoint _/api/EditIntuneScript_ with method POST, but CIPP-API requires PATCH to update script. 

Small improvement to editor syntax highlighting. Dynamically set language from script type.

- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1542