### PR TITLE
Fix: Replace removed add pages with drawer buttons

### DIFF
--- a/src/pages/email/transport/list-connector-templates/index.js
+++ b/src/pages/email/transport/list-connector-templates/index.js
@@ -6,10 +6,12 @@ import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx"
 import { TrashIcon } from "@heroicons/react/24/outline";
 import { GitHub } from "@mui/icons-material";
 import ConnectorTemplateDetails from "../../../../components/CippComponents/ConnectorTemplateDetails";
+import { CippAddConnectorDrawer } from "../../../../components/CippComponents/CippAddConnectorDrawer";
 import { ApiGetCall } from "/src/api/ApiCall";
 
 const Page = () => {
   const pageTitle = "Exchange Connector Templates";
+  const cardButtonPermissions = ["Exchange.Connector.ReadWrite"];
   const integrations = ApiGetCall({
     url: "/api/ListExtensionsConfig",
     queryKey: "Integrations",
@@ -93,17 +95,7 @@ const Page = () => {
         label: "Add Template",
         href: "/email/connectors/add-connector-templates",
       }}
-      cardButton={
-        <>
-          <Button
-            component={Link}
-            href="/email/transport/list-connectors/add"
-            startIcon={<RocketLaunch />}
-          >
-            Deploy Connector
-          </Button>
-        </>
-      }
+      cardButton={<CippAddConnectorDrawer requiredPermissions={cardButtonPermissions} />}
     />
   );
 };

--- a/src/pages/email/transport/list-templates/index.js
+++ b/src/pages/email/transport/list-templates/index.js
@@ -1,13 +1,13 @@
 import { Layout as DashboardLayout } from "/src/layouts/index.js";
 import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx";
 import { TrashIcon } from "@heroicons/react/24/outline";
-import { Button } from "@mui/material";
-import { RocketLaunch, GitHub } from "@mui/icons-material";
-import Link from "next/link";
+import { GitHub } from "@mui/icons-material";
 import { ApiGetCall } from "/src/api/ApiCall";
+import { CippAddTransportRuleDrawer } from "../../../../components/CippComponents/CippAddTransportRuleDrawer";
 
 const Page = () => {
   const pageTitle = "Transport Rule Templates";
+  const cardButtonPermissions = ["Exchange.TransportRule.ReadWrite"];
   const integrations = ApiGetCall({
     url: "/api/ListExtensionsConfig",
     queryKey: "Integrations",
@@ -84,17 +84,7 @@ const Page = () => {
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={simpleColumns}
-      cardButton={
-        <>
-          <Button
-            component={Link}
-            href="/email/transport/list-rules/add"
-            startIcon={<RocketLaunch />}
-          >
-            Deploy Template
-          </Button>
-        </>
-      }
+      cardButton={ <CippAddTransportRuleDrawer requiredPermissions={cardButtonPermissions} />}
     />
   );
 };


### PR DESCRIPTION
Replace the deploy button with an add connector drawer in both exchange and transport rule templates to streamline the user interface.