### PR TITLE
Add JIT Admin Templates and settings integration

### DIFF
--- a/src/layouts/config.js
+++ b/src/layouts/config.js
@@ -74,6 +74,11 @@ export const nativeMenuItems = [
             permissions: ["Identity.Role.*"],
           },
           {
+            title: "JIT Admin Templates",
+            path: "/identity/administration/jit-admin-templates",
+            permissions: ["Identity.Role.*"],
+          },
+          {
             title: "Offboarding Wizard",
             path: "/identity/administration/offboarding-wizard",
             permissions: ["Identity.User.*"],

--- a/src/pages/cipp/super-admin/jit-admin-settings.js
+++ b/src/pages/cipp/super-admin/jit-admin-settings.js
@@ -1,0 +1,146 @@
+import { TabbedLayout } from "/src/layouts/TabbedLayout";
+import { Layout as DashboardLayout } from "/src/layouts/index.js";
+import tabOptions from "./tabOptions";
+import CippFormPage from "/src/components/CippFormPages/CippFormPage";
+import { useForm } from "react-hook-form";
+import { Typography, Alert } from "@mui/material";
+import { Grid } from "@mui/system";
+import CippFormComponent from "/src/components/CippComponents/CippFormComponent";
+import { ApiGetCall } from "../../../api/ApiCall";
+import { useEffect } from "react";
+
+const Page = () => {
+  const pageTitle = "JIT Admin Settings";
+
+  const formControl = useForm({
+    mode: "onChange",
+    defaultValues: {
+      MaxDuration: "",
+    },
+  });
+
+  const jitSettings = ApiGetCall({
+    url: "/api/ExecJITAdminSettings?Action=Get",
+    queryKey: "jitAdminSettings",
+  });
+
+  useEffect(() => {
+    if (jitSettings.isSuccess && jitSettings.data) {
+      formControl.reset({
+        MaxDuration: jitSettings.data?.MaxDuration || [],
+      });
+    }
+  }, [jitSettings.isSuccess, jitSettings.data]);
+
+  return (
+    <CippFormPage
+      title={pageTitle}
+      hideBackButton={true}
+      hidePageType={true}
+      formControl={formControl}
+      resetForm={false}
+      postUrl="/api/ExecJITAdminSettings"
+      queryKey={["jitAdminSettings"]}
+      customDataformatter={(values) => ({
+        Action: "Set",
+        MaxDuration: values.MaxDuration || null,
+      })}
+    >
+      <Grid container spacing={2} sx={{ mb: 3 }}>
+        <Grid size={{ md: 12, xs: 12 }}>
+          <Typography variant="body2" color="textSecondary" sx={{ mb: 3 }}>
+            Configure maximum allowed duration for Just-In-Time (JIT) admin accounts. This setting
+            helps enforce security policies by preventing technicians from creating JIT admin
+            accounts with excessively long lifespans. Validation is performed on the backend when
+            creating JIT admin accounts.
+          </Typography>
+        </Grid>
+
+        <Grid size={{ md: 12, xs: 12 }}>
+          <Alert severity="info" sx={{ mb: 3 }}>
+            Set the maximum duration in ISO 8601 format, or leave empty for no limit (default). The
+            backend will validate that the difference between the start and end dates of any JIT
+            admin account does not exceed the configured maximum duration.
+          </Alert>
+        </Grid>
+
+        <Grid size={{ md: 12, xs: 12 }}>
+          <CippFormComponent
+            type="autoComplete"
+            name="MaxDuration"
+            label="Maximum Duration (ISO 8601)"
+            placeholder="Leave empty for no limit, or enter duration (e.g., P28D for 4 weeks)"
+            options={[
+              { label: "1 Hour", value: "PT1H" },
+              { label: "4 Hours", value: "PT4H" },
+              { label: "8 Hours", value: "PT8H" },
+              { label: "1 Day", value: "P1D" },
+              { label: "3 Days", value: "P3D" },
+              { label: "7 Days", value: "P7D" },
+              { label: "14 Days", value: "P14D" },
+              { label: "30 Days", value: "P30D" },
+            ]}
+            creatable={true}
+            multiple={false}
+            validators={{
+              validate: {
+                iso8601duration: (value) => {
+                  // Allow empty value (no limit)
+                  if (typeof value !== "string" || value.trim() === "") {
+                    return true;
+                  }
+                  const iso8601Regex = /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
+                  if (!iso8601Regex.test(value)) {
+                    return "Invalid format. Use PT1H, P1D, P7D, P28D, etc.";
+                  }
+                  return true;
+                },
+              },
+            }}
+            formControl={formControl}
+            helperText="ISO 8601 format: PT1H (1 hour), P1D (1 day), P7D (1 week), P28D (4 weeks). Leave empty for no limit."
+          />
+        </Grid>
+
+        <Grid size={{ md: 12, xs: 12 }}>
+          <Alert severity="warning">
+            <Typography variant="body2" sx={{ fontWeight: "bold", mb: 1 }}>
+              Important Notes:
+            </Typography>
+            <Typography variant="body2" component="div">
+              <ul style={{ margin: 0, paddingLeft: "20px" }}>
+                <li>Leave empty for no limit on JIT admin account duration (default behavior)</li>
+                <li>
+                  The duration is calculated from the start date to the expiration date of the JIT
+                  admin
+                </li>
+                <li>
+                  If a technician attempts to exceed this limit, the backend will reject the
+                  request with an error message
+                </li>
+                <li>This setting applies globally to all tenants and all JIT admin creations</li>
+              </ul>
+            </Typography>
+          </Alert>
+        </Grid>
+
+        <Grid size={{ md: 12, xs: 12 }}>
+          <Typography variant="body2" color="textSecondary" sx={{ mt: 2 }}>
+            <strong>Example:</strong> If maximum duration is set to P28D (4 weeks), and a
+            technician tries to create a JIT admin account lasting 1.5 months, the backend will
+            reject the request with an error: "Requested JIT Admin duration (56 days) exceeds the
+            maximum allowed duration of P28D (28 days)".
+          </Typography>
+        </Grid>
+      </Grid>
+    </CippFormPage>
+  );
+};
+
+Page.getLayout = (page) => (
+  <DashboardLayout>
+    <TabbedLayout tabOptions={tabOptions}>{page}</TabbedLayout>
+  </DashboardLayout>
+);
+
+export default Page;

--- a/src/pages/cipp/super-admin/tabOptions.json
+++ b/src/pages/cipp/super-admin/tabOptions.json
@@ -12,6 +12,10 @@
     "path": "/cipp/super-admin/time-settings"
   },
   {
+    "label": "JIT Admin Settings",
+    "path": "/cipp/super-admin/jit-admin-settings"
+  },
+  {
     "label": "CIPP Roles",
     "path": "/cipp/super-admin/cipp-roles"
   },

