### PR TITLE
Fix: Fix removing passcode on iOS devices

### DIFF
--- a/src/pages/endpoint/MEM/devices/index.js
+++ b/src/pages/endpoint/MEM/devices/index.js
@@ -189,7 +189,7 @@ const Page = () => {
       url: "/api/ExecDevicePasscodeAction",
       data: {
         GUID: "id",
-        Action: "removeDevicePasscode",
+        Action: "resetPasscode",
       },
       condition: (row) => row.operatingSystem === "iOS",
       confirmText:


### PR DESCRIPTION
Change the action for resetting a device passcode from "removeDevicePasscode" to "resetPasscode" to align with updated documentation.

The Intune portal uses this URI when it removes the passcode for an iOS device: https://graph.microsoft.com/beta/deviceManagement/managedDevices('GUID-HERE')/resetPasscode

https://learn.microsoft.com/en-us/intune/intune-service/remote-actions/device-remove-passcode