### PR TITLE
Fix: Add preselectedEnabled prop and requiredPermissions to CippCADeployDrawer

### DIFF
--- a/src/components/CippComponents/CippCADeployDrawer.jsx
+++ b/src/components/CippComponents/CippCADeployDrawer.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
-import { Button, Stack, Box } from "@mui/material";
+import { Button, Stack } from "@mui/material";
 import { RocketLaunch } from "@mui/icons-material";
 import { useForm, useWatch } from "react-hook-form";
 import { CippOffCanvas } from "./CippOffCanvas";
@@ -125,6 +125,7 @@ export const CippCADeployDrawer = ({
             name="tenantFilter"
             required={true}
             disableClearable={false}
+            preselectedEnabled={true}
             allTenants={true}
             type="multiple"
           />

--- a/src/pages/tenant/conditional/list-policies/index.js
+++ b/src/pages/tenant/conditional/list-policies/index.js
@@ -5,12 +5,10 @@ import {
   Check as CheckIcon,
   Delete as DeleteIcon,
   MenuBook as MenuBookIcon,
-  AddModerator as AddModeratorIcon,
   Visibility as VisibilityIcon,
   Edit as EditIcon,
 } from "@mui/icons-material";
-import { Box, Button } from "@mui/material";
-import Link from "next/link";
+import { Box } from "@mui/material";
 import CippJsonView from "../../../../components/CippFormPages/CippJSONView";
 import { CippCADeployDrawer } from "../../../../components/CippComponents/CippCADeployDrawer";
 
@@ -18,6 +16,7 @@ import { CippCADeployDrawer } from "../../../../components/CippComponents/CippCA
 const Page = () => {
   const pageTitle = "Conditional Access";
   const apiUrl = "/api/ListConditionalAccessPolicies";
+  const cardButtonPermissions = ["Tenant.ConditionalAccess.ReadWrite"];
 
   // Actions configuration
   const actions = [
@@ -159,7 +158,7 @@ const Page = () => {
     <CippTablePage
       cardButton={
         <>
-          <CippCADeployDrawer />
+          <CippCADeployDrawer requiredPermissions={cardButtonPermissions} />
         </>
       }
       title={pageTitle}


### PR DESCRIPTION
Introduce a preselectedEnabled property to the tenant filter and pass requiredPermissions to the CippCADeployDrawer component for enhanced functionality.