### PR TITLE
Feat: Add Teams Chat Protection settings standard

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -4222,6 +4222,34 @@
     "recommendedBy": ["CIS"]
   },
   {
+    "name": "standards.TeamsChatProtection",
+    "cat": "Teams Standards",
+    "tag": [],
+    "helpText": "Configures Teams chat protection settings including weaponizable file protection and malicious URL protection.",
+    "docsDescription": "Configures Teams messaging safety features to protect users from weaponizable files and malicious URLs in chats and channels. Weaponizable File Protection automatically blocks messages containing potentially dangerous file types (like .exe, .dll, .bat, etc.). Malicious URL Protection scans URLs in messages and displays warnings when potentially harmful links are detected. These protections work across internal and external collaboration scenarios.",
+    "executiveText": "Enables automated security protections in Microsoft Teams to block dangerous files and warn users about malicious links in chat messages. This helps protect employees from file-based attacks and phishing attempts. These safeguards work seamlessly in the background, providing essential protection without disrupting normal business communication.",
+    "addedComponent": [
+      {
+        "type": "switch",
+        "name": "standards.TeamsChatProtection.FileTypeCheck",
+        "label": "Enable Weaponizable File Protection",
+        "defaultValue": true
+      },
+      {
+        "type": "switch",
+        "name": "standards.TeamsChatProtection.UrlReputationCheck",
+        "label": "Enable Malicious URL Protection",
+        "defaultValue": true
+      }
+    ],
+    "label": "Set Teams Chat Protection Settings",
+    "impact": "Low Impact",
+    "impactColour": "info",
+    "addedDate": "2025-10-02",
+    "powershellEquivalent": "Set-CsTeamsMessagingConfiguration -FileTypeCheck 'Enabled' -UrlReputationCheck 'Enabled' -ReportIncorrectSecurityDetections 'Enabled'",
+    "recommendedBy": ["CIPP"]
+  },
+  {
     "name": "standards.TeamsEmailIntegration",
     "cat": "Teams Standards",
     "helpText": "Should users be allowed to send emails directly to a channel email addresses?",


### PR DESCRIPTION
Introduce new settings for Teams chat protection, including weaponizable file protection and malicious URL protection.