--- a/src/pages/identity/administration/jit-admin-templates/add.jsx
+++ b/src/pages/identity/administration/jit-admin-templates/add.jsx
@@ -1,0 +1,287 @@
+import { Box, Divider, Typography } from "@mui/material";
+import { Grid } from "@mui/system";
+import CippFormPage from "../../../../components/CippFormPages/CippFormPage";
+import { Layout as DashboardLayout } from "/src/layouts/index.js";
+import { useForm, useWatch } from "react-hook-form";
+import CippFormComponent from "../../../../components/CippComponents/CippFormComponent";
+import { CippFormCondition } from "../../../../components/CippComponents/CippFormCondition";
+import { CippFormDomainSelector } from "../../../../components/CippComponents/CippFormDomainSelector";
+import { CippFormUserSelector } from "../../../../components/CippComponents/CippFormUserSelector";
+import gdaproles from "/src/data/GDAPRoles.json";
+import { useSettings } from "../../../../hooks/use-settings";
+
+const Page = () => {
+  const userSettingsDefaults = useSettings();
+  const formControl = useForm({
+    mode: "onChange",
+    defaultValues: {
+      tenantFilter: userSettingsDefaults.currentTenant,
+    },
+  });
+
+  const watchedTenant = useWatch({ control: formControl.control, name: "tenantFilter" });
+  const isAllTenants = watchedTenant?.value === "AllTenants" || watchedTenant === "AllTenants";
+
+  return (
+    <>
+      <CippFormPage
+        resetForm={false}
+        queryKey={`ListJITAdminTemplates-${userSettingsDefaults.currentTenant}`}
+        formControl={formControl}
+        title="JIT Admin Template"
+        backButtonTitle="JIT Admin Templates"
+        postUrl="/api/AddJITAdminTemplate"
+      >
+        <Box sx={{ my: 2 }}>
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12 }}>
+              <Typography variant="h6">Template Information</Typography>
+            </Grid>
+            <Grid size={{ md: 6, xs: 12 }}>
+              <CippFormComponent
+                type="textField"
+                fullWidth
+                label="Template Name"
+                name="templateName"
+                formControl={formControl}
+                required={true}
+                validators={{ required: "Template name is required" }}
+              />
+            </Grid>
+            <Grid size={{ md: 6, xs: 12 }}>
+              <CippFormComponent
+                type="switch"
+                label="Default for Tenant"
+                name="defaultForTenant"
+                formControl={formControl}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <Divider sx={{ my: 2 }} />
+              <Typography variant="h6">Default JIT Admin Settings</Typography>
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <CippFormComponent
+                type="autoComplete"
+                fullWidth
+                label="Default Roles"
+                name="defaultRoles"
+                creatable={false}
+                options={gdaproles.map((role) => ({ label: role.Name, value: role.ObjectId }))}
+                formControl={formControl}
+                required={true}
+                validators={{
+                  required: "At least one default role is required",
+                  validate: (options) => {
+                    if (!options?.length) {
+                      return "At least one default role is required";
+                    }
+                    return true;
+                  },
+                }}
+              />
+            </Grid>
+
+            <Grid size={{ md: 6, xs: 12 }}>
+              <CippFormComponent
+                type="autoComplete"
+                fullWidth
+                label="Default Duration"
+                name="defaultDuration"
+                multiple={false}
+                options={[
+                  { label: "1 Hour", value: "PT1H" },
+                  { label: "4 Hours", value: "PT4H" },
+                  { label: "8 Hours", value: "PT8H" },
+                  { label: "1 Day", value: "P1D" },
+                  { label: "3 Days", value: "P3D" },
+                  { label: "7 Days", value: "P7D" },
+                  { label: "14 Days", value: "P14D" },
+                  { label: "30 Days", value: "P30D" },
+                ]}
+                formControl={formControl}
+                helperText="ISO 8601 format: PT1H (1 hour), P1D (1 day), PT2H30M (2.5 hours)"
+                validators={{
+                  validate: (value) => {
+                    if (!value) return true; // Optional field
+                    const durationValue = typeof value === "object" && value.value ? value.value : value;
+                    const iso8601Regex = /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
+                    if (!iso8601Regex.test(durationValue)) {
+                      return "Invalid format. Use PT1H, P1D, PT2H30M, etc.";
+                    }
+                    return true;
+                  },
+                }}
+              />
+            </Grid>
+
+            <Grid size={{ md: 6, xs: 12 }}>
+              <CippFormComponent
+                type="autoComplete"
+                fullWidth
+                label="Default Expiration Action"
+                name="defaultExpireAction"
+                multiple={false}
+                creatable={false}
+                options={[
+                  { label: "Delete User", value: "DeleteUser" },
+                  { label: "Disable User", value: "DisableUser" },
+                  { label: "Remove Roles", value: "RemoveRoles" },
+                ]}
+                formControl={formControl}
+              />
+            </Grid>
+
+            <Grid size={{ md: 6, xs: 12 }}>
+              <CippFormComponent
+                type="autoComplete"
+                fullWidth
+                label="Default Notification Actions"
+                name="defaultNotificationActions"
+                multiple={true}
+                creatable={false}
+                options={[
+                  { label: "Webhook", value: "Webhook" },
+                  { label: "Email", value: "email" },
+                  { label: "PSA", value: "PSA" },
+                ]}
+                formControl={formControl}
+              />
+            </Grid>
+
+            <Grid size={{ md: 6, xs: 12 }}>
+              <CippFormComponent
+                type="switch"
+                label="Generate TAP by Default"
+                name="generateTAPByDefault"
+                formControl={formControl}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <CippFormComponent
+                type="textField"
+                label="Reason Template"
+                name="reasonTemplate"
+                placeholder="Enter a default reason template for JIT Admin requests"
+                multiline
+                rows={3}
+                formControl={formControl}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <Divider sx={{ my: 2 }} />
+              <Typography variant="h6">User Creation Settings</Typography>
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                  {isAllTenants
+                    ? "AllTenants templates can only use 'New User' option (no further options are configurable)"
+                    : "Choose whether this template creates a new user or assigns to existing user"}
+                </Typography>
+                <CippFormComponent
+                  type="radio"
+                  label="Default User Action"
+                  name="defaultUserAction"
+                  row
+                  formControl={formControl}
+                  options={
+                    isAllTenants
+                      ? [{ label: "New User", value: "create" }]
+                      : [
+                          { label: "New User", value: "create" },
+                          { label: "Existing User", value: "select" },
+                        ]
+                  }
+                />
+            </Grid>
+
+            <CippFormCondition
+              formControl={formControl}
+              field="defaultUserAction"
+              compareType="is"
+              compareValue="create"
+            >
+              <Grid size={{ xs: 12 }}>
+                <Typography variant="body2" color="text.secondary" sx={{ mt: 2, mb: 1 }}>
+                  {isAllTenants
+                    ? "Pre-fill user details (optional, for AllTenants templates)"
+                    : "Pre-fill user details (optional, only for specific tenant templates)"}
+                </Typography>
+              </Grid>
+              <Grid size={{ md: 6, xs: 12 }}>
+                <CippFormComponent
+                  type="textField"
+                  fullWidth
+                  label="Default First Name"
+                  name="defaultFirstName"
+                  formControl={formControl}
+                />
+              </Grid>
+              <Grid size={{ md: 6, xs: 12 }}>
+                <CippFormComponent
+                  type="textField"
+                  fullWidth
+                  label="Default Last Name"
+                  name="defaultLastName"
+                  formControl={formControl}
+                />
+              </Grid>
+              <Grid size={{ md: 6, xs: 12 }}>
+                <CippFormComponent
+                  type="textField"
+                  fullWidth
+                  label="Default Username"
+                  name="defaultUserName"
+                  formControl={formControl}
+                />
+              </Grid>
+              {!isAllTenants && (
+                <Grid size={{ md: 6, xs: 12 }}>
+                  <CippFormDomainSelector
+                    formControl={formControl}
+                    name="defaultDomain"
+                    label="Default Domain"
+                  />
+                </Grid>
+              )}
+            </CippFormCondition>
+
+            <CippFormCondition
+              formControl={formControl}
+              field="defaultUserAction"
+              compareType="is"
+              compareValue="select"
+            >
+              {!isAllTenants && (
+                <>
+                  <Grid size={{ xs: 12 }}>
+                    <Typography variant="body2" color="text.secondary" sx={{ mt: 2, mb: 1 }}>
+                      Select default user (optional, only for specific tenant templates)
+                    </Typography>
+                  </Grid>
+                  <Grid size={{ xs: 12 }}>
+                    <CippFormUserSelector
+                      formControl={formControl}
+                      multiple={false}
+                      name="defaultExistingUser"
+                      label="Default User"
+                    />
+                  </Grid>
+                </>
+              )}
+            </CippFormCondition>
+          </Grid>
+        </Box>
+      </CippFormPage>
+    </>
+  );
+};
+
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default Page;

