### PR TITLE
Fixed failed labeling workflow

### DIFF
--- a/.github/workflows/label_sponsor_requests.yml
+++ b/.github/workflows/label_sponsor_requests.yml
@@ -1,4 +1,3 @@
----
 name: Label Issues
 on:
   issues:
@@ -14,4 +13,6 @@ jobs:
       - name: Sponsor Labels
         uses: JasonEtco/is-sponsor-label-action@v1.2.0
         with:
-          label: 'Sponsor Request'
+          label: 'Sponsor Priority'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Workflow was missing token as part of the required usage. https://github.com/JasonEtco/is-sponsor-label-action?tab=readme-ov-file#usage added ${{ secrets.GITHUB_TOKEN }} reusing existing token value inside of the repository as referenced by other workflows.

Changed the label to match the one on GitHub