### PR TITLE
Feat: Improve license overview to show assigned users and license groups

### DIFF
--- a/src/pages/tenant/reports/list-licenses/index.js
+++ b/src/pages/tenant/reports/list-licenses/index.js
@@ -11,6 +11,8 @@ const Page = () => {
     "CountUsed",
     "CountAvailable",
     "TotalLicenses",
+    "AssignedUsers",
+    "AssignedGroups",
     "TermInfo", // TODO TermInfo is not showing as a clickable json object in the table, like CApolicies does in the mfa report. IDK how to fix it. -Bobby
   ];
 


### PR DESCRIPTION
Shows pretty much the same as the M365 admin portal does now.

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1696