### PR TITLE
Feat: Add trusted and blocked senders exchange user card and action

### DIFF
--- a/src/pages/identity/administration/users/user/exchange.jsx
+++ b/src/pages/identity/administration/users/user/exchange.jsx
@@ -1100,7 +1100,7 @@ const Page = () => {
       url: "/api/RemoveTrustedBlockedSender",
       customDataformatter: (row, action, formData) => {
         return {
-          userPrincipalName: row?.userPrincipalName,
+          userPrincipalName: row?.UserPrincipalName,
           typeProperty: row?.TypeProperty,
           value: row?.Value,
           tenantFilter: userSettingsDefaults.currentTenant,


### PR DESCRIPTION
Introduce a card for managing trusted and blocked senders, including actions to remove entries. This feature enhances user control over email filtering settings.

- API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1744