### PR TITLE
Fix: Update placeholder text for DeviceNameTemplate input in CippAutopilotProfileDrawer

### DIFF
--- a/src/components/CippComponents/CippAutopilotProfileDrawer.jsx
+++ b/src/components/CippComponents/CippAutopilotProfileDrawer.jsx
@@ -147,7 +147,7 @@ export const CippAutopilotProfileDrawer = ({
               label="Unique Name Template"
               name="DeviceNameTemplate"
               formControl={formControl}
-              placeholder="Leave blank for none"
+              placeholder="Ex. %SERIAL%, %RAND:x% or leave blank for none"
             />
           </Grid>
 


### PR DESCRIPTION
Enhance the clarity of the placeholder text for the DeviceNameTemplate input to provide better guidance on acceptable formats.