### PR TITLE
Feat: Add visibility option to M365 Group settings

### DIFF
--- a/src/pages/identity/administration/groups/edit.jsx
+++ b/src/pages/identity/administration/groups/edit.jsx
@@ -44,6 +44,7 @@ const EditGroup = () => {
       RemoveOwner: [],
       AddContact: [],
       RemoveContact: [],
+      visibility: "Public",
     },
   });
 
@@ -74,6 +75,7 @@ const EditGroup = () => {
           allowExternal: groupInfo?.data?.allowExternal,
           sendCopies: groupInfo?.data?.sendCopies,
           hideFromOutlookClients: groupInfo?.data?.hideFromOutlookClients,
+          visibility: group?.visibility ?? "Public",
           displayName: group.displayName,
           description: group.description || "",
           membershipRules: group.membershipRule || "",
@@ -114,6 +116,7 @@ const EditGroup = () => {
           sendCopies: groupInfo?.data?.sendCopies,
           hideFromOutlookClients: groupInfo?.data?.hideFromOutlookClients,
           securityEnabled: group.securityEnabled,
+          visibility: group.visibility ?? "Public",
         });
 
         // Reset the form with all values
@@ -132,6 +135,7 @@ const EditGroup = () => {
       "sendCopies",
       "hideFromOutlookClients",
       "securityEnabled",
+      "visibility",
     ];
 
     changeDetectionProperties.forEach((property) => {
@@ -377,6 +381,24 @@ const EditGroup = () => {
                 <Divider sx={{ my: 2 }} />
                 <Typography variant="h6">Group Settings</Typography>
               </Grid>
+
+              {groupType === "Microsoft 365" && (
+                <Grid size={{ xs: 12 }}>
+                  <CippFormComponent
+                    type="radio"
+                    label="Group visibility"
+                    name="visibility"
+                    formControl={formControl}
+                    isFetching={groupInfo.isFetching}
+                    disabled={groupInfo.isFetching}
+                    options={[
+                      { label: "Public", value: "Public" },
+                      { label: "Private", value: "Private" },
+                    ]}
+                  />
+                </Grid>
+              )}
+
               {(groupType === "Microsoft 365" || groupType === "Distribution List") && (
                 <Grid size={{ xs: 12 }}>
                   <CippFormComponent


### PR DESCRIPTION
Introduce a visibility option in the group settings form for Microsoft 365 groups, allowing users to set the group as Public or Private. 

- Fixes #4835
- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1681