### PR TITLE
Feat: Add securityEnabled field switch to Edit Group

### DIFF
--- a/src/pages/identity/administration/groups/edit.jsx
+++ b/src/pages/identity/administration/groups/edit.jsx
@@ -98,6 +98,7 @@ const EditGroup = () => {
             }
             return null;
           })(),
+          securityEnabled: group.securityEnabled,
           // Initialize empty arrays for add/remove actions
           AddMember: [],
           RemoveMember: [],
@@ -112,6 +113,7 @@ const EditGroup = () => {
           allowExternal: groupInfo?.data?.allowExternal,
           sendCopies: groupInfo?.data?.sendCopies,
           hideFromOutlookClients: groupInfo?.data?.hideFromOutlookClients,
+          securityEnabled: group.securityEnabled,
         });
 
         // Reset the form with all values
@@ -125,7 +127,12 @@ const EditGroup = () => {
     const cleanedData = { ...formData };
 
     // Properties that should only be sent if they've changed from initial values
-    const changeDetectionProperties = ["allowExternal", "sendCopies", "hideFromOutlookClients"];
+    const changeDetectionProperties = [
+      "allowExternal",
+      "sendCopies",
+      "hideFromOutlookClients",
+      "securityEnabled",
+    ];
 
     changeDetectionProperties.forEach((property) => {
       if (formData[property] === initialValues[property]) {
@@ -402,6 +409,18 @@ const EditGroup = () => {
                     type="switch"
                     label="Hide group mailbox from Outlook"
                     name="hideFromOutlookClients"
+                    formControl={formControl}
+                    isFetching={groupInfo.isFetching}
+                    disabled={groupInfo.isFetching}
+                  />
+                </Grid>
+              )}
+              {groupType === "Microsoft 365" && (
+                <Grid size={{ xs: 12 }}>
+                  <CippFormComponent
+                    type="switch"
+                    label="Security Enabled"
+                    name="securityEnabled"
                     formControl={formControl}
                     isFetching={groupInfo.isFetching}
                     disabled={groupInfo.isFetching}


### PR DESCRIPTION
Introduce a new field for toggling the securityEnabled status in the EditGroup component, enhancing group management capabilities.

- Resolves part of #4480