### PR TITLE
Fix: group settings display issue by updating edit group links

### DIFF
--- a/src/pages/identity/administration/users/user/index.jsx
+++ b/src/pages/identity/administration/users/user/index.jsx
@@ -524,7 +524,7 @@ const Page = () => {
               {
                 icon: <PencilIcon />,
                 label: "Edit Group",
-                link: "/identity/administration/groups/edit?groupId=[id]",
+                link: "/identity/administration/groups/edit?groupId=[id]&groupType=[calculatedGroupType]",
               },
             ],
             data: userMemberOf?.filter(

--- a/src/pages/teams-share/teams/list-team/index.js
+++ b/src/pages/teams-share/teams/list-team/index.js
@@ -11,7 +11,7 @@ const Page = () => {
   const actions = [
     {
       label: "Edit Group",
-      link: "/identity/administration/groups/edit?groupId=[id]",
+      link: "/identity/administration/groups/edit?groupId=[id]&groupType=Microsoft 365",
       multiPost: false,
       color: "warning",
       icon: <Edit />,


### PR DESCRIPTION
Update edit group links to include the `groupType` parameter, resolving the bug that prevented group settings from displaying correctly when accessed from Teams and View User page.

- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1693