### PR TITLE
Feat: Enhance tenant selection and add Deploy Policy button

### DIFF
--- a/src/pages/email/administration/contacts-template/deploy.jsx
+++ b/src/pages/email/administration/contacts-template/deploy.jsx
@@ -31,6 +31,7 @@ const Page = () => {
             name="selectedTenants"
             type="multiple"
             allTenants={true}
+            preselectedEnabled={true}
             validators={{ required: "At least one tenant must be selected" }}
           />
         </Grid>

--- a/src/pages/email/spamfilter/list-connectionfilter/add.jsx
+++ b/src/pages/email/spamfilter/list-connectionfilter/add.jsx
@@ -41,6 +41,7 @@ const AddPolicy = () => {
             name="selectedTenants"
             type="multiple"
             allTenants={true}
+            preselectedEnabled={true}
             validators={{ required: "At least one tenant must be selected" }}
           />
         </Grid>

--- a/src/pages/email/spamfilter/list-quarantine-policies/add.jsx
+++ b/src/pages/email/spamfilter/list-quarantine-policies/add.jsx
@@ -47,6 +47,7 @@ const AddPolicy = () => {
             name="selectedTenants"
             type="multiple"
             allTenants={true}
+            preselectedEnabled={true}
             validators={{ required: "At least one tenant must be selected" }}
           />
         </Grid>
@@ -72,73 +73,67 @@ const AddPolicy = () => {
         </Grid> */}
 
         <Divider sx={{ my: 2, width: "100%" }} />
-          <Grid xs={6} >
-            <CippFormComponent
-              type="textField"
-              label="Policy Name"
-              name="Name"
-              placeholder="Enter policy name"
-              formControl={formControl}
-              required={true}
-            />
-            <Divider sx={{ my: 2, width: "100%" }} />
-            <CippFormComponent
-              type="autoComplete"
-              label="Release Action Preference"
-              name="ReleaseActionPreference"
-              placeholder="Select release action preference"
-              formControl={formControl}
-              required={true}
-              multiple={false}
-              options={[
-                { label: "Release", value: "Release" },
-                { label: "Request Release", value: "RequestRelease" },
-              ]}
-            />
-          </Grid>
+        <Grid xs={6}>
+          <CippFormComponent
+            type="textField"
+            label="Policy Name"
+            name="Name"
+            placeholder="Enter policy name"
+            formControl={formControl}
+            required={true}
+          />
+          <Divider sx={{ my: 2, width: "100%" }} />
+          <CippFormComponent
+            type="autoComplete"
+            label="Release Action Preference"
+            name="ReleaseActionPreference"
+            placeholder="Select release action preference"
+            formControl={formControl}
+            required={true}
+            multiple={false}
+            options={[
+              { label: "Release", value: "Release" },
+              { label: "Request Release", value: "RequestRelease" },
+            ]}
+          />
+        </Grid>
 
-          <Grid xs={2}>
-            
-            <CippFormComponent
-              type="switch"
-              label="Delete"
-              name="Delete"
-              formControl={formControl}
-            />
-            <CippFormComponent
-              type="switch"
-              label="Preview"
-              name="Preview"
-              formControl={formControl}
-            />
-            <CippFormComponent
-              type="switch"
-              label="Block Sender"
-              name="BlockSender"
-              formControl={formControl}
-            />
-            <CippFormComponent
-              type="switch"
-              label="Allow Sender"
-              name="AllowSender"
-              formControl={formControl}
-            />
-          </Grid>
-          <Grid xs={4}>
-            <CippFormComponent
-              type="switch"
-              label="Quarantine Notification"
-              name="QuarantineNotification"
-              formControl={formControl}
-            />
-            <CippFormComponent
-              type="switch"
-              label="Include Messages From Blocked Sender Address"
-              name="IncludeMessagesFromBlockedSenderAddress"
-              formControl={formControl}
-              disabled={!quarantineNotification}
-            />
-          </Grid>
+        <Grid xs={2}>
+          <CippFormComponent type="switch" label="Delete" name="Delete" formControl={formControl} />
+          <CippFormComponent
+            type="switch"
+            label="Preview"
+            name="Preview"
+            formControl={formControl}
+          />
+          <CippFormComponent
+            type="switch"
+            label="Block Sender"
+            name="BlockSender"
+            formControl={formControl}
+          />
+          <CippFormComponent
+            type="switch"
+            label="Allow Sender"
+            name="AllowSender"
+            formControl={formControl}
+          />
+        </Grid>
+        <Grid xs={4}>
+          <CippFormComponent
+            type="switch"
+            label="Quarantine Notification"
+            name="QuarantineNotification"
+            formControl={formControl}
+          />
+          <CippFormComponent
+            type="switch"
+            label="Include Messages From Blocked Sender Address"
+            name="IncludeMessagesFromBlockedSenderAddress"
+            formControl={formControl}
+            disabled={!quarantineNotification}
+          />
+        </Grid>
       </Grid>
     </CippFormPage>
   );

--- a/src/pages/email/spamfilter/list-spamfilter/add.jsx
+++ b/src/pages/email/spamfilter/list-spamfilter/add.jsx
@@ -41,6 +41,7 @@ const AddPolicy = () => {
             name="selectedTenants"
             type="multiple"
             allTenants={true}
+            preselectedEnabled={true}
             validators={{ required: "At least one tenant must be selected" }}
           />
         </Grid>

--- a/src/pages/email/transport/list-connectors/add.jsx
+++ b/src/pages/email/transport/list-connectors/add.jsx
@@ -41,6 +41,7 @@ const AddPolicy = () => {
             name="selectedTenants"
             type="multiple"
             allTenants={true}
+            preselectedEnabled={true}
             validators={{ required: "At least one tenant must be selected" }}
           />
         </Grid>

--- a/src/pages/email/transport/list-rules/add.jsx
+++ b/src/pages/email/transport/list-rules/add.jsx
@@ -41,6 +41,7 @@ const AddPolicy = () => {
             name="selectedTenants"
             type="multiple"
             allTenants={true}
+            preselectedEnabled={true}
             validators={{ required: "At least one tenant must be selected" }}
           />
         </Grid>

--- a/src/pages/endpoint/MEM/add-policy/index.js
+++ b/src/pages/endpoint/MEM/add-policy/index.js
@@ -10,7 +10,7 @@ const Page = () => {
       title: "Step 1",
       description: "Tenant Selection",
       component: CippTenantStep,
-      componentProps: { type: "multiple", valueField: "customerId" },
+      componentProps: { type: "multiple" },
     },
     {
       title: "Step 2",

--- a/src/pages/endpoint/MEM/list-appprotection-policies/index.js
+++ b/src/pages/endpoint/MEM/list-appprotection-policies/index.js
@@ -1,10 +1,13 @@
 import { Layout as DashboardLayout } from "/src/layouts/index.js";
 import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx";
-import { Book } from "@mui/icons-material";
+import { Book, RocketLaunch } from "@mui/icons-material";
 import { TrashIcon } from "@heroicons/react/24/outline";
+import { PermissionButton } from "/src/utils/permissions.js";
+import Link from "next/link";
 
 const Page = () => {
   const pageTitle = "App Protection & Configuration Policies";
+  const cardButtonPermissions = ["Endpoint.MEM.ReadWrite"];
 
   const actions = [
     {
@@ -58,6 +61,16 @@ const Page = () => {
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={simpleColumns}
+      cardButton={
+        <PermissionButton
+          requiredPermissions={cardButtonPermissions}
+          component={Link}
+          href="/endpoint/MEM/add-policy"
+          startIcon={<RocketLaunch />}
+        >
+          Deploy Policy
+        </PermissionButton>
+      }
     />
   );
 };

--- a/src/pages/endpoint/MEM/list-compliance-policies/index.js
+++ b/src/pages/endpoint/MEM/list-compliance-policies/index.js
@@ -1,10 +1,13 @@
 import { Layout as DashboardLayout } from "/src/layouts/index.js";
 import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx";
-import { Book, LaptopChromebook } from "@mui/icons-material";
+import { Book, LaptopChromebook, RocketLaunch } from "@mui/icons-material";
 import { GlobeAltIcon, TrashIcon, UserIcon } from "@heroicons/react/24/outline";
+import { PermissionButton } from "/src/utils/permissions.js";
+import Link from "next/link";
 
 const Page = () => {
   const pageTitle = "Intune Compliance Policies";
+  const cardButtonPermissions = ["Endpoint.MEM.ReadWrite"];
 
   const actions = [
     {
@@ -99,6 +102,16 @@ const Page = () => {
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={simpleColumns}
+      cardButton={
+        <PermissionButton
+          requiredPermissions={cardButtonPermissions}
+          component={Link}
+          href="/endpoint/MEM/add-policy"
+          startIcon={<RocketLaunch />}
+        >
+          Deploy Policy
+        </PermissionButton>
+      }
     />
   );
 };

--- a/src/pages/endpoint/MEM/list-policies/index.js
+++ b/src/pages/endpoint/MEM/list-policies/index.js
@@ -1,10 +1,13 @@
 import { Layout as DashboardLayout } from "/src/layouts/index.js";
 import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx";
-import { Book, LaptopChromebook } from "@mui/icons-material";
+import { Book, LaptopChromebook, RocketLaunch } from "@mui/icons-material";
 import { GlobeAltIcon, TrashIcon, UserIcon } from "@heroicons/react/24/outline";
+import { PermissionButton } from "/src/utils/permissions.js";
+import Link from "next/link";
 
 const Page = () => {
   const pageTitle = "Configuration Policies";
+  const cardButtonPermissions = ["Endpoint.MEM.ReadWrite"];
 
   const actions = [
     {
@@ -98,6 +101,16 @@ const Page = () => {
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={simpleColumns}
+      cardButton={
+        <PermissionButton
+          requiredPermissions={cardButtonPermissions}
+          component={Link}
+          href="/endpoint/MEM/add-policy"
+          startIcon={<RocketLaunch />}
+        >
+          Deploy Policy
+        </PermissionButton>
+      }
     />
   );
 };

--- a/src/pages/endpoint/applications/list/add.jsx
+++ b/src/pages/endpoint/applications/list/add.jsx
@@ -118,6 +118,7 @@ const ApplicationDeploymentForm = () => {
             name="selectedTenants"
             type="multiple"
             allTenants={true}
+            preselectedEnabled={true}
             validators={{ required: "At least one tenant must be selected" }}
           />
         </Grid>

--- a/src/pages/endpoint/autopilot/add-status-page/index.js
+++ b/src/pages/endpoint/autopilot/add-status-page/index.js
@@ -1,6 +1,6 @@
 import { Divider } from "@mui/material";
 import { Grid } from "@mui/system";
-import { useForm} from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { Layout as DashboardLayout } from "/src/layouts/index.js";
 import CippFormPage from "/src/components/CippFormPages/CippFormPage";
 import CippFormComponent from "/src/components/CippComponents/CippFormComponent";
@@ -40,6 +40,7 @@ const Page = () => {
             name="selectedTenants"
             type="multiple"
             allTenants={true}
+            preselectedEnabled={true}
             validators={{ required: "At least one tenant must be selected" }}
           />
         </Grid>

--- a/src/pages/endpoint/autopilot/list-profiles/add.jsx
+++ b/src/pages/endpoint/autopilot/list-profiles/add.jsx
@@ -45,6 +45,7 @@ const AutopilotProfileForm = () => {
             name="selectedTenants"
             type="multiple"
             allTenants={true}
+            preselectedEnabled={true}
             validators={{ required: "At least one tenant must be selected" }}
           />
         </Grid>

--- a/src/pages/identity/administration/jit-admin/add.jsx
+++ b/src/pages/identity/administration/jit-admin/add.jsx
@@ -28,6 +28,7 @@ const Page = () => {
                 formControl={formControl}
                 type="single"
                 allTenants={false}
+                preselectedEnabled={true}
               />
             </Grid>
             <Grid size={{ md: 12, xs: 12 }}>

--- a/src/pages/identity/administration/jit-admin/add.jsx
+++ b/src/pages/identity/administration/jit-admin/add.jsx
@@ -29,6 +29,7 @@ const Page = () => {
                 type="single"
                 allTenants={false}
                 preselectedEnabled={true}
+                validators={{ required: "A tenant must be selected" }}
               />
             </Grid>
             <Grid size={{ md: 12, xs: 12 }}>

--- a/src/pages/security/defender/deployment/index.js
+++ b/src/pages/security/defender/deployment/index.js
@@ -33,6 +33,7 @@ const DeployDefenderForm = () => {
             name="selectedTenants"
             type="multiple"
             allTenants={true}
+            preselectedEnabled={true}
             validators={{ required: "At least one tenant must be selected" }}
           />
         </Grid>

--- a/src/pages/security/safelinks/safelinks-template/add.jsx
+++ b/src/pages/security/safelinks/safelinks-template/add.jsx
@@ -25,25 +25,26 @@ const DeploySafeLinksPolicyTemplate = () => {
       postUrl="/api/AddSafeLinksPolicyFromTemplate"
     >
       <Grid container spacing={2}>
-        <Grid size={{ xs:12 }}>
+        <Grid size={{ xs: 12 }}>
           <CippFormTenantSelector
             label="Select Tenants"
             formControl={formControl}
             name="selectedTenants"
             type="multiple"
             allTenants={true}
+            preselectedEnabled={true}
             validators={{ required: "At least one tenant must be selected" }}
           />
         </Grid>
         <Divider sx={{ my: 2, width: "100%" }} />
-        <Grid size={{ xs:12, md:12 }}>
+        <Grid size={{ xs: 12, md: 12 }}>
           <CippFormComponent
             type="autoComplete"
             label="Select a template"
             name="TemplateList"
             formControl={formControl}
             multiple={true}
-            creatable={false} 
+            creatable={false}
             api={{
               queryKey: `TemplateListSafeLinks`,
               labelField: "TemplateName",

--- a/src/pages/tenant/conditional/list-named-locations/add.jsx
+++ b/src/pages/tenant/conditional/list-named-locations/add.jsx
@@ -38,6 +38,8 @@ const DeployNamedLocationForm = () => {
             formControl={formControl}
             name="selectedTenants"
             type="multiple"
+            preselectedEnabled={true}
+            validators={{ required: "At least one tenant must be selected" }}
             allTenants={true}
           />
         </Grid>


### PR DESCRIPTION
- Remove the `valueField` prop for tenant selection in \src\pages\endpoint\MEM\add-policy\index.js, to fix tenant autoselect. From my testing this didnt break anything
- Enable preselected options across multiple forms
- Introduce a Deploy Policy button with appropriate permissions.