### PR TITLE
feat: Reusable Settings

### DIFF
--- a/src/components/CippComponents/CippReusableSettingsDeployDrawer.jsx
+++ b/src/components/CippComponents/CippReusableSettingsDeployDrawer.jsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from "react";
+import { Button, Stack } from "@mui/material";
+import { RocketLaunch } from "@mui/icons-material";
+import { useForm, useWatch, useFormState } from "react-hook-form";
+import { CippOffCanvas } from "./CippOffCanvas";
+import { ApiGetCall, ApiPostCall } from "../../api/ApiCall";
+import CippFormComponent from "./CippFormComponent";
+import CippJsonView from "../CippFormPages/CippJSONView";
+import { Grid } from "@mui/system";
+import { CippApiResults } from "./CippApiResults";
+import { useSettings } from "../../hooks/use-settings";
+import { CippFormTenantSelector } from "./CippFormTenantSelector";
+import { PermissionButton as PermissionAwareButton } from "../../utils/permissions";
+
+export const CippReusableSettingsDeployDrawer = ({
+  buttonText = "Deploy Reusable Settings",
+  requiredPermissions = [],
+  PermissionButton = PermissionAwareButton,
+}) => {
+  const [drawerVisible, setDrawerVisible] = useState(false);
+  const formControl = useForm({ mode: "onChange" });
+  const { isValid } = useFormState({ control: formControl.control });
+  const tenantFilter = useSettings()?.tenantFilter;
+  const selectedTemplate = useWatch({ control: formControl.control, name: "TemplateList" });
+  const rawJson = useWatch({ control: formControl.control, name: "rawJSON" });
+  const selectedTenants = useWatch({ control: formControl.control, name: "tenantFilter" });
+
+  const templates = ApiGetCall({ url: "/api/ListIntuneReusableSettingTemplates", queryKey: "ListIntuneReusableSettingTemplates" });
+
+  useEffect(() => {
+    if (templates.isSuccess && selectedTemplate?.value) {
+      const match = templates.data?.find((t) => t.GUID === selectedTemplate.value);
+      if (match) {
+        formControl.setValue("rawJSON", match.RawJSON || "");
+        formControl.setValue("TemplateId", match.GUID);
+      }
+    }
+  }, [templates.isSuccess, templates.data, selectedTemplate, formControl]);
+
+  const effectiveTenants = Array.isArray(selectedTenants) && selectedTenants.length > 0
+    ? selectedTenants
+    : tenantFilter
+      ? [tenantFilter]
+      : [];
+
+  const deploy = ApiPostCall({
+    urlFromData: true,
+    relatedQueryKeys: [
+      "ListIntuneReusableSettingTemplates",
+      `ListIntuneReusableSettings-${effectiveTenants.join(",")}`,
+    ],
+  });
+
+  const handleSubmit = async () => {
+    const isFormValid = await formControl.trigger();
+    if (!isFormValid) {
+      return;
+    }
+    const values = formControl.getValues();
+    deploy.mutate({
+      url: "/api/AddIntuneReusableSetting",
+      data: {
+        tenantFilter: effectiveTenants,
+        TemplateId: values?.TemplateList?.value,
+        rawJSON: values?.rawJSON,
+      },
+    });
+  };
+
+  const handleCloseDrawer = () => {
+    setDrawerVisible(false);
+    formControl.reset();
+    deploy.reset();
+  };
+
+  const safeJson = () => {
+    if (!rawJson) return null;
+    try {
+      return JSON.parse(rawJson);
+    } catch (e) {
+      return null;
+    }
+  };
+
+  return (
+    <>
+      <PermissionButton
+        requiredPermissions={requiredPermissions}
+        onClick={() => setDrawerVisible(true)}
+        startIcon={<RocketLaunch />}
+      >
+        {buttonText}
+      </PermissionButton>
+      <CippOffCanvas
+        title="Deploy Reusable Settings"
+        visible={drawerVisible}
+        onClose={handleCloseDrawer}
+        size="lg"
+        footer={
+          <Stack direction="row" spacing={2}>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleSubmit}
+              disabled={deploy.isLoading || !isValid}
+            >
+              {deploy.isLoading ? "Deploying..." : "Deploy"}
+            </Button>
+            <Button variant="outlined" onClick={handleCloseDrawer}>
+              Close
+            </Button>
+          </Stack>
+        }
+      >
+        <Stack spacing={3}>
+          <CippFormTenantSelector
+            formControl={formControl}
+            name="tenantFilter"
+            required={true}
+            disableClearable={false}
+            allTenants={true}
+            preselectedEnabled={true}
+            type="multiple"
+          />
+          <CippFormComponent
+            type="autoComplete"
+            name="TemplateList"
+            label="Choose a Reusable Settings Template"
+            isFetching={templates.isLoading}
+            multiple={false}
+            formControl={formControl}
+            options={
+              templates.isSuccess && Array.isArray(templates.data)
+                ? templates.data.map((t) => ({
+                    label:
+                      t.displayName ||
+                      t.DisplayName ||
+                      t.templateName ||
+                      t.TemplateName ||
+                      t.name ||
+                      `Template ${t.GUID}`,
+                    value: t.GUID,
+                  }))
+                : []
+            }
+            validators={{ required: { value: true, message: "Template selection is required" } }}
+          />
+          <Grid size={{ xs: 12 }}>
+            <CippFormComponent
+              type="json"
+              name="rawJSON"
+              label="Raw JSON"
+              formControl={formControl}
+              required
+              validators={{ required: "Raw JSON is required" }}
+              rows={12}
+            />
+          </Grid>
+          <CippJsonView object={safeJson()} type="intune" />
+          <CippApiResults apiObject={deploy} />
+        </Stack>
+      </CippOffCanvas>
+    </>
+  );
+};

