### PR TITLE
Feat: Add AllTenants support for listing CA policies

### DIFF
--- a/src/pages/tenant/conditional/list-policies/index.js
+++ b/src/pages/tenant/conditional/list-policies/index.js
@@ -137,6 +137,7 @@ const Page = () => {
 
   // Columns for CippTablePage
   const simpleColumns = [
+    "Tenant",
     "displayName",
     "state",
     "modifiedDateTime",
@@ -164,6 +165,7 @@ const Page = () => {
       }
       title={pageTitle}
       apiUrl={apiUrl}
+      apiDataKey="Results"
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={simpleColumns}
@@ -171,5 +173,5 @@ const Page = () => {
   );
 };
 
-Page.getLayout = (page) => <DashboardLayout allTenantsSupport={false}>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>;
 export default Page;


### PR DESCRIPTION
Enable support for listing CA policies across all tenants by updating the layout and adding a new column for tenant information.

- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1663