### PR TITLE
Fix: Refactor user stats and chart card props

### DIFF
--- a/src/components/CippCards/CippChartCard.jsx
+++ b/src/components/CippCards/CippChartCard.jsx
@@ -93,12 +93,15 @@ export const CippChartCard = ({
   title,
   actions,
   onClick,
+  totalLabel = "Total",
+  customTotal,
 }) => {
   const [range, setRange] = useState("Last 7 days");
   const [barSeries, setBarSeries] = useState([]);
   const chartOptions = useChartOptions(labels, chartType);
   chartSeries = chartSeries.filter((item) => item !== null);
-  const total = chartSeries.reduce((acc, value) => acc + value, 0);
+  const calculatedTotal = chartSeries.reduce((acc, value) => acc + value, 0);
+  const total = customTotal !== undefined ? customTotal : calculatedTotal;
   useEffect(() => {
     if (chartType === "bar") {
       setBarSeries(
@@ -160,7 +163,7 @@ export const CippChartCard = ({
         >
           {labels.length > 0 && (
             <>
-              <Typography variant="h5">Total</Typography>
+              <Typography variant="h5">{totalLabel}</Typography>
               <Typography variant="h5">{isFetching ? "0" : total}</Typography>
             </>
           )}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -32,16 +32,6 @@ const Page = () => {
     queryKey: `${currentTenant}-ListuserCounts`,
   });
 
-  const GlobalAdminList = ApiGetCall({
-    url: "/api/ListGraphRequest",
-    queryKey: `${currentTenant}-ListGraphRequest`,
-    data: {
-      tenantFilter: currentTenant,
-      Endpoint: "/directoryRoles(roleTemplateId='62e90394-69f5-4237-9190-012177145e10')/members",
-      $select: "displayName,userPrincipalName,accountEnabled",
-    },
-  });
-
   const sharepoint = ApiGetCall({
     url: "/api/ListSharepointQuota",
     queryKey: `${currentTenant}-ListSharepointQuota`,
@@ -293,11 +283,11 @@ const Page = () => {
                     tenantId={organization.data?.id}
                     userStats={{
                       licensedUsers: dashboard.data?.LicUsers || 0,
-                      unlicensedUsers: dashboard.data?.Users && dashboard.data?.LicUsers && GlobalAdminList.data?.Results && dashboard.data?.Guests
-                        ? dashboard.data?.Users - dashboard.data?.LicUsers - dashboard.data?.Guests - GlobalAdminList.data?.Results?.length
+                      unlicensedUsers: dashboard.data?.Users && dashboard.data?.LicUsers
+                        ? dashboard.data?.Users - dashboard.data?.LicUsers
                         : 0,
                       guests: dashboard.data?.Guests || 0,
-                      globalAdmins: GlobalAdminList.data?.Results?.length || 0
+                      globalAdmins: dashboard.data?.Gas || 0
                     }}
                     standardsData={driftApi.data}
                     organizationData={organization.data}
@@ -316,23 +306,17 @@ const Page = () => {
             <Grid size={{ md: 4, xs: 12 }}>
               <CippChartCard
                 title="User Statistics"
-                isFetching={dashboard.isFetching || GlobalAdminList.isFetching}
+                isFetching={dashboard.isFetching}
                 chartType="pie"
+                totalLabel="Total Users"
+                customTotal={dashboard.data?.Users}
                 chartSeries={[
                   Number(dashboard.data?.LicUsers || 0),
-                  dashboard.data?.Users &&
-                  dashboard.data?.LicUsers &&
-                  GlobalAdminList.data?.Results &&
-                  dashboard.data?.Guests
-                    ? Number(
-                        dashboard.data?.Users -
-                          dashboard.data?.LicUsers -
-                          dashboard.data?.Guests -
-                          GlobalAdminList.data?.Results?.length
-                      )
+                  dashboard.data?.Users && dashboard.data?.LicUsers
+                    ? Number(dashboard.data?.Users - dashboard.data?.LicUsers)
                     : 0,
                   Number(dashboard.data?.Guests || 0),
-                  Number(GlobalAdminList.data?.Results?.length || 0),
+                  Number(dashboard.data?.Gas || 0),
                 ]}
                 labels={["Licensed Users", "Unlicensed Users", "Guests", "Global Admins"]}
               />


### PR DESCRIPTION
Removed GlobalAdminList API call and updated user statistics to use dashboard.data.Gas for global admins. Simplified unlicensed users calculation and added totalLabel and customTotal props to CippChartCard for customizable total display.

This might make purists sad as the "Total Users" does not match the total of all the different categories but this is a necessary evil the correctly display all the data as its possible for GAs and Guests to have licences assigned and this is something that was not handled correctly before.

Also bonus added a custom total label to the chart props if its wanted

Fixes: https://github.com/KelvinTegelaar/CIPP/issues/4731