### PR TITLE
Update GDAP invite URLs to new Microsoft admin domain

### DIFF
--- a/src/pages/tenant/gdap-management/onboarding/start.js
+++ b/src/pages/tenant/gdap-management/onboarding/start.js
@@ -507,7 +507,7 @@ const Page = () => {
                             {
                               label: "Invite URL",
                               value: getCippFormatting(
-                                "https://admin.microsoft.com/AdminPortal/Home#/partners/invitation/granularAdminRelationships/" +
+                                "https://admin.cloud.microsoft/?#/partners/invitation/granularAdminRelationships/" +
                                   currentRelationship.value,
                                 "InviteUrl",
                                 "url"

--- a/src/pages/tenant/gdap-management/relationships/relationship/index.js
+++ b/src/pages/tenant/gdap-management/relationships/relationship/index.js
@@ -120,7 +120,7 @@ const Page = () => {
         properties.push({
           label: "Invite URL",
           value: getCippFormatting(
-            "https://admin.microsoft.com/AdminPortal/Home#/partners/invitation/granularAdminRelationships/" +
+            "https://admin.cloud.microsoft/?#/partners/invitation/granularAdminRelationships/" +
               data?.id,
             "InviteUrl",
             "url"


### PR DESCRIPTION
Replaced 'admin.microsoft.com/AdminPortal/Home' with 'admin.cloud.microsoft' in GDAP invite URLs for onboarding and relationship pages to reflect the updated Microsoft admin portal structure.