### PR TITLE
Fix: Add condition for copying sent items based on recipient type and rename field

### DIFF
--- a/src/components/CippComponents/CippExchangeActions.jsx
+++ b/src/components/CippComponents/CippExchangeActions.jsx
@@ -301,12 +301,14 @@ export const CippExchangeActions = () => {
       label: "Set Copy Sent Items for Delegated Mailboxes",
       type: "POST",
       icon: <MailOutline />,
+      condition: (row) =>
+        row.recipientTypeDetails === "UserMailbox" || row.recipientTypeDetails === "SharedMailbox",
       url: "/api/ExecCopyForSent",
       data: { ID: "UPN" },
       fields: [
         {
           type: "radio",
-          name: "MessageCopyForSentAsEnabled",
+          name: "messageCopyState",
           label: "Copy Sent Items",
           options: [
             { label: "Enabled", value: true },


### PR DESCRIPTION
Introduce a condition to determine when to copy sent items, specifically for user and shared mailboxes, and rename the related field for clarity.

- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1715