### PR TITLE
Feat: Add 14-day and 21-day recurrence intervals for alert scheduling…

### DIFF
--- a/src/components/CippFormPages/CippSchedulerForm.jsx
+++ b/src/components/CippFormPages/CippSchedulerForm.jsx
@@ -100,6 +100,8 @@ const CippSchedulerForm = (props) => {
     { value: "0", label: "Once" },
     { value: "1d", label: "Every 1 day" },
     { value: "7d", label: "Every 7 days" },
+    { value: "14d", label: "Every 14 days" },
+    { value: "21d", label: "Every 21 days" },
     { value: "30d", label: "Every 30 days" },
     { value: "365d", label: "Every 365 days" },
   ];

--- a/src/components/CippWizard/CippAlertsStep.jsx
+++ b/src/components/CippWizard/CippAlertsStep.jsx
@@ -16,6 +16,8 @@ export const CippAlertsStep = (props) => {
     { value: "4h", label: "Every 4 hours" },
     { value: "1d", label: "Every 1 day" },
     { value: "7d", label: "Every 7 days" },
+    { value: "14d", label: "Every 14 days" },
+    { value: "21d", label: "Every 21 days" },
     { value: "30d", label: "Every 30 days" },
     { value: "365d", label: "Every 365 days" },
   ];

--- a/src/pages/tenant/administration/alert-configuration/alert.jsx
+++ b/src/pages/tenant/administration/alert-configuration/alert.jsx
@@ -56,6 +56,8 @@ const AlertWizard = () => {
     { value: "4h", label: "Every 4 hours" },
     { value: "1d", label: "Every 1 day" },
     { value: "7d", label: "Every 7 days" },
+    { value: "14d", label: "Every 14 days" },
+    { value: "21d", label: "Every 21 days" },
     { value: "30d", label: "Every 30 days" },
     { value: "365d", label: "Every 365 days" },
   ]);


### PR DESCRIPTION

This pull request adds new scheduling frequency options of "Every 14 days" and "Every 21 days" to several components related to scheduling and alert configuration. These changes enhance user flexibility by allowing biweekly and three-week scheduling intervals.

Scheduling and alert frequency options:

* Added "Every 14 days" and "Every 21 days" options to the scheduling dropdown in `CippSchedulerForm` (`src/components/CippFormPages/CippSchedulerForm.jsx`).
* Added "Every 14 days" and "Every 21 days" options to the alert frequency dropdown in `CippAlertsStep` (`src/components/CippWizard/CippAlertsStep.jsx`).
* Added "Every 14 days" and "Every 21 days" options to the alert scheduling in `AlertWizard` (`src/pages/tenant/administration/alert-configuration/alert.jsx`).
Fixes #5085