### PR TITLE
Feat: Add defender exclusions option

### DIFF
--- a/src/components/CippComponents/CippFormInputArray.jsx
+++ b/src/components/CippComponents/CippFormInputArray.jsx
@@ -1,4 +1,4 @@
-import { TextField, IconButton, Typography, SvgIcon } from "@mui/material";
+import { TextField, IconButton, Typography, Box } from "@mui/material";
 import { Controller, useFieldArray } from "react-hook-form";
 import { Add, Remove } from "@mui/icons-material";
 
@@ -7,68 +7,111 @@ const convertBracketsToDots = (name) => {
   return name.replace(/\[(\d+)\]/g, ".$1"); // Replace [0] with .0
 };
 
-export const CippFormInputArray = ({ formControl, name, label, validators, ...other }) => {
+export const CippFormInputArray = ({
+  formControl,
+  name,
+  label,
+  validators,
+  mode = "keyValue", // Default to keyValue for backward compatibility
+  placeholder,
+  keyPlaceholder = "Key",
+  valuePlaceholder = "Value",
+  ...other
+}) => {
   // Convert the name from bracket notation to dot notation
   const convertedName = convertBracketsToDots(name);
+
+  // Determine initial value based on mode
+  const getInitialValue = () => {
+    if (mode === "simple") {
+      return "";
+    } else {
+      return { Key: "", Value: "" };
+    }
+  };
 
   // Use `useFieldArray` to manage dynamic field arrays
   const { fields, append, remove } = useFieldArray({
     control: formControl.control,
-    name: convertedName, // Specify the converted name for useFieldArray
+    name: convertedName,
   });
 
+  // Render simple mode (single input field)
+  const renderSimpleField = (field, index) => (
+    <Box key={field.id} sx={{ display: "flex", gap: 1, alignItems: "center", mb: 1 }}>
+      <Controller
+        name={`${convertedName}[${index}]`}
+        control={formControl.control}
+        rules={validators}
+        render={({ field: controllerField, fieldState }) => (
+          <TextField
+            {...controllerField}
+            placeholder={placeholder || "Enter value"}
+            fullWidth
+            error={!!fieldState.error}
+            helperText={fieldState.error?.message}
+            {...other}
+          />
+        )}
+      />
+      <IconButton onClick={() => remove(index)} aria-label="remove item" size="small">
+        <Remove />
+      </IconButton>
+    </Box>
+  );
+
+  // Render key-value mode (two input fields) - original functionality
+  const renderKeyValueField = (field, index) => (
+    <Box key={field.id} sx={{ display: "flex", gap: 1, alignItems: "center", mb: 1 }}>
+      <Controller
+        name={`${convertedName}[${index}].Key`}
+        control={formControl.control}
+        render={({ field: controllerField }) => (
+          <TextField
+            {...controllerField}
+            placeholder={keyPlaceholder}
+            fullWidth
+            {...other}
+            {...formControl.register(`${convertedName}[${index}].Key`, {
+              ...validators,
+            })}
+          />
+        )}
+      />
+      <Controller
+        name={`${convertedName}[${index}].Value`}
+        control={formControl.control}
+        render={({ field: controllerField }) => (
+          <TextField
+            {...controllerField}
+            placeholder={valuePlaceholder}
+            fullWidth
+            {...other}
+            {...formControl.register(`${convertedName}[${index}].Value`, {
+              ...validators,
+            })}
+          />
+        )}
+      />
+      <IconButton onClick={() => remove(index)} aria-label="remove item" size="small">
+        <Remove />
+      </IconButton>
+    </Box>
+  );
+
   return (
-    <>
-      <div>
+    <Box>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
         {label && <Typography variant="body2">{label}</Typography>}
-        <IconButton onClick={() => append({ Key: "", Value: "" })} variant="outlined">
+        <IconButton onClick={() => append(getInitialValue())} variant="outlined" size="small">
           <Add />
         </IconButton>
-      </div>
+      </Box>
 
-      {fields.map((field, index) => (
-        <div
-          key={field.id}
-          style={{ display: "flex", gap: "8px", alignItems: "center", marginBottom: "10px" }}
-        >
-          <Controller
-            name={`${convertedName}[${index}].Key`}
-            control={formControl.control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                placeholder="Key"
-                fullWidth
-                {...other}
-                {...formControl.register(`${convertedName}[${index}].Key`, {
-                  ...validators,
-                })}
-              />
-            )}
-          />
-          <Controller
-            name={`${convertedName}[${index}].Value`}
-            control={formControl.control}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                placeholder="Value"
-                fullWidth
-                {...other}
-                {...formControl.register(`${convertedName}[${index}].Value`, {
-                  ...validators,
-                })}
-              />
-            )}
-          />
-          <IconButton onClick={() => remove(index)} aria-label="remove item">
-            <SvgIcon>
-              <Remove />
-            </SvgIcon>
-          </IconButton>
-        </div>
-      ))}
-    </>
+      {fields.map((field, index) =>
+        mode === "simple" ? renderSimpleField(field, index) : renderKeyValueField(field, index)
+      )}
+    </Box>
   );
 };
 

