### PR TITLE
Add Power Platform and Power BI portal support

### DIFF
--- a/src/components/CippComponents/CippSettingsSideBar.jsx
+++ b/src/components/CippComponents/CippSettingsSideBar.jsx
@@ -14,9 +14,10 @@ import CippFormComponent from "./CippFormComponent";
 import { ApiGetCall, ApiPostCall } from "../../api/ApiCall";
 import { getCippError } from "../../utils/get-cipp-error";
 import { useFormState } from "react-hook-form";
+import { useEffect } from "react";
 
 export const CippSettingsSideBar = (props) => {
-  const { formcontrol, ...others } = props;
+  const { formcontrol, initialUserType, ...others } = props;
   const { isDirty, isValid } = useFormState({ control: formcontrol.control });
 
   const currentUser = ApiGetCall({
@@ -28,6 +29,28 @@ export const CippSettingsSideBar = (props) => {
     url: "/api/ExecUserSettings",
     relatedQueryKeys: "userSettings",
   });
+
+  // Set the correct default value once we have the initial user type and current user data
+  useEffect(() => {
+    if (initialUserType && currentUser.data?.clientPrincipal?.userDetails) {
+      const defaultUserOption = initialUserType === "currentUser" 
+        ? {
+            label: "Current User",
+            value: currentUser.data.clientPrincipal.userDetails,
+          }
+        : {
+            label: "All Users",
+            value: "allUsers"
+          };
+      
+      // Only set if not already set to avoid infinite loops
+      const currentUserValue = formcontrol.getValues("user");
+      if (!currentUserValue || currentUserValue.value !== defaultUserOption.value) {
+        formcontrol.setValue("user", defaultUserOption);
+      }
+    }
+  }, [initialUserType, currentUser.data?.clientPrincipal?.userDetails, formcontrol]);
+
   const handleSaveChanges = () => {
     const formValues = formcontrol.getValues();
 
@@ -37,6 +60,21 @@ export const CippSettingsSideBar = (props) => {
       usageLocation: formValues.usageLocation,
       tablePageSize: formValues.tablePageSize,
       userAttributes: formValues.userAttributes,
+
+      // Portal Links Configuration
+      portalLinks: {
+        M365_Portal: formValues.portalLinks?.M365_Portal,
+        Exchange_Portal: formValues.portalLinks?.Exchange_Portal,
+        Entra_Portal: formValues.portalLinks?.Entra_Portal,
+        Teams_Portal: formValues.portalLinks?.Teams_Portal,
+        Azure_Portal: formValues.portalLinks?.Azure_Portal,
+        Intune_Portal: formValues.portalLinks?.Intune_Portal,
+        SharePoint_Admin: formValues.portalLinks?.SharePoint_Admin,
+        Security_Portal: formValues.portalLinks?.Security_Portal,
+        Compliance_Portal: formValues.portalLinks?.Compliance_Portal,
+        Power_Platform_Portal: formValues.portalLinks?.Power_Platform_Portal,
+        Power_BI_Portal: formValues.portalLinks?.Power_BI_Portal,
+      },
 
       // Offboarding Defaults
       offboardingDefaults: {
@@ -65,6 +103,24 @@ export const CippSettingsSideBar = (props) => {
     saveSettingsPost.mutate({ url: "/api/ExecUserSettings", data: shippedValues });
   };
 
+  // Create user options based on current user data
+  const getUserOptions = () => {
+    if (!currentUser.data?.clientPrincipal?.userDetails) {
+      return [];
+    }
+    
+    return [
+      { 
+        label: "Current User", 
+        value: currentUser.data.clientPrincipal.userDetails 
+      },
+      { 
+        label: "All Users", 
+        value: "allUsers" 
+      },
+    ];
+  };
+
   return (
     <>
       <Card>
@@ -81,15 +137,8 @@ export const CippSettingsSideBar = (props) => {
               disableClearable={true}
               name="user"
               formControl={formcontrol}
-              defaultValue={{
-                label: "Current User",
-                value: currentUser.data?.clientPrincipal?.userDetails,
-              }}
               multiple={false}
-              options={[
-                { label: "Current User", value: currentUser.data?.clientPrincipal?.userDetails },
-                { label: "All Users", value: "allUsers" },
-              ]}
+              options={getUserOptions()}
             />
 
             {saveSettingsPost.isError && (

--- a/src/components/CippComponents/CippTenantSelector.jsx
+++ b/src/components/CippComponents/CippTenantSelector.jsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import { CippAutoComplete } from "../CippComponents/CippAutocomplete";
 import { ApiGetCall } from "../../api/ApiCall";
 import { IconButton, SvgIcon, Tooltip, Box } from "@mui/material";
-import { FilePresent, Laptop, Mail, Refresh, Share, Shield, ShieldMoon } from "@mui/icons-material";
+import { FilePresent, Laptop, Mail, Refresh, Share, Shield, ShieldMoon, PrecisionManufacturing, BarChart } from "@mui/icons-material";
 import {
   BuildingOfficeIcon,
   GlobeAltIcon,
@@ -42,6 +42,111 @@ export const CippTenantSelector = (props) => {
     waiting: false,
     toast: true,
   });
+
+  // Filter portal actions based on user preferences
+  const getFilteredPortalActions = () => {
+    // Define all available portal actions with current tenant data
+    const allPortalActions = [
+      {
+        key: "M365_Portal",
+        label: "M365 Admin Portal",
+        link: `https://admin.cloud.microsoft/?delegatedOrg=${currentTenant?.addedFields?.initialDomainName}`,
+        icon: <GlobeAltIcon />,
+      },
+      {
+        key: "Exchange_Portal",
+        label: "Exchange Portal",
+        link: `https://admin.cloud.microsoft/exchange?delegatedOrg=${currentTenant?.addedFields?.initialDomainName}`,
+        icon: <Mail />,
+      },
+      {
+        key: "Entra_Portal",
+        label: "Entra Portal",
+        link: `https://entra.microsoft.com/${currentTenant?.value}`,
+        icon: <UsersIcon />,
+      },
+      {
+        key: "Teams_Portal",
+        label: "Teams Portal",
+        link: `https://admin.teams.microsoft.com/?delegatedOrg=${currentTenant?.addedFields?.initialDomainName}`,
+        icon: <FilePresent />,
+      },
+      {
+        key: "Azure_Portal",
+        label: "Azure Portal",
+        link: `https://portal.azure.com/${currentTenant?.value}`,
+        icon: <ServerIcon />,
+      },
+      {
+        key: "Intune_Portal",
+        label: "Intune Portal",
+        link: `https://intune.microsoft.com/${currentTenant?.value}`,
+        icon: <Laptop />,
+      },
+      {
+        key: "SharePoint_Admin",
+        label: "SharePoint Portal",
+        link: `/api/ListSharePointAdminUrl?tenantFilter=${currentTenant?.value}`,
+        icon: <Share />,
+        external: true,
+      },
+      {
+        key: "Security_Portal",
+        label: "Security Portal",
+        link: `https://security.microsoft.com/?tid=${currentTenant?.addedFields?.customerId}`,
+        icon: <Shield />,
+      },
+      {
+        key: "Compliance_Portal",
+        label: "Compliance Portal",
+        link: `https://purview.microsoft.com/?tid=${currentTenant?.addedFields?.customerId}`,
+        icon: <ShieldMoon />,
+      },
+      {
+        key: "Power_Platform_Portal",
+        label: "Power Platform Portal",
+        link: `https://admin.powerplatform.microsoft.com/account/login/${currentTenant?.addedFields?.customerId}`,
+        icon: <PrecisionManufacturing />,
+      },
+      {
+        key: "Power_BI_Portal",
+        label: "Power BI Portal",
+        link: `https://app.powerbi.com/admin-portal?ctid=${currentTenant?.addedFields?.customerId}`,
+        icon: <BarChart />,
+      },
+    ];
+
+    // Default to all links enabled (final fallback)
+    const defaultLinks = {
+      M365_Portal: true,
+      Exchange_Portal: true,
+      Entra_Portal: true,
+      Teams_Portal: true,
+      Azure_Portal: true,
+      Intune_Portal: true,
+      SharePoint_Admin: true,
+      Security_Portal: true,
+      Compliance_Portal: true,
+      Power_Platform_Portal: true,
+      Power_BI_Portal: true,
+    };
+
+    let portalLinks;
+    if (settings.UserSpecificSettings?.portalLinks) {
+      portalLinks = { ...defaultLinks, ...settings.UserSpecificSettings.portalLinks };
+    } else if (settings.portalLinks) {
+      portalLinks = { ...defaultLinks, ...settings.portalLinks };
+    } else {
+      portalLinks = defaultLinks;
+    }
+
+    const filteredActions = allPortalActions.filter(action => {
+      const isEnabled = portalLinks[action.key] === true;
+      return isEnabled;
+    });
+
+    return filteredActions;
+  };
 
   // This effect handles updates when the tenant is changed via dropdown selection
   useEffect(() => {
@@ -240,54 +345,7 @@ export const CippTenantSelector = (props) => {
           "onPremisesLastSyncDateTime",
           "onPremisesLastPasswordSyncDateTime",
         ]}
-        actions={[
-          {
-            label: "M365 Admin Portal",
-            link: `https://admin.cloud.microsoft/?delegatedOrg=${currentTenant?.addedFields?.initialDomainName}`,
-            icon: <GlobeAltIcon />,
-          },
-          {
-            label: "Exchange Portal",
-            link: `https://admin.cloud.microsoft/exchange?delegatedOrg=${currentTenant?.addedFields?.initialDomainName}`,
-            icon: <Mail />,
-          },
-          {
-            label: "Entra Portal",
-            link: `https://entra.microsoft.com/${currentTenant?.value}`,
-            icon: <UsersIcon />,
-          },
-          {
-            label: "Teams Portal",
-            link: `https://admin.teams.microsoft.com/?delegatedOrg=${currentTenant?.addedFields?.initialDomainName}`,
-            icon: <FilePresent />,
-          },
-          {
-            label: "Azure Portal",
-            link: `https://portal.azure.com/${currentTenant?.value}`,
-            icon: <ServerIcon />,
-          },
-          {
-            label: "Intune Portal",
-            link: `https://intune.microsoft.com/${currentTenant?.value}`,
-            icon: <Laptop />,
-          },
-          {
-            label: "SharePoint Portal",
-            link: `/api/ListSharePointAdminUrl?tenantFilter=${currentTenant?.value}`,
-            icon: <Share />,
-            external: true,
-          },
-          {
-            label: "Security Portal",
-            link: `https://security.microsoft.com/?tid=${currentTenant?.addedFields?.customerId}`,
-            icon: <Shield />,
-          },
-          {
-            label: "Compliance Portal",
-            link: `https://purview.microsoft.com/?tid=${currentTenant?.addedFields?.customerId}`,
-            icon: <ShieldMoon />,
-          },
-        ]}
+        actions={getFilteredPortalActions()}
       />
     </>
   );

--- a/src/components/CippComponents/CippTranslations.jsx
+++ b/src/components/CippComponents/CippTranslations.jsx
@@ -36,6 +36,8 @@ export const CippTranslations = {
   portal_security: "Security Portal",
   portal_compliance: "Compliance Portal",
   portal_sharepoint: "SharePoint Portal",
+  portal_platform: "Power Platform Portal",
+  portal_bi: "Power BI Portal",
   "@odata.type": "Type",
   roleDefinitionId: "GDAP Role",
   FromIP: "From IP",

--- a/src/components/bulk-actions-menu.js
+++ b/src/components/bulk-actions-menu.js
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import ChevronDownIcon from "@heroicons/react/24/outline/ChevronDownIcon";
 import { Button, Link, ListItemText, Menu, MenuItem, SvgIcon } from "@mui/material";
 import { usePopover } from "../hooks/use-popover";
-import { FilePresent, Laptop, Mail, Share, Shield, ShieldMoon } from "@mui/icons-material";
+import { FilePresent, Laptop, Mail, Share, Shield, ShieldMoon, PrecisionManufacturing, BarChart } from "@mui/icons-material";
 import { GlobeAltIcon, UsersIcon, ServerIcon } from "@heroicons/react/24/outline";
 
 function getIconByName(iconName) {
@@ -25,6 +25,10 @@ function getIconByName(iconName) {
       return <Shield />;
     case "ShieldMoon":
       return <ShieldMoon />;
+    case "PrecisionManufacturing":
+      return <PrecisionManufacturing />;
+    case "BarChart":
+      return <BarChart />;
     default:
       return null;
   }

--- a/src/data/portals.json
+++ b/src/data/portals.json
@@ -79,5 +79,23 @@
     "target": "_blank",
     "external": true,
     "icon": "ShieldMoon"
+  },
+  {
+    "label": "Power Platform Portal",
+    "name": "Power_Platform_Portal",
+    "url": "https://admin.powerplatform.microsoft.com/account/login/customerId",
+    "variable": "customerId",
+    "target": "_blank",
+    "external": true,
+    "icon": "PrecisionManufacturing"
+  },
+  {
+    "label": "Power BI Portal",
+    "name": "Power_BI_Portal",
+    "url": "https://app.powerbi.com/admin-portal?ctid=customerId",
+    "variable": "customerId",
+    "target": "_blank",
+    "external": true,
+    "icon": "BarChart"
   }
 ]

--- a/src/pages/cipp/preferences.js
+++ b/src/pages/cipp/preferences.js
@@ -4,16 +4,39 @@ import { Grid } from "@mui/system";
 import { Layout as DashboardLayout } from "/src/layouts/index.js";
 import { CippPropertyListCard } from "../../components/CippCards/CippPropertyListCard";
 import CippFormComponent from "../../components/CippComponents/CippFormComponent";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { useSettings } from "../../hooks/use-settings";
 import countryList from "../../data/countryList.json";
 import { CippSettingsSideBar } from "../../components/CippComponents/CippSettingsSideBar";
 import CippDevOptions from "/src/components/CippComponents/CippDevOptions";
 import { ApiGetCall } from "../../api/ApiCall";
 import { getCippFormatting } from "../../utils/get-cipp-formatting";
+import { useEffect, useState } from "react";
 
 const Page = () => {
   const settings = useSettings();
+  const [initialUserType, setInitialUserType] = useState(null);
+  
+  // Default portal links configuration
+  const defaultPortalLinks = {
+    M365_Portal: true,
+    Exchange_Portal: true,
+    Entra_Portal: true,
+    Teams_Portal: true,
+    Azure_Portal: true,
+    Intune_Portal: true,
+    SharePoint_Admin: true,
+    Security_Portal: true,
+    Compliance_Portal: true,
+    Power_Platform_Portal: true,
+    Power_BI_Portal: true,
+  };
+  
+  const auth = ApiGetCall({
+    url: "/api/me",
+    queryKey: "authmecipp",
+  });
+
   const cleanedSettings = { ...settings };
 
   if (cleanedSettings.offboardingDefaults?.keepCopy) {
@@ -21,12 +44,109 @@ const Page = () => {
     settings.handleUpdate(cleanedSettings);
   }
 
-  const formcontrol = useForm({ mode: "onChange", defaultValues: cleanedSettings });
+  // Determine if we have user-specific settings and set initial user type
+  useEffect(() => {
+    if (cleanedSettings && auth.data?.clientPrincipal?.userDetails && initialUserType === null) {
+      const hasUserSpecificSettings = cleanedSettings.UserSpecificSettings && 
+        Object.keys(cleanedSettings.UserSpecificSettings).length > 0;
+      
+      setInitialUserType(hasUserSpecificSettings ? "currentUser" : "allUsers");
+    }
+  }, [cleanedSettings, auth.data?.clientPrincipal?.userDetails, initialUserType]);
 
-  const auth = ApiGetCall({
-    url: "/api/me",
-    queryKey: "authmecipp",
+  // Set default portal links if they don't exist at global level
+  if (!cleanedSettings.portalLinks) {
+    cleanedSettings.portalLinks = defaultPortalLinks;
+  }
+
+  // Determine initial portal links based on user type
+  const getInitialPortalLinks = () => {
+    if (initialUserType === "currentUser" && cleanedSettings.UserSpecificSettings?.portalLinks) {
+      // Merge with defaults to ensure all keys exist
+      return { ...defaultPortalLinks, ...cleanedSettings.UserSpecificSettings.portalLinks };
+    }
+    
+    // Use global settings or defaults
+    return { ...defaultPortalLinks, ...cleanedSettings.portalLinks };
+  };
+
+  // Set up initial form values with proper user selector default
+  const initialFormValues = {
+    ...cleanedSettings,
+    user: initialUserType === "currentUser" ? {
+      label: "Current User",
+      value: auth.data?.clientPrincipal?.userDetails || "currentUser",
+    } : {
+      label: "All Users", 
+      value: "allUsers"
+    },
+    portalLinks: getInitialPortalLinks()
+  };
+
+  const formcontrol = useForm({ 
+    mode: "onChange", 
+    defaultValues: initialFormValues 
   });
+
+  // Watch the user selector to determine which settings to show
+  const selectedUser = useWatch({ 
+    control: formcontrol.control, 
+    name: "user" 
+  });
+
+  // Update form when initial user type is determined
+  useEffect(() => {
+    if (initialUserType !== null && auth.data?.clientPrincipal?.userDetails) {
+      const userValue = initialUserType === "currentUser" 
+        ? {
+            label: "Current User",
+            value: auth.data.clientPrincipal.userDetails,
+          }
+        : {
+            label: "All Users",
+            value: "allUsers"
+          };
+      
+      const newFormValues = {
+        ...cleanedSettings,
+        user: userValue,
+        portalLinks: getInitialPortalLinks()
+      };
+
+      // Reset the entire form with new values
+      formcontrol.reset(newFormValues);
+    }
+  }, [initialUserType, auth.data?.clientPrincipal?.userDetails]);
+
+  // Handle switching between user types
+  useEffect(() => {
+    if (selectedUser?.value && initialUserType !== null) {
+      const getPortalLinksForUserType = () => {
+        if (selectedUser.value === "allUsers") {
+          // Show global settings (root level)
+          return { ...defaultPortalLinks, ...cleanedSettings.portalLinks };
+        } else {
+          // Show user-specific settings if they exist, otherwise show global settings
+          const userSpecificLinks = cleanedSettings.UserSpecificSettings?.portalLinks;
+          const globalLinks = cleanedSettings.portalLinks;
+          return { ...defaultPortalLinks, ...globalLinks, ...userSpecificLinks };
+        }
+      };
+
+      const newPortalLinks = getPortalLinksForUserType();
+      const currentPortalLinks = formcontrol.getValues("portalLinks");
+      
+      // Only update if the portal links actually changed
+      if (JSON.stringify(currentPortalLinks) !== JSON.stringify(newPortalLinks)) {
+        // Reset form with updated portal links but preserve other values
+        const currentValues = formcontrol.getValues();
+        formcontrol.reset({
+          ...currentValues,
+          portalLinks: newPortalLinks
+        });
+      }
+    }
+  }, [selectedUser?.value, cleanedSettings, initialUserType]);
 
   const addedAttributes = [
     { value: "consentProvidedForMinor", label: "consentProvidedForMinor" },
@@ -48,9 +168,63 @@ const Page = () => {
     { value: "100", label: "100" },
     { value: "250", label: "250" },
   ];
+  
   const languageListOptions = countryList.map((language) => {
     return { value: language.Code, label: language.Name };
   });
+
+  // Portal links configuration
+  const portalLinksConfig = [
+    {
+      name: "portalLinks.M365_Portal",
+      label: "M365 Portal",
+    },
+    {
+      name: "portalLinks.Exchange_Portal",
+      label: "Exchange Portal",
+    },
+    {
+      name: "portalLinks.Entra_Portal",
+      label: "Entra Portal",
+    },
+    {
+      name: "portalLinks.Teams_Portal",
+      label: "Teams Portal",
+    },
+    {
+      name: "portalLinks.Azure_Portal",
+      label: "Azure Portal",
+    },
+    {
+      name: "portalLinks.Intune_Portal",
+      label: "Intune Portal",
+    },
+    {
+      name: "portalLinks.SharePoint_Admin",
+      label: "SharePoint Admin",
+    },
+    {
+      name: "portalLinks.Security_Portal",
+      label: "Security Portal",
+    },
+    {
+      name: "portalLinks.Compliance_Portal",
+      label: "Compliance Portal",
+    },
+    {
+      name: "portalLinks.Power_Platform_Portal",
+      label: "Power Platform Portal",
+    },
+    {
+      name: "portalLinks.Power_BI_Portal",
+      label: "Power BI Portal",
+    },
+  ];
+
+  // Don't render until we've determined the initial user type
+  if (initialUserType === null || !auth.data?.clientPrincipal?.userDetails) {
+    return <div>Loading...</div>;
+  }
 
   return (
     <>
@@ -293,8 +467,23 @@ const Page = () => {
                       showDivider={false}
                     />
 
-                    <CippSettingsSideBar formcontrol={formcontrol} />
+                    <CippSettingsSideBar formcontrol={formcontrol} initialUserType={initialUserType} />
                     <CippDevOptions />
+                    <CippPropertyListCard
+                      layout="two"
+                      showDivider={false}
+                      title="Portal Links Configuration"
+                      propertyItems={portalLinksConfig.map((portal) => ({
+                        label: portal.label,
+                        value: (
+                          <CippFormComponent
+                            type="switch"
+                            name={portal.name}
+                            formControl={formcontrol}
+                          />
+                        ),
+                      }))}
+                    />
                   </Stack>
                 </Grid>
               </Grid>

--- a/src/pages/tenant/administration/tenants/index.js
+++ b/src/pages/tenant/administration/tenants/index.js
@@ -18,6 +18,8 @@ const Page = () => {
     "portal_intune",
     "portal_security",
     "portal_compliance",
+    "portal_platform",
+    "portal_bi",
   ];
 
   const actions = [

--- a/src/utils/get-cipp-formatting.js
+++ b/src/utils/get-cipp-formatting.js
@@ -7,6 +7,8 @@ import {
   Shield,
   Description,
   GroupOutlined,
+  PrecisionManufacturing,
+  BarChart,
 } from "@mui/icons-material";
 import { Chip, Link, SvgIcon } from "@mui/material";
 import { Box } from "@mui/system";
@@ -54,6 +56,8 @@ export const getCippFormatting = (data, cellName, type, canReceive, flatten = tr
     portal_security: Shield,
     portal_compliance: CompassCalibration,
     portal_sharepoint: Description,
+    portal_platform: PrecisionManufacturing,
+    portal_bi: BarChart,
   };
 
   // Create a helper function to render chips with CollapsibleChipList


### PR DESCRIPTION
Introduces configuration and UI support for Power Platform and Power BI portals, including new portal link toggles in preferences, icon mapping, translations, and filtering logic based on user-specific or global settings. Updates relevant components and data files to enable these portals and ensure user preferences are respected throughout.

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1590
Resolves: https://github.com/KelvinTegelaar/CIPP/issues/4518