### PR TITLE
Feat: Remove invalid switch option and add Install windows updates option in AutopilotStatusPage standard

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -4437,14 +4437,14 @@
       },
       {
         "type": "switch",
-        "name": "standards.AutopilotStatusPage.BlockDevice",
-        "label": "Block device usage during setup",
+        "name": "standards.AutopilotStatusPage.InstallWindowsUpdates",
+        "label": "Install Windows Updates during setup",
         "defaultValue": true
       },
       {
         "type": "switch",
-        "name": "standards.AutopilotStatusPage.AllowRetry",
-        "label": "Allow retry",
+        "name": "standards.AutopilotStatusPage.BlockDevice",
+        "label": "Block device usage during setup",
         "defaultValue": true
       },
       {


### PR DESCRIPTION
Remove invalid switch option and add Install windows updates option

I forgot that we have a standard for this too lol

- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1610