### PR TITLE
Fix: Users bulk actions, set out of office options in UI

### DIFF
--- a/src/components/CippTable/CIPPTableToptoolbar.js
+++ b/src/components/CippTable/CIPPTableToptoolbar.js
@@ -1269,6 +1269,7 @@ export const CIPPTableToptoolbar = ({
           api={actionData.action}
           row={actionData.data}
           relatedQueryKeys={queryKeys}
+          {...actionData.action}
         />
       )}
 

--- a/src/components/actions-menu.js
+++ b/src/components/actions-menu.js
@@ -92,6 +92,7 @@ export const ActionsMenu = (props) => {
           api={actionData.action}
           row={actionData.data}
           relatedQueryKeys={queryKeys}
+          {...actionData.action}
         />
       )}
     </>


### PR DESCRIPTION
The changes ensure that the action data is properly spread in the `CIPPTableToptoolbar` and `ActionsMenu` components, allowing the bulk action for setting out of office to display the necessary options in the UI. This addresses the issue where no options were shown when attempting to set out of office for multiple users.

Fixes #5036