### PR TITLE
Feat? Add default domain display for tenant details

### DIFF
--- a/src/pages/tenant/manage/edit.js
+++ b/src/pages/tenant/manage/edit.js
@@ -191,6 +191,10 @@ const Page = () => {
                   label: "Tenant ID",
                   value: getCippFormatting(tenantDetails.data?.id, "Tenant"),
                 },
+                {
+                  label: "Default Domain",
+                  value: currentTenant,
+                },
               ]}
               showDivider={false}
               isFetching={tenantDetails.isFetching}


### PR DESCRIPTION
Include the default domain information in the tenant details view.