### PR TITLE
exclude all tenant user template from template list page

### DIFF
--- a/src/pages/tenant/manage/user-defaults.js
+++ b/src/pages/tenant/manage/user-defaults.js
@@ -61,7 +61,7 @@ const Page = () => {
     <>
       <CippTablePage
         title={pageTitle}
-        apiUrl={`/api/ListNewUserDefaults`}
+        apiUrl={`/api/ListNewUserDefaults?includeAllTenants=false`}
         queryKey={`ListNewUserDefaults-${userSettings.currentTenant}`}
         actions={actions}
         offCanvas={offCanvas}


### PR DESCRIPTION
This pull request makes a small change to the API call in the `Page` component to ensure that only user defaults for the current tenant are fetched, rather than for all tenants. 