### PR TITLE
Feat: Add source of authority configuration

### DIFF
--- a/src/components/CippComponents/CippUserActions.jsx
+++ b/src/components/CippComponents/CippUserActions.jsx
@@ -11,13 +11,13 @@ import {
   LockPerson,
   LockReset,
   MeetingRoom,
-  NoMeetingRoom,
   Password,
   PersonOff,
   PhonelinkLock,
   PhonelinkSetup,
   Shortcut,
   EditAttributes,
+  CloudSync,
 } from "@mui/icons-material";
 import { getCippLicenseTranslation } from "../../utils/get-cipp-license-translation";
 import { useSettings } from "/src/hooks/use-settings.js";
@@ -513,6 +513,32 @@ export const useCippUserActions = () => {
       confirmText: "Are you sure you want to clear the Immutable ID for [userPrincipalName]?",
       multiPost: false,
       condition: (row) => !row?.onPremisesSyncEnabled && row?.onPremisesImmutableId && canWriteUser,
+    },
+    {
+      label: "Set Source of Authority",
+      type: "POST",
+      url: "/api/ExecSetCloudManaged",
+      icon: <CloudSync />,
+      data: {
+        ID: "id",
+        displayName: "displayName",
+        type: "!User",
+      },
+      fields: [
+        {
+          type: "radio",
+          name: "isCloudManaged",
+          label: "Source of Authority",
+          options: [
+            { label: "Cloud Managed", value: true },
+            { label: "On-Premises Managed", value: false },
+          ],
+          validators: { required: "Please select a source of authority" },
+        },
+      ],
+      confirmText:
+        "Are you sure you want to change the source of authority for [userPrincipalName]? Setting it to On-Premises Managed will take until the next sync cycle to show the change.",
+      multiPost: false,
     },
     {
       label: "Revoke all user sessions",

--- a/src/pages/email/administration/contacts/index.js
+++ b/src/pages/email/administration/contacts/index.js
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { Layout as DashboardLayout } from "/src/layouts/index.js";
 import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx";
-import { Edit } from "@mui/icons-material";
+import { CloudSync, Edit } from "@mui/icons-material";
 import TrashIcon from "@heroicons/react/24/outline/TrashIcon";
 import { CippAddContactDrawer } from "../../../../components/CippComponents/CippAddContactDrawer";
 import { CippDeployContactTemplateDrawer } from "../../../../components/CippComponents/CippDeployContactTemplateDrawer";
@@ -19,6 +19,32 @@ const Page = () => {
         icon: <Edit />,
         color: "warning",
         condition: (row) => !row.IsDirSynced,
+      },
+      {
+        label: "Set Source of Authority",
+        type: "POST",
+        url: "/api/ExecSetCloudManaged",
+        icon: <CloudSync />,
+        data: {
+          ID: "graphId",
+          displayName: "DisplayName",
+          type: "!Contact",
+        },
+        fields: [
+          {
+            type: "radio",
+            name: "isCloudManaged",
+            label: "Source of Authority",
+            options: [
+              { label: "Cloud Managed", value: true },
+              { label: "On-Premises Managed", value: false },
+            ],
+            validators: { required: "Please select a source of authority" },
+          },
+        ],
+        confirmText:
+          "Are you sure you want to change the source of authority for '[DisplayName]'? Setting it to On-Premises Managed will take until the next sync cycle to show the change.",
+        multiPost: false,
       },
       {
         label: "Remove Contact",

--- a/src/pages/identity/administration/groups/index.js
+++ b/src/pages/identity/administration/groups/index.js
@@ -113,7 +113,7 @@ const Page = () => {
         },
       ],
       confirmText:
-        "Are you sure you want to change the source of authority for this group? Setting it to On-Premises Managed will take until the next sync cycle to show the change.",
+        "Are you sure you want to change the source of authority for '[displayName]'? Setting it to On-Premises Managed will take until the next sync cycle to show the change.",
       multiPost: false,
     },
     {


### PR DESCRIPTION
Introduce a new configuration option to set the source of authority for groups, users and contacts.

- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1705
- https://learn.microsoft.com/en-us/graph/api/onpremisessyncbehavior-get