### PR TITLE
fix: Add boolean sorting function for status columns in tables

### DIFF
--- a/src/components/CippTable/CippDataTable.js
+++ b/src/components/CippTable/CippDataTable.js
@@ -473,6 +473,23 @@ export const CippDataTable = (props) => {
         }
         return aVal - bVal;
       },
+      boolean: (a, b, id) => {
+        const aVal = a?.original?.[id] ?? null;
+        const bVal = b?.original?.[id] ?? null;
+        if (aVal === null && bVal === null) {
+          return 0;
+        }
+        if (aVal === null) {
+          return 1;
+        }
+        if (bVal === null) {
+          return -1;
+        }
+        // Convert to numbers: true = 1, false = 0
+        const aNum = aVal === true ? 1 : 0;
+        const bNum = bVal === true ? 1 : 0;
+        return aNum - bNum;
+      },
     },
     filterFns: {
       notContains: (row, columnId, value) => {

--- a/src/utils/get-cipp-filter-variant.js
+++ b/src/utils/get-cipp-filter-variant.js
@@ -97,7 +97,7 @@ export const getCippFilterVariant = (providedColumnKeys, arg) => {
   if (typeOf === "boolean") {
     return {
       filterVariant: "select",
-      sortingFn: "alphanumeric",
+      sortingFn: "boolean",
       filterFn: "equals",
     };
   }


### PR DESCRIPTION
- Fixes "s.sortingFn is not a function" error when sorting GraphStatus/ExchangeStatus columns
- Add boolean sorting function to CippDataTable component
- Update get-cipp-filter-variant to use boolean sorting for boolean columns