### PR TITLE
Clarify help text for excludeGroup field

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -4652,7 +4652,7 @@
         "label": "Exclude Groups",
         "type": "textField",
         "required": false,
-        "helpText": "Enter the group name to exclude from the assignment. Wildcards are allowed."
+        "helpText": "Enter the group name(s) to exclude from the assignment. Wildcards are allowed. Multiple group names are comma-seperated."
       }
     ]
   },


### PR DESCRIPTION
Updated help text to clarify input format for multiple exclude groups.