### PR TITLE
Feat: Enhance Defender deployment page with new fields and adjustments

### DIFF
--- a/src/pages/security/defender/deployment/index.js
+++ b/src/pages/security/defender/deployment/index.js
@@ -217,6 +217,17 @@ const DeployDefenderForm = () => {
                   name="Policy.LowCPU"
                   formControl={formControl}
                 />
+                <CippFormComponent
+                  type="number"
+                  label="Avg CPU Load Factor(%)"
+                  name="Policy.AvgCPULoadFactor"
+                  formControl={formControl}
+                  defaultValue={50}
+                  validators={{
+                    min: { value: 0, message: "Value must be at least 0" },
+                    max: { value: 100, message: "Value cannot exceed 100" },
+                  }}
+                />
               </Grid>
               <Grid size={{ md: 6, xs: 12 }}>
                 <CippFormComponent
@@ -273,6 +284,21 @@ const DeployDefenderForm = () => {
                   name="Policy.DisableCatchupQuickScan"
                   formControl={formControl}
                 />
+                <CippFormComponent
+                  type="autoComplete"
+                  label="Cloud Block Level"
+                  multiple={false}
+                  name="Policy.CloudBlockLevel"
+                  options={[
+                    { label: "Default", value: "0" },
+                    { label: "High", value: "2" },
+                    { label: "High Plus", value: "4" },
+                    { label: "Zero Tolerance", value: "6" },
+                  ]}
+                  formControl={formControl}
+                  validators={{}}
+                />
+
               </Grid>
 
               {/* Assign to Group */}

--- a/src/pages/security/defender/deployment/index.js
+++ b/src/pages/security/defender/deployment/index.js
@@ -276,6 +276,18 @@ const DeployDefenderForm = () => {
                   formControl={formControl}
                 />
                 <CippFormComponent
+                  type="number"
+                  label="Signature Update Interval (hours)"
+                  name="Policy.SignatureUpdateInterval"
+                  formControl={formControl}
+                  defaultValue={8}
+                  validators={{
+                    min: { value: 0, message: "Value must be at least 0" },
+                    max: { value: 24, message: "Value cannot exceed 24" },
+                  }}
+                  sx={{ my: 1 }}
+                />
+                <CippFormComponent
                   type="switch"
                   label="Disable Catchup Full Scan"
                   name="Policy.DisableCatchupFullScan"

--- a/src/pages/security/defender/deployment/index.js
+++ b/src/pages/security/defender/deployment/index.js
@@ -255,16 +255,18 @@ const DeployDefenderForm = () => {
                   name="Policy.AllowUI"
                   formControl={formControl}
                 />
+
                 <CippFormComponent
-                  type="switch"
-                  label="Enable Network Protection in Block Mode"
-                  name="Policy.NetworkProtectionBlock"
-                  formControl={formControl}
-                />
-                <CippFormComponent
-                  type="switch"
-                  label="Enable Network Protection in Audit Mode"
-                  name="Policy.NetworkProtectionAudit"
+                  type="autoComplete"
+                  label="Enable Network Protection"
+                  name="Policy.EnableNetworkProtection"
+                  multiple={false}
+                  options={[
+                    { label: "Disabled (Default)", value: "0" },
+                    { label: "Enabled (block mode)", value: "1" },
+                    { label: "Enabled (audit mode)", value: "2" },
+                  ]}
+                  sx={{ my: 1 }}
                   formControl={formControl}
                 />
                 <CippFormComponent

--- a/src/pages/security/defender/deployment/index.js
+++ b/src/pages/security/defender/deployment/index.js
@@ -235,6 +235,25 @@ const DeployDefenderForm = () => {
                   name="Policy.MeteredConnectionUpdates"
                   formControl={formControl}
                 />
+                <CippFormComponent
+                  type="autoComplete"
+                  label="Allow On Access Protection"
+                  name="Policy.AllowOnAccessProtection"
+                  multiple={false}
+                  creatable={false}
+                  options={[
+                    { label: "Not Allowed", value: "0" },
+                    { label: "Allowed (Default)", value: "1" },
+                  ]}
+                  sx={{ my: 1 }}
+                  formControl={formControl}
+                />
+                <CippFormComponent
+                  type="switch"
+                  label="Disable Local Admin Merge"
+                  name="Policy.DisableLocalAdminMerge"
+                  formControl={formControl}
+                />
               </Grid>
               <Grid size={{ md: 6, xs: 12 }}>
                 <CippFormComponent
@@ -267,6 +286,7 @@ const DeployDefenderForm = () => {
                   label="Enable Network Protection"
                   name="Policy.EnableNetworkProtection"
                   multiple={false}
+                  creatable={false}
                   options={[
                     { label: "Disabled (Default)", value: "0" },
                     { label: "Enabled (block mode)", value: "1" },
@@ -309,6 +329,7 @@ const DeployDefenderForm = () => {
                   type="autoComplete"
                   label="Cloud Block Level"
                   multiple={false}
+                  creatable={false}
                   name="Policy.CloudBlockLevel"
                   options={[
                     { label: "Default", value: "0" },

--- a/src/pages/security/defender/deployment/index.js
+++ b/src/pages/security/defender/deployment/index.js
@@ -227,6 +227,7 @@ const DeployDefenderForm = () => {
                     min: { value: 0, message: "Value must be at least 0" },
                     max: { value: 100, message: "Value cannot exceed 100" },
                   }}
+                  sx={{ my: 1 }}
                 />
               </Grid>
               <Grid size={{ md: 6, xs: 12 }}>
@@ -296,9 +297,20 @@ const DeployDefenderForm = () => {
                     { label: "Zero Tolerance", value: "6" },
                   ]}
                   formControl={formControl}
-                  validators={{}}
+                  sx={{ my: 1 }}
                 />
-
+                <CippFormComponent
+                  type="number"
+                  label="Cloud Extended Timeout (seconds)"
+                  name="Policy.CloudExtendedTimeout"
+                  formControl={formControl}
+                  defaultValue={50}
+                  validators={{
+                    min: { value: 0, message: "Value must be at least 0" },
+                    max: { value: 50, message: "Value cannot exceed 50" },
+                  }}
+                  sx={{ my: 1 }}
+                />
               </Grid>
 
               {/* Assign to Group */}
@@ -572,8 +584,6 @@ const DeployDefenderForm = () => {
             </Grid>
           </Grid>
         </CippFormCondition>
-
-        {/* Remove the Review and Confirm section as per your request */}
       </Grid>
     </CippFormPage>
   );

--- a/src/pages/security/defender/deployment/index.js
+++ b/src/pages/security/defender/deployment/index.js
@@ -222,12 +222,18 @@ const DeployDefenderForm = () => {
                   label="Avg CPU Load Factor(%)"
                   name="Policy.AvgCPULoadFactor"
                   formControl={formControl}
-                  defaultValue={50}
+                  placeholder="50"
                   validators={{
                     min: { value: 0, message: "Value must be at least 0" },
                     max: { value: 100, message: "Value cannot exceed 100" },
                   }}
                   sx={{ my: 1 }}
+                />
+                <CippFormComponent
+                  type="switch"
+                  label="Allow Metered Connection Updates"
+                  name="Policy.MeteredConnectionUpdates"
+                  formControl={formControl}
                 />
               </Grid>
               <Grid size={{ md: 6, xs: 12 }}>
@@ -280,7 +286,7 @@ const DeployDefenderForm = () => {
                   label="Signature Update Interval (hours)"
                   name="Policy.SignatureUpdateInterval"
                   formControl={formControl}
-                  defaultValue={8}
+                  placeholder="8"
                   validators={{
                     min: { value: 0, message: "Value must be at least 0" },
                     max: { value: 24, message: "Value cannot exceed 24" },
@@ -318,7 +324,7 @@ const DeployDefenderForm = () => {
                   label="Cloud Extended Timeout (seconds)"
                   name="Policy.CloudExtendedTimeout"
                   formControl={formControl}
-                  defaultValue={50}
+                  placeholder="0"
                   validators={{
                     min: { value: 0, message: "Value must be at least 0" },
                     max: { value: 50, message: "Value cannot exceed 50" },

--- a/src/pages/security/defender/deployment/index.js
+++ b/src/pages/security/defender/deployment/index.js
@@ -207,14 +207,20 @@ const DeployDefenderForm = () => {
                 />
                 <CippFormComponent
                   type="switch"
-                  label="Allow Intrusion Prevention System"
-                  name="Policy.AllowIPS"
+                  label="Enable Low CPU priority"
+                  name="Policy.LowCPU"
                   formControl={formControl}
                 />
                 <CippFormComponent
                   type="switch"
-                  label="Enable Low CPU priority"
-                  name="Policy.LowCPU"
+                  label="Allow Metered Connection Updates"
+                  name="Policy.MeteredConnectionUpdates"
+                  formControl={formControl}
+                />
+                <CippFormComponent
+                  type="switch"
+                  label="Disable Local Admin Merge"
+                  name="Policy.DisableLocalAdminMerge"
                   formControl={formControl}
                 />
                 <CippFormComponent
@@ -230,12 +236,6 @@ const DeployDefenderForm = () => {
                   sx={{ my: 1 }}
                 />
                 <CippFormComponent
-                  type="switch"
-                  label="Allow Metered Connection Updates"
-                  name="Policy.MeteredConnectionUpdates"
-                  formControl={formControl}
-                />
-                <CippFormComponent
                   type="autoComplete"
                   label="Allow On Access Protection"
                   name="Policy.AllowOnAccessProtection"
@@ -249,9 +249,18 @@ const DeployDefenderForm = () => {
                   formControl={formControl}
                 />
                 <CippFormComponent
-                  type="switch"
-                  label="Disable Local Admin Merge"
-                  name="Policy.DisableLocalAdminMerge"
+                  type="autoComplete"
+                  label="Submit Samples Consent"
+                  name="Policy.SubmitSamplesConsent"
+                  multiple={false}
+                  creatable={false}
+                  options={[
+                    { label: "Always prompt", value: "0" },
+                    { label: "Send safe samples automatically (Default)", value: "1" },
+                    { label: "Never send", value: "2" },
+                    { label: "Send all samples automatically", value: "3" },
+                  ]}
+                  sx={{ my: 1 }}
                   formControl={formControl}
                 />
               </Grid>
@@ -270,7 +279,7 @@ const DeployDefenderForm = () => {
                 />
                 <CippFormComponent
                   type="switch"
-                  label="Allow scanning of mapped drives"
+                  label="Allow Scanning Network Files"
                   name="Policy.AllowNetwork"
                   formControl={formControl}
                 />
@@ -278,21 +287,6 @@ const DeployDefenderForm = () => {
                   type="switch"
                   label="Allow users to access UI"
                   name="Policy.AllowUI"
-                  formControl={formControl}
-                />
-
-                <CippFormComponent
-                  type="autoComplete"
-                  label="Enable Network Protection"
-                  name="Policy.EnableNetworkProtection"
-                  multiple={false}
-                  creatable={false}
-                  options={[
-                    { label: "Disabled (Default)", value: "0" },
-                    { label: "Enabled (block mode)", value: "1" },
-                    { label: "Enabled (audit mode)", value: "2" },
-                  ]}
-                  sx={{ my: 1 }}
                   formControl={formControl}
                 />
                 <CippFormComponent
@@ -326,6 +320,32 @@ const DeployDefenderForm = () => {
                   formControl={formControl}
                 />
                 <CippFormComponent
+                  type="number"
+                  label="Cloud Extended Timeout (seconds)"
+                  name="Policy.CloudExtendedTimeout"
+                  formControl={formControl}
+                  placeholder="0"
+                  validators={{
+                    min: { value: 0, message: "Value must be at least 0" },
+                    max: { value: 50, message: "Value cannot exceed 50" },
+                  }}
+                  sx={{ my: 1 }}
+                />
+                <CippFormComponent
+                  type="autoComplete"
+                  label="Enable Network Protection"
+                  name="Policy.EnableNetworkProtection"
+                  multiple={false}
+                  creatable={false}
+                  options={[
+                    { label: "Disabled (Default)", value: "0" },
+                    { label: "Enabled (block mode)", value: "1" },
+                    { label: "Enabled (audit mode)", value: "2" },
+                  ]}
+                  sx={{ my: 1 }}
+                  formControl={formControl}
+                />
+                <CippFormComponent
                   type="autoComplete"
                   label="Cloud Block Level"
                   multiple={false}
@@ -340,39 +360,142 @@ const DeployDefenderForm = () => {
                   formControl={formControl}
                   sx={{ my: 1 }}
                 />
+              </Grid>
+            </Grid>
+          </Grid>
+
+          <Divider sx={{ my: 3 }} />
+
+          {/* Threat Remediation Actions Section */}
+          <Grid size={{ xs: 12 }}>
+            <Typography variant="h6" sx={{ mb: 2 }}>
+              Threat Remediation Actions
+            </Typography>
+            <Grid container spacing={2}>
+              <Grid size={{ md: 6, xs: 12 }}>
                 <CippFormComponent
-                  type="number"
-                  label="Cloud Extended Timeout (seconds)"
-                  name="Policy.CloudExtendedTimeout"
+                  type="autoComplete"
+                  label="Low severity threats"
+                  name="Policy.Remediation.Low"
+                  multiple={false}
+                  creatable={false}
+                  options={[
+                    {
+                      label: "Clean. Service tries to recover files and try to disinfect.",
+                      value: "clean",
+                    },
+                    { label: "Quarantine. Moves files to quarantine.", value: "quarantine" },
+                    { label: "Remove. Removes files from system.", value: "remove" },
+                    { label: "Allow. Allows file/does none of the above actions.", value: "allow" },
+                    {
+                      label:
+                        "User defined. Requires user to make a decision on which action to take.",
+                      value: "userDefined",
+                    },
+                    { label: "Block. Blocks file execution.", value: "block" },
+                  ]}
                   formControl={formControl}
-                  placeholder="0"
-                  validators={{
-                    min: { value: 0, message: "Value must be at least 0" },
-                    max: { value: 50, message: "Value cannot exceed 50" },
-                  }}
+                  sx={{ my: 1 }}
+                />
+                <CippFormComponent
+                  type="autoComplete"
+                  label="Moderate severity threats"
+                  name="Policy.Remediation.Moderate"
+                  multiple={false}
+                  creatable={false}
+                  options={[
+                    {
+                      label: "Clean. Service tries to recover files and try to disinfect.",
+                      value: "clean",
+                    },
+                    { label: "Quarantine. Moves files to quarantine.", value: "quarantine" },
+                    { label: "Remove. Removes files from system.", value: "remove" },
+                    { label: "Allow. Allows file/does none of the above actions.", value: "allow" },
+                    {
+                      label:
+                        "User defined. Requires user to make a decision on which action to take.",
+                      value: "userDefined",
+                    },
+                    { label: "Block. Blocks file execution.", value: "block" },
+                  ]}
+                  formControl={formControl}
                   sx={{ my: 1 }}
                 />
               </Grid>
-
-              {/* Assign to Group */}
-              <Grid size={{ xs: 12 }}>
-                <Typography variant="subtitle1">Assign to Group</Typography>
+              <Grid size={{ md: 6, xs: 12 }}>
                 <CippFormComponent
-                  type="radio"
-                  label=""
-                  name="Policy.AssignTo"
+                  type="autoComplete"
+                  label="High severity threats"
+                  name="Policy.Remediation.High"
+                  multiple={false}
+                  creatable={false}
                   options={[
-                    { label: "Do not assign", value: "none" },
-                    { label: "Assign to all users", value: "allLicensedUsers" },
-                    { label: "Assign to all devices", value: "AllDevices" },
-                    { label: "Assign to all users and devices", value: "AllDevicesAndUsers" },
+                    {
+                      label: "Clean. Service tries to recover files and try to disinfect.",
+                      value: "clean",
+                    },
+                    { label: "Quarantine. Moves files to quarantine.", value: "quarantine" },
+                    { label: "Remove. Removes files from system.", value: "remove" },
+                    { label: "Allow. Allows file/does none of the above actions.", value: "allow" },
+                    {
+                      label:
+                        "User defined. Requires user to make a decision on which action to take.",
+                      value: "userDefined",
+                    },
+                    { label: "Block. Blocks file execution.", value: "block" },
                   ]}
                   formControl={formControl}
-                  validators={{ required: "Assignment must be selected" }}
-                  row
+                  sx={{ my: 1 }}
+                />
+                <CippFormComponent
+                  type="autoComplete"
+                  label="Severe threats"
+                  name="Policy.Remediation.Severe"
+                  multiple={false}
+                  creatable={false}
+                  options={[
+                    {
+                      label: "Clean. Service tries to recover files and try to disinfect.",
+                      value: "clean",
+                    },
+                    { label: "Quarantine. Moves files to quarantine.", value: "quarantine" },
+                    { label: "Remove. Removes files from system.", value: "remove" },
+                    { label: "Allow. Allows file/does none of the above actions.", value: "allow" },
+                    {
+                      label:
+                        "User defined. Requires user to make a decision on which action to take.",
+                      value: "userDefined",
+                    },
+                    { label: "Block. Blocks file execution.", value: "block" },
+                  ]}
+                  formControl={formControl}
+                  sx={{ my: 1 }}
                 />
               </Grid>
             </Grid>
+          </Grid>
+
+          <Divider sx={{ my: 3 }} />
+
+          {/* Assignment Section */}
+          <Grid size={{ xs: 12 }}>
+            <Typography variant="h6" sx={{ mb: 2 }}>
+              Policy Assignment
+            </Typography>
+            <CippFormComponent
+              type="radio"
+              label=""
+              name="Policy.AssignTo"
+              options={[
+                { label: "Do not assign", value: "none" },
+                { label: "Assign to all users", value: "allLicensedUsers" },
+                { label: "Assign to all devices", value: "AllDevices" },
+                { label: "Assign to all users and devices", value: "AllDevicesAndUsers" },
+              ]}
+              formControl={formControl}
+              validators={{ required: "Assignment must be selected" }}
+              row
+            />
           </Grid>
         </CippFormCondition>
 


### PR DESCRIPTION
Introduce multiple new fields to the DeployDefenderForm, including Avg CPU Load Factor, Cloud Block Level, and Signature Update Interval. Adjust spacing and add a switch for Allow Metered Connection Updates. Fix issues with network protection audit mode and remove deprecated options while reordering existing fields for better usability.