--- a/src/pages/identity/administration/jit-admin-templates/edit.jsx
+++ b/src/pages/identity/administration/jit-admin-templates/edit.jsx
@@ -1,0 +1,313 @@
+import { Box, Divider, Typography } from "@mui/material";
+import { Grid } from "@mui/system";
+import CippFormPage from "../../../../components/CippFormPages/CippFormPage";
+import { Layout as DashboardLayout } from "/src/layouts/index.js";
+import { useForm, useWatch } from "react-hook-form";
+import CippFormComponent from "../../../../components/CippComponents/CippFormComponent";
+import { CippFormCondition } from "../../../../components/CippComponents/CippFormCondition";
+import { CippFormDomainSelector } from "../../../../components/CippComponents/CippFormDomainSelector";
+import { CippFormUserSelector } from "../../../../components/CippComponents/CippFormUserSelector";
+import gdaproles from "/src/data/GDAPRoles.json";
+import { useSettings } from "../../../../hooks/use-settings";
+import { useRouter } from "next/router";
+import { ApiGetCall } from "../../../../api/ApiCall";
+import { useEffect } from "react";
+
+const Page = () => {
+  const userSettingsDefaults = useSettings();
+  const router = useRouter();
+  const { id } = router.query;
+
+  const formControl = useForm({
+    mode: "onChange",
+    defaultValues: {
+      tenantFilter: userSettingsDefaults.currentTenant,
+    },
+  });
+
+  const watchedTenant = useWatch({ control: formControl.control, name: "tenantFilter" });
+  const isAllTenants = watchedTenant?.value === "AllTenants" || watchedTenant === "AllTenants";
+
+  // Get the template data
+  const template = ApiGetCall({
+    url: `/api/ListJITAdminTemplates?GUID=${id}`,
+    queryKey: `JITAdminTemplate-${id}`,
+    waiting: !!id,
+  });
+
+  // Populate form when template data is loaded
+  useEffect(() => {
+    if (template.isSuccess && template.data?.[0]) {
+      const templateData = template.data[0];
+      formControl.reset({
+        ...templateData,
+        GUID: id,
+      });
+    }
+  }, [template.isSuccess, template.data]);
+
+  return (
+    <>
+      <CippFormPage
+        resetForm={false}
+        queryKey={`JITAdminTemplate-${id}`}
+        formControl={formControl}
+        title="Edit JIT Admin Template"
+        backButtonTitle="JIT Admin Templates"
+        postUrl="/api/EditJITAdminTemplate"
+      >
+        <Box sx={{ my: 2 }}>
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12 }}>
+              <Typography variant="h6">Template Information</Typography>
+            </Grid>
+            <Grid size={{ md: 6, xs: 12 }}>
+              <CippFormComponent
+                type="textField"
+                fullWidth
+                label="Template Name"
+                name="templateName"
+                formControl={formControl}
+                required={true}
+                validators={{ required: "Template name is required" }}
+              />
+            </Grid>
+            <Grid size={{ md: 6, xs: 12 }}>
+              <CippFormComponent
+                type="switch"
+                label="Default for Tenant"
+                name="defaultForTenant"
+                formControl={formControl}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <Divider sx={{ my: 2 }} />
+              <Typography variant="h6">Default JIT Admin Settings</Typography>
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <CippFormComponent
+                type="autoComplete"
+                fullWidth
+                label="Default Roles"
+                name="defaultRoles"
+                creatable={false}
+                options={gdaproles.map((role) => ({ label: role.Name, value: role.ObjectId }))}
+                formControl={formControl}
+                required={true}
+                validators={{
+                  required: "At least one default role is required",
+                  validate: (options) => {
+                    if (!options?.length) {
+                      return "At least one default role is required";
+                    }
+                    return true;
+                  },
+                }}
+              />
+            </Grid>
+
+            <Grid size={{ md: 6, xs: 12 }}>
+              <CippFormComponent
+                type="autoComplete"
+                fullWidth
+                label="Default Duration"
+                name="defaultDuration"
+                multiple={false}
+                options={[
+                  { label: "1 Hour", value: "PT1H" },
+                  { label: "4 Hours", value: "PT4H" },
+                  { label: "8 Hours", value: "PT8H" },
+                  { label: "1 Day", value: "P1D" },
+                  { label: "3 Days", value: "P3D" },
+                  { label: "7 Days", value: "P7D" },
+                  { label: "14 Days", value: "P14D" },
+                  { label: "30 Days", value: "P30D" },
+                ]}
+                formControl={formControl}
+                helperText="ISO 8601 format: PT1H (1 hour), P1D (1 day), PT2H30M (2.5 hours)"
+                validators={{
+                  validate: (value) => {
+                    if (!value) return true; // Optional field
+                    const durationValue = typeof value === "object" && value.value ? value.value : value;
+                    const iso8601Regex = /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
+                    if (!iso8601Regex.test(durationValue)) {
+                      return "Invalid format. Use PT1H, P1D, PT2H30M, etc.";
+                    }
+                    return true;
+                  },
+                }}
+              />
+            </Grid>
+
+            <Grid size={{ md: 6, xs: 12 }}>
+              <CippFormComponent
+                type="autoComplete"
+                fullWidth
+                label="Default Expiration Action"
+                name="defaultExpireAction"
+                multiple={false}
+                creatable={false}
+                options={[
+                  { label: "Delete User", value: "DeleteUser" },
+                  { label: "Disable User", value: "DisableUser" },
+                  { label: "Remove Roles", value: "RemoveRoles" },
+                ]}
+                formControl={formControl}
+              />
+            </Grid>
+
+            <Grid size={{ md: 6, xs: 12 }}>
+              <CippFormComponent
+                type="autoComplete"
+                fullWidth
+                label="Default Notification Actions"
+                name="defaultNotificationActions"
+                multiple={true}
+                creatable={false}
+                options={[
+                  { label: "Webhook", value: "Webhook" },
+                  { label: "Email", value: "email" },
+                  { label: "PSA", value: "PSA" },
+                ]}
+                formControl={formControl}
+              />
+            </Grid>
+
+            <Grid size={{ md: 6, xs: 12 }}>
+              <CippFormComponent
+                type="switch"
+                label="Generate TAP by Default"
+                name="generateTAPByDefault"
+                formControl={formControl}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <CippFormComponent
+                type="textField"
+                label="Reason Template"
+                name="reasonTemplate"
+                placeholder="Enter a default reason template for JIT Admin requests"
+                multiline
+                rows={3}
+                formControl={formControl}
+              />
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <Divider sx={{ my: 2 }} />
+              <Typography variant="h6">User Creation Settings</Typography>
+            </Grid>
+
+            <Grid size={{ xs: 12 }}>
+              <CippFormComponent
+                type="radio"
+                label="Default User Action"
+                name="defaultUserAction"
+                row
+                formControl={formControl}
+                options={
+                  isAllTenants
+                    ? [{ label: "New User", value: "create" }]
+                    : [
+                        { label: "New User", value: "create" },
+                        { label: "Existing User", value: "select" },
+                      ]
+                }
+                helperText={
+                  isAllTenants
+                    ? "AllTenants templates can only use 'New User' option"
+                    : "Choose whether this template creates a new user or assigns to existing user"
+                }
+              />
+            </Grid>
+
+            <CippFormCondition
+              formControl={formControl}
+              field="defaultUserAction"
+              compareType="is"
+              compareValue="create"
+            >
+              <Grid size={{ xs: 12 }}>
+                <Typography variant="body2" color="text.secondary" sx={{ mt: 2, mb: 1 }}>
+                  {isAllTenants
+                    ? "Pre-fill user details (optional, for AllTenants templates)"
+                    : "Pre-fill user details (optional, only for specific tenant templates)"}
+                </Typography>
+              </Grid>
+              <Grid size={{ md: 6, xs: 12 }}>
+                <CippFormComponent
+                  type="textField"
+                  fullWidth
+                  label="Default First Name"
+                  name="defaultFirstName"
+                  formControl={formControl}
+                />
+              </Grid>
+              <Grid size={{ md: 6, xs: 12 }}>
+                <CippFormComponent
+                  type="textField"
+                  fullWidth
+                  label="Default Last Name"
+                  name="defaultLastName"
+                  formControl={formControl}
+                />
+              </Grid>
+              <Grid size={{ md: 6, xs: 12 }}>
+                <CippFormComponent
+                  type="textField"
+                  fullWidth
+                  label="Default Username"
+                  name="defaultUserName"
+                  formControl={formControl}
+                />
+              </Grid>
+              {!isAllTenants && (
+                <Grid size={{ md: 6, xs: 12 }}>
+                  <CippFormDomainSelector
+                    formControl={formControl}
+                    name="defaultDomain"
+                    label="Default Domain"
+                  />
+                </Grid>
+              )}
+            </CippFormCondition>
+
+            <CippFormCondition
+              formControl={formControl}
+              field="defaultUserAction"
+              compareType="is"
+              compareValue="select"
+            >
+              {!isAllTenants && (
+                <>
+                  <Grid size={{ xs: 12 }}>
+                    <Typography variant="body2" color="text.secondary" sx={{ mt: 2, mb: 1 }}>
+                      Select default user (optional, only for specific tenant templates)
+                    </Typography>
+                  </Grid>
+                  <Grid size={{ xs: 12 }}>
+                    <CippFormUserSelector
+                      formControl={formControl}
+                      multiple={false}
+                      name="defaultExistingUser"
+                      label="Default User"
+                    />
+                  </Grid>
+                </>
+              )}
+            </CippFormCondition>
+
+            <CippFormComponent type="hidden" name="GUID" formControl={formControl} />
+          </Grid>
+        </Box>
+      </CippFormPage>
+    </>
+  );
+};
+
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default Page;

