### PR TITLE
feat: Add multi-group selection support for Add to Group user action

### DIFF
--- a/src/components/CippComponents/CippApiDialog.jsx
+++ b/src/components/CippComponents/CippApiDialog.jsx
@@ -122,8 +122,11 @@ export const CippApiDialog = (props) => {
   const handleActionClick = (row, action, formData) => {
     setIsFormSubmitted(true);
     let finalData = {};
+    let isBulkRequest = false;
     if (typeof api?.customDataformatter === "function") {
       finalData = api.customDataformatter(row, action, formData);
+      // If customDataformatter returns an array, enable bulk request mode
+      isBulkRequest = Array.isArray(finalData);
     } else {
       if (action.multiPost === undefined) action.multiPost = false;
 
@@ -201,7 +204,7 @@ export const CippApiDialog = (props) => {
     if (action.type === "POST") {
       actionPostRequest.mutate({
         url: action.url,
-        bulkRequest: false,
+        bulkRequest: isBulkRequest,
         data: finalData,
       });
     } else if (action.type === "GET") {
@@ -209,7 +212,7 @@ export const CippApiDialog = (props) => {
         url: action.url,
         waiting: true,
         queryKey: Date.now(),
-        bulkRequest: false,
+        bulkRequest: isBulkRequest,
         data: finalData,
       });
     }

--- a/src/components/CippComponents/CippUserActions.jsx
+++ b/src/components/CippComponents/CippUserActions.jsx
@@ -281,6 +281,7 @@ export const useCippUserActions = () => {
       icon: <GroupAdd />,
       url: "/api/EditGroup",
       customDataformatter: (row, action, formData) => {
+        // Build the member list from selected users
         let addMember = [];
         if (Array.isArray(row)) {
           row
@@ -305,20 +306,26 @@ export const useCippUserActions = () => {
             },
           });
         }
-        return {
+
+        // Handle multiple groups - return an array of requests (one per group)
+        const selectedGroups = Array.isArray(formData.groupId)
+          ? formData.groupId
+          : [formData.groupId];
+
+        return selectedGroups.map((group) => ({
           addMember: addMember,
           tenantFilter: tenant,
-          groupId: formData.groupId,
-        };
+          groupId: group,
+        }));
       },
       fields: [
         {
           type: "autoComplete",
           name: "groupId",
-          label: "Select a group to add the user to",
-          multiple: false,
+          label: "Select groups to add the user to",
+          multiple: true,
           creatable: false,
-          validators: { required: "Please select a group" },
+          validators: { required: "Please select at least one group" },
           api: {
             url: "/api/ListGroups",
             labelField: (option) =>
@@ -335,8 +342,8 @@ export const useCippUserActions = () => {
           },
         },
       ],
-      confirmText: "Are you sure you want to add [userPrincipalName] to this group?",
-      multiPost: true,
+      confirmText: "Are you sure you want to add [userPrincipalName] to the selected groups?",
+      multiPost: false,
       allowResubmit: true,
       condition: () => canWriteGroup,
     },


### PR DESCRIPTION
Enables selecting multiple groups when using the "Add to Group" action on users, allowing users to be added to several groups in a single operation.

The `CippApiDialog` change is fully backward compatible - existing actions that return objects from `customDataformatter` continue to work unchanged. Only formatters that explicitly return arrays will trigger bulk request mode.