--- a/src/components/CippFormPages/CippAddIntuneReusableSettingTemplateForm.jsx
+++ b/src/components/CippFormPages/CippAddIntuneReusableSettingTemplateForm.jsx
@@ -1,0 +1,54 @@
+import { Grid } from "@mui/system";
+import CippFormComponent from "/src/components/CippComponents/CippFormComponent";
+
+const CippAddIntuneReusableSettingTemplateForm = ({ formControl }) => {
+  return (
+    <Grid container spacing={2}>
+      <CippFormComponent type="hidden" name="GUID" formControl={formControl} />
+
+      <Grid size={{ md: 6, xs: 12 }}>
+        <CippFormComponent
+          type="textField"
+          label="Display Name"
+          name="displayName"
+          required
+          formControl={formControl}
+          validators={{ required: "Display Name is required" }}
+        />
+      </Grid>
+      <Grid size={{ md: 6, xs: 12 }}>
+        <CippFormComponent
+          type="textField"
+          label="Description"
+          name="description"
+          formControl={formControl}
+        />
+      </Grid>
+
+      <Grid size={{ md: 6, xs: 12 }}>
+        <CippFormComponent
+          type="textField"
+          label="Package (optional)"
+          name="package"
+          formControl={formControl}
+          helperText="Optional metadata to group templates (e.g., internal package name)."
+        />
+      </Grid>
+
+      <Grid size={{ xs: 12 }}>
+        <CippFormComponent
+          type="json"
+          label="Raw JSON"
+          name="rawJSON"
+          formControl={formControl}
+          required
+          validators={{ required: "Raw JSON is required" }}
+          helperText="Paste the reusablePolicySetting payload (Graph beta: deviceManagement/reusablePolicySettings)."
+          rows={12}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default CippAddIntuneReusableSettingTemplateForm;

--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -5345,6 +5345,46 @@
     ]
   },
   {
+    "name": "standards.ReusableSettingsTemplate",
+    "cat": "Templates",
+    "label": "Reusable Settings Template",
+    "multiple": true,
+    "disabledFeatures": {
+      "report": false,
+      "warn": false,
+      "remediate": false
+    },
+    "impact": "High Impact",
+    "impactColour": "info",
+    "addedDate": "2026-01-02",
+    "helpText": "Deploy and maintain Intune reusable settings templates that can be referenced by multiple policies.",
+    "executiveText": "Creates and keeps reusable Intune settings templates consistent so common firewall and configuration blocks can be reused across many policies.",
+    "addedComponent": [
+      {
+        "type": "autoComplete",
+        "multiple": true,
+        "creatable": false,
+        "required": true,
+        "name": "TemplateList",
+        "label": "Select Reusable Settings Template",
+        "api": {
+          "queryKey": "ListIntuneReusableSettingTemplates",
+          "url": "/api/ListIntuneReusableSettingTemplates",
+          "labelField": "displayName",
+          "valueField": "GUID",
+          "showRefresh": true,
+          "templateView": {
+            "title": "Reusable Settings",
+            "property": "RawJSON",
+            "type": "intune"
+          }
+        }
+      }
+    ],
+    "powershellEquivalent": "",
+    "recommendedBy": []
+  },
+  {
     "name": "standards.TransportRuleTemplate",
     "label": "Transport Rule Template",
     "cat": "Templates",

--- a/src/layouts/config.js
+++ b/src/layouts/config.js
@@ -448,6 +448,16 @@ export const nativeMenuItems = [
             permissions: ["Endpoint.MEM.*"],
           },
           {
+            title: "Reusable Settings",
+            path: "/endpoint/MEM/reusable-settings",
+            permissions: ["Endpoint.MEM.*"],
+          },
+          {
+            title: "Reusable Settings Templates",
+            path: "/endpoint/MEM/reusable-settings-templates",
+            permissions: ["Endpoint.MEM.*"],
+          },
+          {
             title: "Assignment Filters",
             path: "/endpoint/MEM/assignment-filters",
             permissions: ["Endpoint.MEM.*"],

--- a/src/pages/endpoint/MEM/reusable-settings-templates/add.jsx
+++ b/src/pages/endpoint/MEM/reusable-settings-templates/add.jsx
@@ -1,0 +1,36 @@
+import { Box } from "@mui/material";
+import { useForm } from "react-hook-form";
+import { useSettings } from "../../../../hooks/use-settings";
+import CippFormPage from "../../../../components/CippFormPages/CippFormPage";
+import { Layout as DashboardLayout } from "/src/layouts/index.js";
+import CippAddIntuneReusableSettingTemplateForm from "../../../../components/CippFormPages/CippAddIntuneReusableSettingTemplateForm";
+
+const Page = () => {
+  const userSettingsDefaults = useSettings();
+
+  const formControl = useForm({
+    mode: "onChange",
+    defaultValues: {
+      tenantFilter: userSettingsDefaults.currentTenant,
+    },
+  });
+
+  return (
+    <CippFormPage
+      resetForm={false}
+      queryKey={`IntuneReusableSettingTemplates-${userSettingsDefaults.currentTenant}`}
+      formControl={formControl}
+      title="Reusable Settings Template"
+      backButtonTitle="Reusable Settings Templates"
+      postUrl="/api/AddIntuneReusableSettingTemplate"
+    >
+      <Box sx={{ my: 2 }}>
+        <CippAddIntuneReusableSettingTemplateForm formControl={formControl} />
+      </Box>
+    </CippFormPage>
+  );
+};
+
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default Page;

--- a/src/pages/endpoint/MEM/reusable-settings-templates/edit.jsx
+++ b/src/pages/endpoint/MEM/reusable-settings-templates/edit.jsx
@@ -1,0 +1,374 @@
+import { Alert, Box, Button, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography, Divider } from "@mui/material";
+import { useForm, useFieldArray } from "react-hook-form";
+import { useRouter } from "next/router";
+import { Layout as DashboardLayout } from "/src/layouts/index.js";
+import CippFormPage from "../../../../components/CippFormPages/CippFormPage";
+import CippFormSkeleton from "../../../../components/CippFormPages/CippFormSkeleton";
+import CippFormComponent from "../../../../components/CippComponents/CippFormComponent";
+import { ApiGetCall } from "../../../../api/ApiCall";
+import { useSettings } from "../../../../hooks/use-settings";
+import { useEffect, useMemo } from "react";
+
+// Structured clone helper for older runtimes
+const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
+
+const generateGuid = () => {
+  const wrap = (val) => `{${val}}`;
+  if (typeof crypto !== "undefined" && crypto.randomUUID) return wrap(crypto.randomUUID());
+  const s4 = () => Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
+  return wrap(`${s4()}${s4()}-${s4()}-${s4()}-${s4()}-${s4()}${s4()}${s4()}`);
+};
+
+const EditReusableSettingsTemplate = () => {
+  const router = useRouter();
+  const { id: rawId } = router.query;
+  const { currentTenant } = useSettings();
+
+  const normalizedId = useMemo(() => {
+    if (typeof rawId === "string") return rawId;
+    if (Array.isArray(rawId) && rawId.length > 0) return rawId[0];
+    return undefined;
+  }, [rawId]);
+
+  const formControl = useForm({
+    mode: "onChange",
+    defaultValues: {
+      tenantFilter: currentTenant,
+      GUID: normalizedId,
+    },
+  });
+
+  const templateQuery = ApiGetCall({
+    url: "/api/ListIntuneReusableSettingTemplates",
+    data: normalizedId ? { id: normalizedId } : undefined,
+    queryKey: `ReusableSettingTemplate-${normalizedId}`,
+    waiting: !!normalizedId,
+  });
+
+  const templateData = Array.isArray(templateQuery.data)
+    ? templateQuery.data[0]
+    : templateQuery.data;
+
+  const normalizedTemplate = useMemo(() => {
+    if (!templateData) return null;
+    return {
+      ...templateData,
+      // Normalize all known casing variants to the canonical RawJSON property
+      RawJSON: templateData.RawJSON ?? templateData.RAWJson ?? templateData.RAWJSON,
+    };
+  }, [templateData]);
+
+  const parsedRaw = useMemo(() => {
+    if (!normalizedTemplate?.RawJSON) return null;
+    try {
+      return JSON.parse(normalizedTemplate.RawJSON);
+    } catch (e) {
+      return null;
+    }
+  }, [normalizedTemplate]);
+
+  // Strip the group collection out of the parsed RAW for cleaner form state
+  const sanitizedParsedRaw = useMemo(() => {
+    if (!parsedRaw) return null;
+    const clone = deepClone(parsedRaw);
+    if (clone?.settingInstance?.groupSettingCollectionValue) {
+      delete clone.settingInstance.groupSettingCollectionValue;
+    }
+    return clone;
+  }, [parsedRaw]);
+
+  const groupCollection = useMemo(() => {
+    return (
+      parsedRaw?.settingInstance?.groupSettingCollectionValue ||
+      templateData?.settingInstance?.groupSettingCollectionValue ||
+      []
+    );
+  }, [parsedRaw, templateData]);
+
+  const groupChildDefinitions = useMemo(() => {
+    const first = groupCollection?.[0]?.children || [];
+    return {
+      idDef: first.find((c) => c.settingDefinitionId?.toLowerCase().includes("_id"))?.settingDefinitionId,
+      autoresolveDef: first.find((c) => c.settingDefinitionId?.toLowerCase().includes("_autoresolve"))?.settingDefinitionId,
+      keywordDef: first.find((c) => c.settingDefinitionId?.toLowerCase().includes("_keyword"))?.settingDefinitionId,
+    };
+  }, [groupCollection]);
+
+  useEffect(() => {
+    if (groupCollection) {
+      formControl.setValue("groupSettingCollectionValue", groupCollection);
+      if (sanitizedParsedRaw) {
+        formControl.setValue("parsedRAWJson", sanitizedParsedRaw);
+      }
+    }
+  }, [groupCollection, sanitizedParsedRaw, formControl]);
+
+  useEffect(() => {
+    if (normalizedTemplate) {
+      formControl.setValue("displayName", normalizedTemplate.displayName || normalizedTemplate.name);
+      formControl.setValue("description", normalizedTemplate.description || normalizedTemplate.Description);
+    }
+  }, [normalizedTemplate, formControl]);
+
+  /**
+   * Convert RHF form values into the API payload while preserving Graph @odata fields.
+   * - Flattens react-hook-form autocomplete objects to their .value.
+   * - Restores @odata.* keys from the original template to avoid dot-notation loss from RHF.
+   * - Syncs displayName/description into parsed RAW JSON and reinserts the edited groupSettingCollectionValue.
+   * - Builds the final payload expected by /api/AddIntuneReusableSettingTemplate, including tenant fallback.
+   */
+  const customDataFormatter = useMemo(() => {
+    const getOriginalValueByPath = (obj, path) => {
+      if (!obj) return undefined;
+      const keys = path.split(".");
+      let current = obj;
+      for (const key of keys) {
+        if (current && typeof current === "object" && key in current) {
+          current = current[key];
+        } else {
+          return undefined;
+        }
+      }
+      return current;
+    };
+
+    const extractValues = (obj) => {
+      if (obj === null || obj === undefined) return obj;
+
+      if (
+        obj &&
+        typeof obj === "object" &&
+        obj.hasOwnProperty("value") &&
+        obj.hasOwnProperty("label")
+      ) {
+        return obj.value;
+      }
+
+      if (Array.isArray(obj)) {
+        return obj.map((item) => extractValues(item));
+      }
+
+      if (typeof obj === "object") {
+        const result = {};
+        Object.keys(obj).forEach((key) => {
+          const value = extractValues(obj[key]);
+
+          if (key.endsWith("@odata") && value && typeof value === "object") {
+            // Restore @odata.* keys from the original template to avoid RHF dot-notation artifacts
+            Object.keys(value).forEach((odataKey) => {
+              const baseKey = key.replace("@odata", "");
+              const originalKey = `${baseKey}@odata.${odataKey}`;
+              const originalValue = getOriginalValueByPath(normalizedTemplate, originalKey);
+              if (originalValue !== undefined) {
+                result[originalKey] = originalValue;
+              }
+            });
+          } else {
+            result[key] = value;
+          }
+        });
+        return result;
+      }
+
+      return obj;
+    };
+
+    return (values) => {
+      const processedValues = extractValues(values) || {};
+
+      // Sync template/policy name & description into parsed RAW JSON, and merge edited group collection
+      if (processedValues.parsedRAWJson) {
+        if (processedValues.displayName) {
+          processedValues.parsedRAWJson.displayName = processedValues.displayName;
+        }
+        if (processedValues.description) {
+          processedValues.parsedRAWJson.description = processedValues.description;
+        }
+
+        if (processedValues.groupSettingCollectionValue && processedValues.parsedRAWJson.settingInstance) {
+          processedValues.parsedRAWJson.settingInstance.groupSettingCollectionValue =
+            processedValues.groupSettingCollectionValue;
+        }
+      }
+
+      return {
+        GUID: processedValues.GUID || normalizedId,
+        displayName: processedValues.displayName,
+        description: processedValues.description,
+        package: processedValues.package,
+        rawJSON: JSON.stringify(processedValues.parsedRAWJson || processedValues, null, 2),
+        tenantFilter: processedValues.tenantFilter || currentTenant,
+      };
+    };
+  }, [currentTenant, normalizedId, normalizedTemplate]);
+
+  const { fields, append, remove } = useFieldArray({
+    control: formControl.control,
+    name: "groupSettingCollectionValue",
+  });
+
+  const createEmptyEntry = () => {
+    const { idDef, autoresolveDef, keywordDef } = groupChildDefinitions;
+    const children = [];
+
+    if (idDef) {
+      children.push({
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
+        settingDefinitionId: idDef,
+        simpleSettingValue: {
+          "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
+          value: generateGuid(),
+        },
+      });
+    }
+
+    if (autoresolveDef) {
+      children.push({
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        settingDefinitionId: autoresolveDef,
+        choiceSettingValue: { value: "", children: [] },
+      });
+    }
+
+    if (keywordDef) {
+      children.push({
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
+        settingDefinitionId: keywordDef,
+        simpleSettingValue: {
+          "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
+          value: "",
+        },
+      });
+    }
+
+    return { children };
+  };
+
+  return (
+    <CippFormPage
+      title={
+        normalizedTemplate?.displayName ||
+        normalizedTemplate?.name ||
+        normalizedTemplate?.Displayname ||
+        "Edit Reusable Settings Template"
+      }
+      formControl={formControl}
+      queryKey={[`ReusableSettingTemplate-${normalizedId}`, "ListIntuneReusableSettingTemplates"]}
+      backButtonTitle="Reusable Settings Templates"
+      postUrl="/api/AddIntuneReusableSettingTemplate"
+      backUrl="/endpoint/MEM/reusable-settings-templates"
+      customDataformatter={customDataFormatter}
+      formPageType="Edit"
+      resetForm={false}
+    >
+      <Box sx={{ my: 2 }}>
+        {templateQuery.isLoading ? (
+          <CippFormSkeleton layout={[2, 1, 2, 2]} />
+        ) : templateQuery.isError || !normalizedTemplate ? (
+          <Alert severity="error">Error loading reusable settings template.</Alert>
+        ) : (
+          <>
+            <Stack spacing={2} sx={{ mb: 3 }}>
+              <Typography variant="h6">Template</Typography>
+              <CippFormComponent
+                type="textField"
+                name="displayName"
+                label="Template / Policy Display Name"
+                formControl={formControl}
+              />
+              <CippFormComponent
+                type="textField"
+                name="description"
+                label="Template / Policy Description"
+                formControl={formControl}
+                multiline
+                minRows={2}
+              />
+            </Stack>
+
+            <Divider sx={{ mb: 2 }} />
+
+            {fields?.length > 0 && (
+              <Box sx={{ mb: 3 }}>
+                <Typography variant="h6" sx={{ mb: 1 }}>
+                  Group Setting Collection (Policy)
+                </Typography>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell sx={{ display: "none" }}>ID</TableCell>
+                      <TableCell>Autoresolve</TableCell>
+                      <TableCell>Keyword</TableCell>
+                      <TableCell align="right">Actions</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {fields.map((field, index) => {
+                      const idPath = `groupSettingCollectionValue.${index}.children.0.simpleSettingValue.value`;
+                      const autoresolvePath = `groupSettingCollectionValue.${index}.children.1.choiceSettingValue.value`;
+                      const keywordPath = `groupSettingCollectionValue.${index}.children.2.simpleSettingValue.value`;
+
+                      const autoresolveBase = groupChildDefinitions.autoresolveDef || "autoresolve";
+                      const autoresolveTrue = `${autoresolveBase}_true`;
+                      const autoresolveFalse = `${autoresolveBase}_false`;
+
+                      return (
+                        <TableRow key={field.id || index}>
+                          <TableCell sx={{ display: "none" }}>
+                            <CippFormComponent
+                              type="textField"
+                              name={idPath}
+                              label="ID"
+                              formControl={formControl}
+                            />
+                          </TableCell>
+                          <TableCell sx={{ width: "25%" }}>
+                            <CippFormComponent
+                              type="autoComplete"
+                              name={autoresolvePath}
+                              label="Autoresolve"
+                              formControl={formControl}
+                              multiple={false}
+                              options={[
+                                { label: "True", value: autoresolveTrue },
+                                { label: "False", value: autoresolveFalse },
+                              ]}
+                              creatable
+                            />
+                          </TableCell>
+                          <TableCell sx={{ width: "35%" }}>
+                            <CippFormComponent
+                              type="textField"
+                              name={keywordPath}
+                              label="Keyword"
+                              formControl={formControl}
+                              includeSystemVariables
+                            />
+                          </TableCell>
+                          <TableCell align="right">
+                            <Button size="small" color="error" onClick={() => remove(index)}>
+                              Remove
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+                <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+                  <Button variant="outlined" size="small" onClick={() => append(createEmptyEntry())}>
+                    Add row
+                  </Button>
+                </Stack>
+              </Box>
+            )}
+          </>
+        )}
+      </Box>
+    </CippFormPage>
+  );
+};
+
+EditReusableSettingsTemplate.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default EditReusableSettingsTemplate;

--- a/src/pages/endpoint/MEM/reusable-settings-templates/index.js
+++ b/src/pages/endpoint/MEM/reusable-settings-templates/index.js
@@ -1,0 +1,108 @@
+import { Layout as DashboardLayout } from "/src/layouts/index.js";
+import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx";
+import CippJsonView from "../../../../components/CippFormPages/CippJSONView";
+import { Button } from "@mui/material";
+import Link from "next/link";
+import { AddBox, GitHub, Delete, Edit } from "@mui/icons-material";
+import { ApiGetCall } from "/src/api/ApiCall";
+
+const Page = () => {
+  const pageTitle = "Reusable Settings Templates";
+
+  const integrations = ApiGetCall({
+    url: "/api/ListExtensionsConfig",
+    queryKey: "Integrations",
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+  });
+
+  const actions = [
+    {
+      label: "Edit Template",
+      icon: <Edit />,
+      link: "/endpoint/MEM/reusable-settings-templates/edit?id=[GUID]",
+    },
+    {
+      label: "Save to GitHub",
+      type: "POST",
+      url: "/api/ExecCommunityRepo",
+      icon: <GitHub />,
+      data: {
+        Action: "UploadTemplate",
+        GUID: "GUID",
+      },
+      fields: [
+        {
+          label: "Repository",
+          name: "FullName",
+          type: "select",
+          api: {
+            url: "/api/ListCommunityRepos",
+            data: {
+              WriteAccess: true,
+            },
+            queryKey: "CommunityRepos-Write",
+            dataKey: "Results",
+            valueField: "FullName",
+            labelField: "FullName",
+          },
+          multiple: false,
+          creatable: false,
+          required: true,
+          validators: {
+            required: { value: true, message: "This field is required" },
+          },
+        },
+        {
+          label: "Commit Message",
+          placeholder: "Enter a commit message for adding this file to GitHub",
+          name: "Message",
+          type: "textField",
+          multiline: true,
+          required: true,
+          rows: 4,
+        },
+      ],
+      confirmText: "Are you sure you want to save this template to the selected repository?",
+      condition: () => integrations.isSuccess && integrations?.data?.GitHub?.Enabled,
+    },
+    {
+      label: "Delete Template",
+      type: "POST",
+      url: "/api/RemoveIntuneReusableSettingTemplate",
+      icon: <Delete />,
+      data: {
+        ID: "GUID",
+      },
+      confirmText: "Do you want to delete the template?",
+      multiPost: false,
+    },
+  ];
+
+  const offCanvas = {
+    children: (row) => <CippJsonView object={row} type={"intune"} defaultOpen={true} />,
+    size: "lg",
+  };
+
+  const simpleColumns = ["displayName", "package", "description", "isSynced"];
+
+  return (
+    <CippTablePage
+      title={pageTitle}
+      cardButton={
+        <Button component={Link} href="reusable-settings-templates/add" startIcon={<AddBox />}>
+          Add Reusable Settings Template
+        </Button>
+      }
+      apiUrl="/api/ListIntuneReusableSettingTemplates"
+      tenantInTitle={false}
+      actions={actions}
+      offCanvas={offCanvas}
+      simpleColumns={simpleColumns}
+      queryKey="ListIntuneReusableSettingTemplates-table"
+    />
+  );
+};
+
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+export default Page;

--- a/src/pages/endpoint/MEM/reusable-settings/edit.jsx
+++ b/src/pages/endpoint/MEM/reusable-settings/edit.jsx
@@ -1,0 +1,136 @@
+import { useEffect } from "react";
+import { Alert, Box, Stack } from "@mui/material";
+import { Grid } from "@mui/system";
+import { useForm } from "react-hook-form";
+import { useRouter } from "next/router";
+import { Layout as DashboardLayout } from "/src/layouts/index.js";
+import CippFormPage from "/src/components/CippFormPages/CippFormPage";
+import CippFormSkeleton from "/src/components/CippFormPages/CippFormSkeleton";
+import CippFormComponent from "/src/components/CippComponents/CippFormComponent";
+import CippJsonView from "/src/components/CippFormPages/CippJSONView";
+import { ApiGetCall } from "/src/api/ApiCall";
+import { useSettings } from "/src/hooks/use-settings";
+
+const EditReusableSetting = () => {
+  const router = useRouter();
+  const { id, tenant } = router.query;
+  const { currentTenant } = useSettings();
+
+  const effectiveTenant = tenant || currentTenant;
+
+  const formControl = useForm({
+    mode: "onChange",
+    defaultValues: {
+      tenantFilter: effectiveTenant,
+    },
+  });
+
+  const { reset } = formControl;
+
+  const settingQuery = ApiGetCall({
+    url: "/api/ListIntuneReusableSettings",
+    queryKey: ["ListIntuneReusableSettings", effectiveTenant, id],
+    enabled: !!id && !!effectiveTenant,
+    data: { tenantFilter: effectiveTenant, ID: id },
+  });
+
+  const record = Array.isArray(settingQuery.data) ? settingQuery.data[0] : settingQuery.data;
+
+  useEffect(() => {
+    if (record) {
+      reset({
+        tenantFilter: effectiveTenant,
+        ID: record.id,
+        displayName: record.displayName,
+        description: record.description,
+        rawJSON: record.RawJSON,
+      });
+    }
+  }, [record, effectiveTenant, reset]);
+
+  const safeJson = () => {
+    if (!record?.RawJSON) return null;
+    try {
+      return JSON.parse(record.RawJSON);
+    } catch (e) {
+      console.error("Failed to parse RawJSON for reusable setting preview", {
+        error: e,
+        recordId: record?.id,
+      });
+      return null;
+    }
+  };
+
+  const customDataformatter = (values) => ({
+    tenantFilter: values.tenantFilter || effectiveTenant,
+    ID: values.ID, // forward the existing setting id so the API updates the same record
+    TemplateId: values.ID, // keep legacy TemplateId for API compatibility
+    displayName: values.displayName,
+    description: values.description,
+    rawJSON: values.rawJSON,
+  });
+
+  return (
+    <CippFormPage
+      title={record?.displayName ? `Reusable Setting - ${record.displayName}` : "Edit Reusable Setting"}
+      formControl={formControl}
+      queryKey={["ListIntuneReusableSettings", effectiveTenant, id]}
+      backButtonTitle="Reusable Settings"
+      postUrl="/api/AddIntuneReusableSetting"
+      customDataformatter={customDataformatter}
+      formPageType="Edit"
+      resetForm={false}
+    >
+      <Box sx={{ my: 2 }}>
+        {settingQuery.isLoading ? (
+          <CippFormSkeleton layout={[2, 2, 2]} />
+        ) : settingQuery.isError || !record ? (
+          <Alert severity="error">Error loading reusable setting or setting not found.</Alert>
+        ) : (
+          <Stack spacing={2}>
+            <Grid container spacing={2}>
+              <Grid size={{ xs: 12 }}>
+                <CippFormComponent type="hidden" name="tenantFilter" formControl={formControl} />
+                <CippFormComponent type="hidden" name="ID" formControl={formControl} />
+              </Grid>
+              <Grid size={{ xs: 12, md: 6 }}>
+                <CippFormComponent
+                  type="textField"
+                  name="displayName"
+                  label="Display Name"
+                  formControl={formControl}
+                  validators={{ required: "Display Name is required" }}
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 6 }}>
+                <CippFormComponent
+                  type="textField"
+                  name="description"
+                  label="Description"
+                  formControl={formControl}
+                  fullWidth
+                />
+              </Grid>
+              <Grid size={{ xs: 12 }}>
+                <CippFormComponent
+                  type="json"
+                  name="rawJSON"
+                  label="Raw JSON"
+                  formControl={formControl}
+                  required
+                  validators={{ required: "Raw JSON is required" }}
+                  rows={14}
+                />
+              </Grid>
+            </Grid>
+            <CippJsonView object={safeJson()} type="intune" defaultOpen={true} />
+          </Stack>
+        )}
+      </Box>
+    </CippFormPage>
+  );
+};
+
+EditReusableSetting.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default EditReusableSetting;

--- a/src/pages/endpoint/MEM/reusable-settings/index.js
+++ b/src/pages/endpoint/MEM/reusable-settings/index.js
@@ -1,0 +1,65 @@
+import { Book, DeleteForever } from "@mui/icons-material";
+import { CippReusableSettingsDeployDrawer } from "/src/components/CippComponents/CippReusableSettingsDeployDrawer.jsx";
+import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx";
+import { Layout as DashboardLayout } from "/src/layouts/index.js";
+import { useSettings } from "../../../../hooks/use-settings";
+import CippJsonView from "../../../../components/CippFormPages/CippJSONView";
+
+const Page = () => {
+  const { currentTenant } = useSettings();
+  const pageTitle = "Reusable Settings";
+
+  const actions = [
+    {
+      label: "Edit Reusable Setting",
+      link: `/endpoint/MEM/reusable-settings/edit?id=[id]&tenant=${currentTenant}&tenantFilter=${currentTenant}`,
+    },
+    {
+      label: "Delete Reusable Setting",
+      type: "POST",
+      url: "/api/RemoveIntuneReusableSetting",
+      icon: <DeleteForever />,
+      color: "error",
+      data: {
+        ID: "id",
+        DisplayName: "displayName",
+      },
+      confirmText: "Delete this reusable setting from the tenant?",
+      multiPost: false,
+    },
+    {
+      label: "Create Template from Setting",
+      type: "POST",
+      url: "/api/AddIntuneReusableSettingTemplate",
+      icon: <Book />,
+      data: {
+        displayName: "displayName",
+        description: "description",
+        rawJSON: "RawJSON",
+      },
+      confirmText: "Create a reusable settings template from this entry?",
+      multiPost: false,
+    },
+  ];
+
+  const offCanvas = {
+    children: (row) => <CippJsonView object={row} type={"intune"} defaultOpen={true} />,
+    size: "lg",
+  };
+
+  return (
+    <CippTablePage
+      title={pageTitle}
+      cardButton={<CippReusableSettingsDeployDrawer requiredPermissions={["Endpoint.MEM.ReadWrite"]} />}
+      apiUrl="/api/ListIntuneReusableSettings"
+      queryKey={`ListIntuneReusableSettings-${currentTenant}`}
+      actions={actions}
+      offCanvas={offCanvas}
+      simpleColumns={["displayName", "description", "id", "version"]}
+    />
+  );
+};
+
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default Page;


### PR DESCRIPTION
This pull request introduces comprehensive support for Intune Reusable Settings Templates throughout the application, including new UI components, API integration, and navigation updates. The changes enable users to create, view, and deploy reusable settings templates, improving consistency and reusability of Intune policy configurations.

**Depends on**: https://github.com/KelvinTegelaar/CIPP-API/pull/1766
**Closes**: #5153 

**Intune Reusable Settings Templates Feature**

* Added a new reusable settings deploy drawer component (`CippReusableSettingsDeployDrawer.jsx`) that allows users to select, view, and deploy Intune reusable settings templates, with permission checks and API integration for listing and deploying templates.
* Created a form component for adding new Intune reusable settings templates (`CippAddIntuneReusableSettingTemplateForm.jsx`) and a dedicated page for submitting new templates (`reusable-settings-templates/add.jsx`). [[1]](diffhunk://#diff-c46c73ad19cdd8d1d1afd2b79b4632444c03c494dac39ddf83a855cfa90d4134R1-R54) [[2]](diffhunk://#diff-6dee06195f5f77cb119f5c107895b35c74cd80fe39e327885d59b40eaadaa4d1R1-R36)
* Updated the standards configuration (`standards.json`) to define the new "Reusable Settings Template" standard, including metadata, help text, and UI configuration for template selection.

**UI and Navigation Enhancements**

* Added new navigation menu items for "Reusable Settings" and "Reusable Settings Templates" in the endpoint MEM section, making these features easily discoverable.

**Intune Template Field Rendering Improvements**

* Enhanced the template field renderer to support child-friendly rendering of Intune group setting collections, using memoized lookup for setting definitions and improved handling of choice and simple setting values. [[1]](diffhunk://#diff-94b740c67bf7f7bb925dbbe70989eeaf0e9030e98b8b77c6ee7689ed29a067e4L1-R1) [[2]](diffhunk://#diff-94b740c67bf7f7bb925dbbe70989eeaf0e9030e98b8b77c6ee7689ed29a067e4R13-R21) [[3]](diffhunk://#diff-94b740c67bf7f7bb925dbbe70989eeaf0e9030e98b8b77c6ee7689ed29a067e4R265-R344) [[4]](diffhunk://#diff-94b740c67bf7f7bb925dbbe70989eeaf0e9030e98b8b77c6ee7689ed29a067e4L302-R391) [[5]](diffhunk://#diff-94b740c67bf7f7bb925dbbe70989eeaf0e9030e98b8b77c6ee7689ed29a067e4L330-R417)

**Screenshots**
<img width="1092" height="409" alt="image" src="https://github.com/user-attachments/assets/4c2b8880-1fcd-48f1-b60b-05f063a1c8e4" />
<img width="1076" height="841" alt="image" src="https://github.com/user-attachments/assets/56264749-6d6e-4a5f-ba4e-3011f467138d" />