--- a/src/pages/identity/administration/jit-admin-templates/index.js
+++ b/src/pages/identity/administration/jit-admin-templates/index.js
@@ -1,0 +1,140 @@
+import { Button } from "@mui/material";
+import { CippTablePage } from "/src/components/CippComponents/CippTablePage.jsx";
+import { Layout as DashboardLayout } from "/src/layouts/index.js";
+import { AddBox, Delete, GitHub, Edit } from "@mui/icons-material";
+import Link from "next/link";
+import { ApiGetCall } from "/src/api/ApiCall";
+import { CippPropertyListCard } from "../../../../components/CippCards/CippPropertyListCard";
+import { getCippTranslation } from "../../../../utils/get-cipp-translation";
+import { getCippFormatting } from "../../../../utils/get-cipp-formatting";
+import { useSettings } from "../../../../hooks/use-settings";
+
+const Page = () => {
+  const pageTitle = "JIT Admin Templates";
+  const tenantFilter = useSettings()?.currentTenant;
+  const integrations = ApiGetCall({
+    url: "/api/ListExtensionsConfig",
+    queryKey: "Integrations",
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+  });
+  const actions = [
+    {
+      label: "Edit Template",
+      icon: <Edit />,
+      link: "/identity/administration/jit-admin-templates/edit?id=[GUID]",
+    },
+    {
+      label: "Save to GitHub",
+      type: "POST",
+      url: "/api/ExecCommunityRepo",
+      icon: <GitHub />,
+      data: {
+        Action: "UploadTemplate",
+        GUID: "GUID",
+      },
+      fields: [
+        {
+          label: "Repository",
+          name: "FullName",
+          type: "select",
+          api: {
+            url: "/api/ListCommunityRepos",
+            data: {
+              WriteAccess: true,
+            },
+            queryKey: "CommunityRepos-Write",
+            dataKey: "Results",
+            valueField: "FullName",
+            labelField: "FullName",
+          },
+          multiple: false,
+          creatable: false,
+          required: true,
+          validators: {
+            required: { value: true, message: "This field is required" },
+          },
+        },
+        {
+          label: "Commit Message",
+          placeholder: "Enter a commit message for adding this file to GitHub",
+          name: "Message",
+          type: "textField",
+          multiline: true,
+          required: true,
+          rows: 4,
+        },
+      ],
+      confirmText: "Are you sure you want to save this template to the selected repository?",
+      condition: () => integrations.isSuccess && integrations?.data?.GitHub?.Enabled,
+    },
+    {
+      label: "Delete Template",
+      type: "POST",
+      url: "/api/RemoveJITAdminTemplate",
+      icon: <Delete />,
+      data: {
+        ID: "GUID",
+      },
+      confirmText: "Do you want to delete the template?",
+      multiPost: false,
+    },
+  ];
+
+  const offCanvas = {
+    children: (data) => {
+      const keys = Object.keys(data).filter(
+        (key) => !key.includes("@odata") && !key.includes("@data")
+      );
+      const properties = [];
+      keys.forEach((key) => {
+        if (data[key] && data[key].length > 0) {
+          properties.push({
+            label: getCippTranslation(key),
+            value: getCippFormatting(data[key], key),
+          });
+        }
+      });
+      return (
+        <CippPropertyListCard
+          cardSx={{ p: 0, m: -2 }}
+          title="Template Details"
+          propertyItems={properties}
+          actionItems={actions}
+          data={data}
+        />
+      );
+    },
+  };
+
+  return (
+    <CippTablePage
+      title={pageTitle}
+      apiUrl="/api/ListJITAdminTemplates"
+      queryKey={`ListJITAdminTemplates-${tenantFilter}`}
+      tenantInTitle={false}
+      actions={actions}
+      cardButton={
+        <Button component={Link} href="jit-admin-templates/add" startIcon={<AddBox />}>
+          Add JIT Admin Template
+        </Button>
+      }
+      offCanvas={offCanvas}
+      simpleColumns={[
+        "templateName",
+        "defaultForTenant",
+        "tenantFilter",
+        "defaultDuration.label",
+        "defaultRoles",
+        "generateTAPByDefault",
+        "defaultExpireAction.label",
+        "defaultNotificationActions",
+        "reasonTemplate"
+      ]}
+    />
+  );
+};
+
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+
+export default Page;

