### PR TITLE
Update Azurite launch task to ensure en-US locale.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,6 +10,12 @@
       "type": "shell",
       "command": "azurite --location ../",
       "isBackground": true,
+      "options": {
+        "env": {
+          "LC_ALL": "en-US.UTF-8",
+          "LANG": "en-US"
+        }
+      },
       "problemMatcher": {
         "pattern": [
           {


### PR DESCRIPTION
This ensure correct timestamp formatting in tables during dev - regardless of local system formatting.

Azurite was using the system's default locale, producing datetime strings like 2025-09-29T19.14.01Z instead of the expected ISO 8601 format 2025-09-29T19:14:01Z on my system.