### PR TITLE
Fix: Now button time selection rounding logic

### DIFF
--- a/src/components/CippComponents/CippFormComponent.jsx
+++ b/src/components/CippComponents/CippFormComponent.jsx
@@ -495,9 +495,10 @@ export const CippFormComponent = (props) => {
                     disabled={other?.disabled}
                     onClick={() => {
                       const now = new Date();
-                      // Round to nearest 15-minute interval
+                      // Always round down to the previous 15-minute mark, unless exactly on a 15-min mark
                       const minutes = now.getMinutes();
-                      const roundedMinutes = Math.round(minutes / 15) * 15;
+                      const roundedMinutes =
+                        minutes % 15 === 0 ? minutes : Math.floor(minutes / 15) * 15;
                       now.setMinutes(roundedMinutes, 0, 0); // Set seconds and milliseconds to 0
                       const unixTimestamp = Math.floor(now.getTime() / 1000);
                       field.onChange(unixTimestamp);


### PR DESCRIPTION
Adjust the rounding logic for time selection to consistently round down to the previous 15-minute mark, to ensure the scheduled taskes runs imidiately