--- a/src/pages/identity/administration/jit-admin/add.jsx
+++ b/src/pages/identity/administration/jit-admin/add.jsx
@@ -3,14 +3,181 @@ import { Grid } from "@mui/system";
 import CippFormPage from "../../../../components/CippFormPages/CippFormPage";
 import { Layout as DashboardLayout } from "/src/layouts/index.js";
 import { CippFormTenantSelector } from "../../../../components/CippComponents/CippFormTenantSelector";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import CippFormComponent from "../../../../components/CippComponents/CippFormComponent";
 import { CippFormCondition } from "../../../../components/CippComponents/CippFormCondition";
 import gdaproles from "/src/data/GDAPRoles.json";
 import { CippFormDomainSelector } from "../../../../components/CippComponents/CippFormDomainSelector";
 import { CippFormUserSelector } from "../../../../components/CippComponents/CippFormUserSelector";
+import { ApiGetCall } from "../../../../api/ApiCall";
+import { useEffect, useState } from "react";
+
 const Page = () => {
   const formControl = useForm({ mode: "onChange" });
+  const selectedTenant = useWatch({ control: formControl.control, name: "tenantFilter" });
+  const [selectedTemplate, setSelectedTemplate] = useState(null);
+  
+  const jitAdminTemplates = ApiGetCall({
+    url: selectedTenant ? `/api/ListJITAdminTemplates?TenantFilter=${selectedTenant.value}` : undefined,
+    queryKey: selectedTenant ? `JITAdminTemplates-${selectedTenant.value}` : undefined,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    enabled: !!selectedTenant,
+  });
+
+  const watcher = useWatch({ control: formControl.control });
+
+  // Simple duration parser for basic ISO 8601 durations
+  const parseDuration = (duration) => {
+    if (!duration) return null;
+    const matches = duration.match(/P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?/);
+    if (!matches) return null;
+    return {
+      years: parseInt(matches[1] || 0),
+      months: parseInt(matches[2] || 0),
+      weeks: parseInt(matches[3] || 0),
+      days: parseInt(matches[4] || 0),
+      hours: parseInt(matches[5] || 0),
+      minutes: parseInt(matches[6] || 0),
+      seconds: parseInt(matches[7] || 0),
+    };
+  };
+
+  const addDurationToDate = (date, duration) => {
+    if (!date || !duration) return null;
+    const parsed = parseDuration(duration);
+    if (!parsed) return null;
+    
+    const result = new Date(date);
+    result.setFullYear(result.getFullYear() + parsed.years);
+    result.setMonth(result.getMonth() + parsed.months);
+    result.setDate(result.getDate() + parsed.weeks * 7);
+    result.setDate(result.getDate() + parsed.days);
+    result.setHours(result.getHours() + parsed.hours);
+    result.setMinutes(result.getMinutes() + parsed.minutes);
+    result.setSeconds(result.getSeconds() + parsed.seconds);
+    return result;
+  };
+
+  // Auto-select default template for tenant
+  // Priority: tenant-specific default > AllTenants default
+  useEffect(() => {
+    if (jitAdminTemplates.isSuccess && !watcher.jitAdminTemplate) {
+      const templates = jitAdminTemplates.data || [];
+      
+      // First, try to find a tenant-specific default template
+      let defaultTemplate = templates.find(
+        (template) => 
+          template.defaultForTenant === true && 
+          template.tenantFilter !== "AllTenants" &&
+          template.tenantFilter === selectedTenant?.value
+      );
+      
+      // If not found, fall back to AllTenants default template
+      if (!defaultTemplate) {
+        defaultTemplate = templates.find(
+          (template) => 
+            template.defaultForTenant === true && 
+            template.tenantFilter === "AllTenants"
+        );
+      }
+      
+      if (defaultTemplate) {
+        formControl.setValue("jitAdminTemplate", {
+          label: defaultTemplate.templateName,
+          value: defaultTemplate.GUID,
+          addedFields: defaultTemplate,
+        });
+        setSelectedTemplate(defaultTemplate);
+      }
+    }
+  }, [jitAdminTemplates.isSuccess, selectedTenant]);
+
+  // Only set template-driven fields when the template actually changes
+  const [lastTemplate, setLastTemplate] = useState(null);
+  useEffect(() => {
+    const template = watcher.jitAdminTemplate?.addedFields;
+    if (!template || template.GUID === lastTemplate) return;
+    setSelectedTemplate(template);
+    setLastTemplate(template.GUID);
+
+    // Helpers
+    const roundDown15 = (date) => {
+      const d = new Date(date);
+      d.setMilliseconds(0);
+      d.setSeconds(0);
+      d.setMinutes(Math.floor(d.getMinutes() / 15) * 15);
+      return d;
+    };
+    const roundUp15 = (date) => {
+      const d = new Date(date);
+      d.setMilliseconds(0);
+      d.setSeconds(0);
+      let min = d.getMinutes();
+      d.setMinutes(min % 15 === 0 ? min : Math.ceil(min / 15) * 15);
+      if (d.getMinutes() === 60) {
+        d.setHours(d.getHours() + 1);
+        d.setMinutes(0);
+      }
+      return d;
+    };
+
+    // Set all template-driven fields
+    formControl.setValue("adminRoles", template.defaultRoles || [], { shouldDirty: true });
+    formControl.setValue("expireAction", template.defaultExpireAction || null, { shouldDirty: true });
+    formControl.setValue("postExecution", template.defaultNotificationActions || [], { shouldDirty: true });
+    formControl.setValue("UseTAP", template.generateTAPByDefault ?? false, { shouldDirty: true });
+    formControl.setValue("reason", template.reasonTemplate || "", { shouldDirty: true });
+
+    // User action and user details
+    if (template.defaultUserAction) {
+      formControl.setValue("userAction", template.defaultUserAction, { shouldDirty: true });
+    }
+    if (template.defaultFirstName) {
+      formControl.setValue("firstName", template.defaultFirstName, { shouldDirty: true });
+    }
+    if (template.defaultLastName) {
+      formControl.setValue("lastName", template.defaultLastName, { shouldDirty: true });
+    }
+    if (template.defaultUserName) {
+      formControl.setValue("userName", template.defaultUserName, { shouldDirty: true });
+    }
+    if (template.defaultDomain) {
+      formControl.setValue("domain", template.defaultDomain, { shouldDirty: true });
+    }
+    if (template.defaultExistingUser) {
+      formControl.setValue("existingUser", template.defaultExistingUser, { shouldDirty: true });
+    }
+
+    // Dates
+    if (template.defaultDuration) {
+      const duration = typeof template.defaultDuration === "object" && template.defaultDuration !== null
+        ? template.defaultDuration.value
+        : template.defaultDuration;
+      const start = roundDown15(new Date());
+      const unixStart = Math.floor(start.getTime() / 1000);
+      formControl.setValue("startDate", unixStart, { shouldDirty: true });
+      const end = roundUp15(addDurationToDate(start, duration));
+      const unixEnd = Math.floor(end.getTime() / 1000);
+      formControl.setValue("endDate", unixEnd, { shouldDirty: true });
+    }
+  }, [watcher.jitAdminTemplate, lastTemplate]);
+
+  // Recalculate end date when start date changes and template has default duration
+  useEffect(() => {
+    if (watcher.startDate && selectedTemplate?.defaultDuration) {
+      const durationValue = typeof selectedTemplate.defaultDuration === 'object' && selectedTemplate.defaultDuration !== null
+        ? selectedTemplate.defaultDuration.value
+        : selectedTemplate.defaultDuration;
+      const startDateDate = new Date(watcher.startDate * 1000);
+      const endDateObj = addDurationToDate(startDateDate, durationValue);
+      if (endDateObj) {
+        const unixEnd = Math.floor(endDateObj.getTime() / 1000);
+        formControl.setValue("endDate", unixEnd);
+      }
+    }
+  }, [watcher.startDate]);
+
   return (
     <>
       <CippFormPage
@@ -30,6 +197,25 @@ const Page = () => {
                 allTenants={false}
                 preselectedEnabled={true}
                 validators={{ required: "A tenant must be selected" }}
+              />
+            </Grid>
+            <Grid size={{ md: 12, xs: 12 }}>
+              <CippFormComponent
+                type="autoComplete"
+                label="JIT Admin Template (optional)"
+                name="jitAdminTemplate"
+                multiple={false}
+                creatable={false}
+                options={
+                  jitAdminTemplates.isSuccess
+                    ? jitAdminTemplates.data?.map((template) => ({
+                        label: template.templateName,
+                        value: template.GUID,
+                        addedFields: template,
+                      }))
+                    : []
+                }
+                formControl={formControl}
               />
             </Grid>
             <Grid size={{ md: 12, xs: 12 }}>
@@ -199,6 +385,7 @@ const Page = () => {
                 label="Expiration Action"
                 name="expireAction"
                 multiple={false}
+                creatable={false}
                 required={true}
                 options={[
                   { label: "Delete User", value: "DeleteUser" },
@@ -216,6 +403,7 @@ const Page = () => {
                 label="Notification Action"
                 name="postExecution"
                 multiple={true}
+                creatable={false}
                 options={[
                   { label: "Webhook", value: "Webhook" },
                   { label: "Email", value: "email" },


### PR DESCRIPTION
Introduces JIT Admin Templates management (add, edit, list) under Identity Administration, including new pages and menu entry. Adds JIT Admin Settings page for super-admins to limit maximum JIT lifetime and integrates template selection and auto-fill into the JIT Admin creation form. Updates navigation and tab options to reflect new features.

Fixes: https://github.com/KelvinTegelaar/CIPP/issues/3908
Fixes: https://github.com/KelvinTegelaar/CIPP/issues/4854
API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1767