### PR TITLE
Fix SMTP Auth alerts

### DIFF
--- a/src/data/alerts.json
+++ b/src/data/alerts.json
@@ -15,7 +15,7 @@
     "recommendedRunInterval": "1d"
   },
   {
-    "name": "AlertSmtpAuthSuccess",
+    "name": "SmtpAuthSuccess",
     "label": "Alert on SMTP AUTH usage with success, helps to phase out SMTP AUTH (Entra P1 Required)",
     "recommendedRunInterval": "1d"
   },


### PR DESCRIPTION
User reported this on Discord.
Caused by it calling "Get-CIPPAlertAlertSmtpAuthSuccess" because of the redundant "alert" in the alert name.
<img width="1425" height="617" alt="image" src="https://github.com/user-attachments/assets/c0adb077-bd71-49cb-adec-d7c3a5ebc799" />
