### PR TITLE
Feat: Update default usage location handling in user forms

### DIFF
--- a/src/components/CippFormPages/CippAddEditUser.jsx
+++ b/src/components/CippFormPages/CippAddEditUser.jsx
@@ -164,7 +164,7 @@ const CippAddEditUser = (props) => {
           label="Usage Location"
           name="usageLocation"
           multiple={false}
-          defaultValue="US"
+          defaultValue={userSettingsDefaults?.usageLocation || "US"}
           options={countryList.map(({ Code, Name }) => ({
             label: Name,
             value: Code,

--- a/src/pages/cipp/preferences.js
+++ b/src/pages/cipp/preferences.js
@@ -254,7 +254,7 @@ const Page = () => {
                       title="General Settings"
                       propertyItems={[
                         {
-                          label: "Default new user usage location",
+                          label: "Default usage location for users",
                           value: (
                             <CippFormComponent
                               type="autoComplete"

--- a/src/pages/identity/administration/users/user/edit.jsx
+++ b/src/pages/identity/administration/users/user/edit.jsx
@@ -43,8 +43,13 @@ const Page = () => {
           defaultAttributes[attribute.label] = { Value: user?.[attribute.label] };
         });
       }
+
+      // Use fallback for usageLocation if user's usageLocation is null/undefined
+      const usageLocation = user?.usageLocation || userSettingsDefaults?.usageLocation || null;
+
       formControl.reset({
         ...user,
+        usageLocation: usageLocation,
         defaultAttributes: defaultAttributes,
         tenantFilter: userSettingsDefaults.currentTenant,
         licenses: user.assignedLicenses.map((license) => ({
@@ -104,7 +109,8 @@ const Page = () => {
     >
       {userRequest.isSuccess && userRequest.data?.[0]?.onPremisesSyncEnabled && (
         <Alert severity="error" sx={{ mb: 1 }}>
-          This user is synced from on-premises Active Directory. Changes should be made in the on-premises environment instead.
+          This user is synced from on-premises Active Directory. Changes should be made in the
+          on-premises environment instead.
         </Alert>
       )}
       <CippFormPage


### PR DESCRIPTION
Improve handling of default usage location in user forms and rephrase the setting label for clarity.
Auto uses the UsageLocation usersetting if the usageLocation on the user you're editing is null.
Done so its nicer to put licenses on users created via methods that dont set the usageLocation, like creating room mailboxes and such.