### PR TITLE
Feat: Add custom group assignment option for Intune applications and enhance assignment dialogs

### DIFF
--- a/src/pages/endpoint/applications/list/index.js
+++ b/src/pages/endpoint/applications/list/index.js
@@ -236,8 +236,10 @@ const Page = () => {
   const simpleColumns = [
     "displayName",
     "publishingState",
-    "installCommandLine",
-    "uninstallCommandLine",
+    "isAssigned",
+    "lastModifiedDateTime",
+    "createdDateTime",
+    "applicableDeviceType",
   ];
 
   return (


### PR DESCRIPTION
Introduce a custom group assignment option and improve assignment intent handling in the application assignment dialogs. Update confirmation messages to reflect the new features and provide clearer guidance on assignment intents.

- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1718

<img width="586" height="588" alt="billede" src="https://github.com/user-attachments/assets/a04503c7-58ed-4c90-bebb-aeda07f7bce4" />

<img width="587" height="729" alt="billede" src="https://github.com/user-attachments/assets/209693dc-ae0d-4a23-86e0-9c28d108c70b" />


