### PR TITLE
Add internal reference field to GDAP invites

### DIFF
--- a/src/pages/tenant/gdap-management/invites/add.js
+++ b/src/pages/tenant/gdap-management/invites/add.js
@@ -67,6 +67,7 @@ const Page = () => {
     if (!formControl.formState.isValid) return;
     const eachInvite = Array.from({ length: values.inviteCount }, (_, i) => ({
       roleMappings: values.roleMappings.value,
+      Reference: values.Reference,
     }));
 
     addInvites.mutate({
@@ -180,13 +181,22 @@ const Page = () => {
                 }}
               />
             </Grid>
-            <Grid size={{ xs: 12, md: 6 }}>
+            <Grid size={{ xs: 12, md: 2 }}>
               <CippFormComponent
                 type="number"
                 name="inviteCount"
                 label="Number of Invites to generate"
                 formControl={formControl}
                 required={true}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, md: 4 }}>
+              <CippFormComponent
+                type="textField"
+                name="Reference"
+                label="Internal Reference Message"
+                formControl={formControl}
+                required={false}
               />
             </Grid>
             {selectedTemplate?.value && (

--- a/src/pages/tenant/gdap-management/invites/index.js
+++ b/src/pages/tenant/gdap-management/invites/index.js
@@ -5,13 +5,34 @@ import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx"
 import { Button } from "@mui/material";
 import { Add } from "@mui/icons-material";
 import Link from "next/link";
-import { TrashIcon } from "@heroicons/react/24/outline";
+import { TrashIcon, PencilIcon } from "@heroicons/react/24/outline";
 
 const pageTitle = "GDAP Invites";
-const simpleColumns = ["Timestamp", "RowKey", "InviteUrl", "OnboardingUrl", "RoleMappings"];
+const simpleColumns = ["Timestamp", "RowKey", "Reference", "Technician", "InviteUrl", "OnboardingUrl", "RoleMappings"];
 const apiUrl = "/api/ListGDAPInvite";
 
 const actions = [
+  {
+    label: "Update Internal Reference",
+    url: "/api/ExecGDAPInvite",
+    type: "POST",
+    icon: <PencilIcon />,
+    confirmText: "Are you sure you want to update the internal reference for this invite?",
+    data: {
+      Action: "Update",
+      InviteId: "RowKey",
+    },
+    fields: [
+      {
+        label: "Internal Reference",
+        name: "Reference",
+        type: "textField",
+        required: false,
+        helperText: "Enter an internal reference/note for this GDAP invite (e.g., client name, ticket number).",
+      },
+    ],
+    relatedQueryKeys: ["ListGDAPInvite"],
+  },
   {
     label: "Delete Invite",
     url: "/api/ExecGDAPInvite",
@@ -23,6 +44,7 @@ const actions = [
       Action: "Delete",
       InviteId: "RowKey",
     },
+    relatedQueryKeys: ["ListGDAPInvite"],
   },
 ];
 


### PR DESCRIPTION
Introduces a 'Reference' field to the invite creation form and displays it in the invites table. Also adds an action to update the internal reference for existing invites, improving tracking and context for each invite.

Resolves: https://github.com/KelvinTegelaar/CIPP/issues/4718
API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1641