### PR TITLE
Adjust spacing in standards templates and add a word for clarity

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,7 @@
     "CIPP",
     "CIPP-API",
     "Datto",
+    "DMARC",
     "Entra",
     "ESET",
     "GDAP",
@@ -31,8 +32,8 @@
     "Sherweb",
     "Syncro",
     "TERRL",
-    "Yubikey",
-    "DMARC"
+    "unconfigured",
+    "Yubikey"
   ],
   "ignoreWords": [
     "Addins",

--- a/src/components/CippStandards/CippStandardAccordion.jsx
+++ b/src/components/CippStandards/CippStandardAccordion.jsx
@@ -136,9 +136,7 @@ const CippStandardAccordion = ({
         // Set default autoRemediate if not set
         if (currentValues.autoRemediate === undefined) {
           formControl.setValue(`${standardName}.autoRemediate`, false);
-          formControl.setValue(`${standardName}.action`, [
-            { label: "Report", value: "Report" },
-          ]);
+          formControl.setValue(`${standardName}.action`, [{ label: "Report", value: "Report" }]);
         }
       });
     }
@@ -667,9 +665,9 @@ const CippStandardAccordion = ({
                   direction="row"
                   justifyContent="space-between"
                   alignItems="center"
-                  sx={{ p: 3 }}
+                  sx={{ p: 2 }}
                 >
-                  <Stack direction="row" alignItems="center" spacing={3}>
+                  <Stack direction="row" alignItems="center" spacing={2}>
                     <Avatar>
                       {standard.cat === "Global Standards" ? (
                         <Public />
@@ -687,7 +685,7 @@ const CippStandardAccordion = ({
                     </Avatar>
                     <Stack>
                       <Typography variant="h6">{accordionTitle}</Typography>
-                      <Stack direction="row" spacing={1} sx={{ my: 0.5 }}>
+                      <Stack direction="row" spacing={1} sx={{ my: 0.25 }}>
                         {/* Hide action chips in drift mode */}
                         {!isDriftMode && selectedActions && selectedActions?.length > 0 && (
                           <>

--- a/src/pages/tenant/standards/template.jsx
+++ b/src/pages/tenant/standards/template.jsx
@@ -31,7 +31,7 @@ const Page = () => {
   const [currentStep, setCurrentStep] = useState(0);
   const [hasDriftConflict, setHasDriftConflict] = useState(false);
   const initialStandardsRef = useRef({});
-  
+
   // Check if this is drift mode
   const isDriftMode = router.query.type === "drift";
 
@@ -264,9 +264,9 @@ const Page = () => {
   // Determine if save button should be disabled based on configuration
   const isSaveDisabled = isDriftMode
     ? currentStep < 3 || hasDriftConflict // For drift mode, only require steps 1, 3, and 4 (skip tenant requirement) and no drift conflicts
-    : (!_.get(watchForm, "tenantFilter") ||
-       !_.get(watchForm, "tenantFilter").length ||
-       currentStep < 3);
+    : !_.get(watchForm, "tenantFilter") ||
+      !_.get(watchForm, "tenantFilter").length ||
+      currentStep < 3;
 
   const actions = [];
 
@@ -291,9 +291,9 @@ const Page = () => {
   };
 
   return (
-    <Box sx={{ flexGrow: 1, py: 4 }}>
+    <Box sx={{ flexGrow: 1, py: 2 }}>
       <Container maxWidth={"xl"}>
-        <Stack spacing={4}>
+        <Stack spacing={2}>
           <Stack direction="row" justifyContent="space-between" alignItems="center">
             <Button
               color="inherit"
@@ -322,9 +322,12 @@ const Page = () => {
           >
             <Typography variant="h4">
               {editMode
-                ? (isDriftMode ? "Edit Drift Template" : "Edit Standards Template")
-                : (isDriftMode ? "Add Drift Template" : "Add Standards Template")
-              }
+                ? isDriftMode
+                  ? "Edit Drift Template"
+                  : "Edit Standards Template"
+                : isDriftMode
+                ? "Add Drift Template"
+                : "Add Standards Template"}
             </Typography>
             <Stack direction="row" spacing={2}>
               <Button
@@ -372,7 +375,7 @@ const Page = () => {
                 />
               </Grid>
               <Grid size={{ xs: 12, lg: 8 }} sx={{ height: "100%", overflow: "auto", pr: 1 }}>
-                <Stack spacing={3}>
+                <Stack spacing={2}>
                   {/* Show accordions based on selectedStandards (which is populated by API when editing) */}
                   {existingTemplate.isLoading ? (
                     <Skeleton variant="rectangular" height="700px" />


### PR DESCRIPTION
Change spacing to enhance information density and add a

# _**WORD**_

Helps a little with #4588 but not a real fix