--- a/src/pages/security/defender/deployment/index.js
+++ b/src/pages/security/defender/deployment/index.js
@@ -6,6 +6,7 @@ import CippFormPage from "/src/components/CippFormPages/CippFormPage";
 import CippFormComponent from "/src/components/CippComponents/CippFormComponent";
 import { CippFormTenantSelector } from "/src/components/CippComponents/CippFormTenantSelector";
 import { CippFormCondition } from "/src/components/CippComponents/CippFormCondition";
+import { CippFormInputArray } from "/src/components/CippComponents/CippFormInputArray";
 
 const DeployDefenderForm = () => {
   const formControl = useForm({
@@ -292,6 +293,77 @@ const DeployDefenderForm = () => {
                 />
               </Grid>
             </Grid>
+          </Grid>
+        </CippFormCondition>
+
+        <Divider sx={{ my: 2 }} />
+
+        {/* Exclusion Policy Section */}
+        <Grid size={{ xs: 12 }}>
+          <CippFormComponent
+            type="switch"
+            label="Show Exclusion Policy Options"
+            name="showExclusionPolicy"
+            formControl={formControl}
+          />
+        </Grid>
+
+        <CippFormCondition
+          formControl={formControl}
+          field="showExclusionPolicy"
+          compareType="is"
+          compareValue={true}
+        >
+          <Grid size={{ xs: 12 }}>
+            <Typography variant="h6">Exclusion Policy</Typography>
+            <Typography variant="subtitle1">Configure Defender Exclusions</Typography>
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <CippFormInputArray
+              formControl={formControl}
+              name="Exclusion.excludedExtensions"
+              label="Excluded Extensions"
+              mode="simple"
+              placeholder="e.g., txt, log, tmp"
+              validators={{}}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <CippFormInputArray
+              formControl={formControl}
+              name="Exclusion.excludedPaths"
+              label="Excluded Paths"
+              mode="simple"
+              placeholder={"e.g., C:\\temp, C:\\Program Files\\App"}
+              validators={{}}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <CippFormInputArray
+              formControl={formControl}
+              name="Exclusion.excludedProcesses"
+              label="Excluded Processes"
+              mode="simple"
+              placeholder="e.g., notepad.exe, chrome.exe"
+              validators={{}}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <Typography variant="subtitle1">Assign to Group</Typography>
+            <CippFormComponent
+              type="radio"
+              label=""
+              name="Exclusion.AssignTo"
+              options={[
+                { label: "Do not assign", value: "none" },
+                { label: "Assign to all users", value: "allLicensedUsers" },
+                { label: "Assign to all devices", value: "AllDevices" },
+                { label: "Assign to all users and devices", value: "AllDevicesAndUsers" },
+              ]}
+              formControl={formControl}
+              validators={{ required: "Assignment must be selected" }}
+              row
+            />
           </Grid>
         </CippFormCondition>
 


### PR DESCRIPTION
Introduce a new section for configuring Defender exclusions, allowing users to specify excluded extensions, paths, and processes. The input fields support both simple and key-value modes for flexibility.

- Update CippFormInputArray to have a simple input mode too, aswell as keeping the original keyValue mode the default, to have full backwards compatibility.
- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1545