### PR TITLE
Fix: Readd "View release notes" button

### DIFF
--- a/src/components/ReleaseNotesDialog.js
+++ b/src/components/ReleaseNotesDialog.js
@@ -260,8 +260,9 @@ export const ReleaseNotesDialog = forwardRef((_props, ref) => {
   }, [releaseCatalog, selectedReleaseTag, releaseMeta.releaseTag]);
 
   const handleDismissUntilNextRelease = () => {
+    const newestRelease = releaseCatalog[0];
     const tagToStore =
-      selectedReleaseData?.releaseTag ?? selectedReleaseTag ?? releaseMeta.releaseTag;
+      newestRelease?.releaseTag ?? newestRelease?.tagName ?? releaseMeta.releaseTag;
     setCookie(RELEASE_COOKIE_KEY, tagToStore);
     setOpen(false);
     setIsExpanded(false);

--- a/src/layouts/account-popover.js
+++ b/src/layouts/account-popover.js
@@ -24,7 +24,8 @@ import {
 import { usePopover } from "../hooks/use-popover";
 import { paths } from "../paths";
 import { ApiGetCall } from "../api/ApiCall";
-import { CogIcon } from "@heroicons/react/24/outline";
+import { CogIcon, DocumentTextIcon } from "@heroicons/react/24/outline";
+import { useReleaseNotes } from "../contexts/release-notes-context";
 import { useQueryClient } from "@tanstack/react-query";
 
 export const AccountPopover = (props) => {
@@ -39,6 +40,7 @@ export const AccountPopover = (props) => {
   const mdDown = useMediaQuery((theme) => theme.breakpoints.down("md"));
   const popover = usePopover();
   const queryClient = useQueryClient();
+  const { openReleaseNotes } = useReleaseNotes();
   const orgData = ApiGetCall({
     url: "/api/me",
     queryKey: "authmecipp",
@@ -161,6 +163,19 @@ export const AccountPopover = (props) => {
                 </SvgIcon>
               </ListItemIcon>
               <ListItemText primary="Preferences" />
+            </ListItemButton>
+            <ListItemButton
+              onClick={() => {
+                popover.handleClose();
+                openReleaseNotes();
+              }}
+            >
+              <ListItemIcon>
+                <SvgIcon fontSize="small">
+                  <DocumentTextIcon />
+                </SvgIcon>
+              </ListItemIcon>
+              <ListItemText primary="View release notes" />
             </ListItemButton>
             <ListItemButton onClick={handleLogout}>
               <ListItemIcon>


### PR DESCRIPTION
Restore the "View release notes" option in the AccountPopover, also ensuring it only appears for the next version as intended, removing button shenannigans