### PR TITLE
Fix: Use tenant id instead of default domain for tenant group editing

### DIFF
--- a/src/pages/tenant/standards/manage-drift/edit-tenant.js
+++ b/src/pages/tenant/standards/manage-drift/edit-tenant.js
@@ -214,7 +214,7 @@ const Page = () => {
                         groupId: group.value,
                         groupName: group.label,
                       })),
-                      customerId: currentTenant,
+                      customerId: tenantDetails.data?.id,
                     };
                     updateTenant.mutate({
                       url: "/api/EditTenant",


### PR DESCRIPTION
Fixes: https://github.com/KelvinTegelaar/CIPP/issues/4724