### PR TITLE
Feat: Add "None" option to permission levels in Cal and Contact dialogs

### DIFF
--- a/src/components/CippComponents/CippCalendarPermissionsDialog.jsx
+++ b/src/components/CippComponents/CippCalendarPermissionsDialog.jsx
@@ -66,6 +66,7 @@ const CippCalendarPermissionsDialog = ({ formHook, combinedOptions, isUserGroupL
             { value: "Reviewer", label: "Reviewer" },
             { value: "LimitedDetails", label: "Limited Details" },
             { value: "AvailabilityOnly", label: "Availability Only" },
+            { value: "None", label: "None" },
           ]}
           multiple={false}
           formControl={formHook}

--- a/src/components/CippComponents/CippContactPermissionsDialog.jsx
+++ b/src/components/CippComponents/CippContactPermissionsDialog.jsx
@@ -58,6 +58,7 @@ const CippContactPermissionsDialog = ({ formHook, combinedOptions, isUserGroupLo
             { value: "Reviewer", label: "Reviewer" },
             { value: "LimitedDetails", label: "Limited Details" },
             { value: "AvailabilityOnly", label: "Availability Only" },
+            { value: "None", label: "None" },
           ]}
           multiple={false}
           formControl={formHook}


### PR DESCRIPTION
Introduce a "None" option for permission levels in both calendar and contact dialogs to enhance user flexibility.

- Resolves #4662