### PR TITLE
Fix: EDR only assignment and remove deprecated option

### DIFF
--- a/src/pages/security/defender/deployment/index.js
+++ b/src/pages/security/defender/deployment/index.js
@@ -90,8 +90,8 @@ const DeployDefenderForm = () => {
                 />
                 <CippFormComponent
                   type="switch"
-                  label="EDR: Expedite Telemetry Reporting Frequency"
-                  name="EDR.Telemetry"
+                  label="EDR: Connect Defender Configuration Package automatically from Connector"
+                  name="EDR.Config"
                   formControl={formControl}
                 />
               </Grid>
@@ -122,18 +122,39 @@ const DeployDefenderForm = () => {
                 />
                 <CippFormComponent
                   type="switch"
-                  label="EDR: Connect Defender Configuration Package automatically from Connector"
-                  name="EDR.Config"
-                  formControl={formControl}
-                />
-                <CippFormComponent
-                  type="switch"
                   label="EDR: Enable Sample Sharing"
                   name="EDR.SampleSharing"
                   formControl={formControl}
                 />
               </Grid>
             </Grid>
+            <CippFormCondition
+              formControl={formControl}
+              field="EDR.Config"
+              compareType="is"
+              compareValue={true}
+            >
+              {/* EDR Assignment Section */}
+              <Grid size={{ xs: 12 }}>
+                <Typography variant="h6" sx={{ mb: 2 }}>
+                  EDR Assignment
+                </Typography>
+                <CippFormComponent
+                  type="radio"
+                  label=""
+                  name="EDR.AssignTo"
+                  options={[
+                    { label: "Do not assign", value: "none" },
+                    { label: "Assign to all users", value: "allLicensedUsers" },
+                    { label: "Assign to all devices", value: "AllDevices" },
+                    { label: "Assign to all users and devices", value: "AllDevicesAndUsers" },
+                  ]}
+                  formControl={formControl}
+                  validators={{ required: "Assignment must be selected" }}
+                  row
+                />
+              </Grid>
+            </CippFormCondition>
           </Grid>
         </CippFormCondition>
 


### PR DESCRIPTION
Remove the deprecated telemetry reporting option and introduce a new assignment feature for EDR, allowing users to specify assignment preferences for the EDR policy.

- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1671