### PR TITLE
Add Intune policy conflict alert configuration

### DIFF
--- a/src/data/alerts.json
+++ b/src/data/alerts.json
@@ -188,6 +188,41 @@
     "recommendedRunInterval": "4h"
   },
   {
+    "name": "IntunePolicyConflicts",
+    "label": "Alert on Intune policy or app conflicts/errors",
+    "recommendedRunInterval": "4h",
+    "requiresInput": true,
+    "multipleInput": true,
+    "inputs": [
+      {
+        "inputType": "switch",
+        "inputLabel": "Alert per issue (off = aggregated)",
+        "inputName": "AlertEachIssue"
+      },
+      {
+        "inputType": "switch",
+        "inputLabel": "Include policy status issues",
+        "inputName": "IncludePolicies"
+      },
+      {
+        "inputType": "switch",
+        "inputLabel": "Include app install issues",
+        "inputName": "IncludeApplications"
+      },
+      {
+        "inputType": "switch",
+        "inputLabel": "Alert on conflicts",
+        "inputName": "AlertConflicts"
+      },
+      {
+        "inputType": "switch",
+        "inputLabel": "Alert on errors/failures",
+        "inputName": "AlertErrors"
+      }
+    ],
+    "description": "Monitors Intune policy assignment states and app install statuses for conflicts or errors. Defaults to aggregated alerts with all mechanisms enabled and both conflicts and errors included."
+  },
+  {
     "name": "BreachAlert",
     "label": "Alert on (new) potentially breached passwords. Generates an alert if a password is found to be breached.",
     "recommendedRunInterval": "7d"


### PR DESCRIPTION
Introduce a new alert configuration for monitoring Intune policy assignment states and app install statuses. This feature allows for granular alerting on conflicts and errors, enhancing visibility for MSPs on non-functional policies and change managment. 

Closes #5149
Depends on backend PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1759

Frontend Screenshot:
<img width="1820" height="986" alt="image" src="https://github.com/user-attachments/assets/5593fabf-1076-44c4-ba93-9362b19eb3f6" />
