### PR TITLE
Feat: Add SendNotificationToUser option when adding calendar permissions

### DIFF
--- a/src/components/CippComponents/CippCalendarPermissionsDialog.jsx
+++ b/src/components/CippComponents/CippCalendarPermissionsDialog.jsx
@@ -17,6 +17,15 @@ const CippCalendarPermissionsDialog = ({ formHook, combinedOptions, isUserGroupL
     }
   }, [isEditor, formHook]);
 
+  // default SendNotificationToUser to false on mount
+  useEffect(() => {
+    formHook.setValue("SendNotificationToUser", false);
+  }, [formHook]);
+
+  // Only certain permission levels support sending a notification when calendar permissions are added
+  const notifyAllowed = ["AvailabilityOnly", "LimitedDetails", "Reviewer", "Editor"];
+  const isNotifyAllowed = notifyAllowed.includes(permissionLevel?.value ?? permissionLevel);
+
   return (
     <Stack spacing={3} sx={{ mt: 1 }}>
       <Box>
@@ -75,6 +84,29 @@ const CippCalendarPermissionsDialog = ({ formHook, combinedOptions, isUserGroupL
               name="CanViewPrivateItems"
               formControl={formHook}
               disabled={!isEditor}
+              sx={{ ml: 1.5, mt: 0, mb: 0 }}
+            />
+          </span>
+        </Tooltip>
+      </Box>
+
+      <Box>
+        <Tooltip
+          title={
+            !isNotifyAllowed
+              ? `Send notification is only supported for: ${notifyAllowed.join(", ")}`
+              : ""
+          }
+          followCursor
+          placement="right"
+        >
+          <span>
+            <CippFormComponent
+              type="switch"
+              label="Send notification"
+              name="SendNotificationToUser"
+              formControl={formHook}
+              disabled={!isNotifyAllowed}
               sx={{ ml: 1.5, mt: 0, mb: 0 }}
             />
           </span>

--- a/src/pages/identity/administration/users/user/exchange.jsx
+++ b/src/pages/identity/administration/users/user/exchange.jsx
@@ -235,6 +235,9 @@ const Page = () => {
         permission.CanViewPrivateItems = true;
       }
 
+      // Always include SendNotificationToUser explicitly (default false)
+      permission.SendNotificationToUser = Boolean(data.SendNotificationToUser);
+
       return {
         userID: graphUserRequest.data?.[0]?.userPrincipalName,
         tenantFilter: userSettingsDefaults.currentTenant,


### PR DESCRIPTION
Introduce handling for the SendNotificationToUser option in the calendar permissions dialog and user exchange page, ensuring it defaults to false and is only enabled for specific permission levels.

- Resolves #4538