### PR TITLE
Feat: Enhance inactive user alert functionality with dynamic days setting

### DIFF
--- a/src/data/alerts.json
+++ b/src/data/alerts.json
@@ -31,12 +31,22 @@
   },
   {
     "name": "InactiveLicensedUsers",
-    "label": "Alert on licensed users that have not logged in for 90 days",
+    "label": "Alert on licensed users that have not logged in for X days",
+    "recommendedRunInterval": "1d",
     "requiresInput": true,
-    "inputType": "switch",
-    "inputLabel": "Exclude disabled users?",
-    "inputName": "InactiveLicensedUsersExcludeDisabled",
-    "recommendedRunInterval": "1d"
+    "multipleInput": true,
+    "inputs": [
+      {
+        "inputType": "number",
+        "inputLabel": "Days since last login (default: 90)",
+        "inputName": "DaysSinceLastLogin"
+      },
+      {
+        "inputType": "switch",
+        "inputLabel": "Exclude disabled users?",
+        "inputName": "ExcludeDisabled"
+      }
+    ]
   },
   {
     "name": "EntraConnectSyncStatus",

--- a/src/pages/tenant/administration/alert-configuration/alert.jsx
+++ b/src/pages/tenant/administration/alert-configuration/alert.jsx
@@ -116,7 +116,7 @@ const AlertWizard = () => {
             formControl.setValue(
               `conditions.${index}.Input`,
               { value: "" },
-              { shouldValidate: false }
+              { shouldValidate: false },
             );
           } else {
             formControl.setValue(`conditions.${index}.Input`, "", { shouldValidate: false });
@@ -139,13 +139,13 @@ const AlertWizard = () => {
           ? alert.excludedTenants.map((tenant) => ({ value: tenant, label: tenant }))
           : [];
         const usedCommand = alertList?.find(
-          (cmd) => cmd.name === alert.RawAlert.Command.replace("Get-CIPPAlert", "")
+          (cmd) => cmd.name === alert.RawAlert.Command.replace("Get-CIPPAlert", ""),
         );
         const recurrenceOption = recurrenceOptions?.find(
-          (opt) => opt.value === alert.RawAlert.Recurrence
+          (opt) => opt.value === alert.RawAlert.Recurrence,
         );
         const postExecutionValue = postExecutionOptions.filter((opt) =>
-          alert.RawAlert.PostExecution.split(",").includes(opt.value)
+          alert.RawAlert.PostExecution.split(",").includes(opt.value),
         );
         let tenantFilterForForm;
         if (alert.RawAlert.TenantGroup) {
@@ -216,7 +216,7 @@ const AlertWizard = () => {
         setAlertType("audit");
         setIsLoadingExistingAlert(true);
         const foundLogbook = logbookOptions?.find(
-          (logbook) => logbook.value === alert.RawAlert.type
+          (logbook) => logbook.value === alert.RawAlert.type,
         );
         const rawConditions = alert.RawAlert.Conditions || [];
         const formattedConditions = rawConditions.map((cond) => {
@@ -264,7 +264,7 @@ const AlertWizard = () => {
         setTimeout(() => {
           // Seed previous operator values BEFORE setting conditions to prevent clearing
           prevOperatorValuesRef.current = formattedConditions.map((c) =>
-            (c.Operator?.value || "").toLowerCase()
+            (c.Operator?.value || "").toLowerCase(),
           );
 
           // Process each condition with proper normalization
@@ -277,7 +277,7 @@ const AlertWizard = () => {
             // Normalize based on operator and property type
             if (Array.isArray(finalInput)) {
               finalInput = finalInput.map((item) =>
-                typeof item === "string" ? { label: item, value: item } : item
+                typeof item === "string" ? { label: item, value: item } : item,
               );
               // Further ensure label/value presence and rebuild from schema if possible
               const schemaOptions = auditLogSchema[cond.Property?.value] || [];
@@ -362,7 +362,7 @@ const AlertWizard = () => {
       }));
 
       const recommendedOption = updatedRecurrenceOptions?.find(
-        (opt) => opt.value === commandValue.value.recommendedRunInterval
+        (opt) => opt.value === commandValue.value.recommendedRunInterval,
       );
 
       if (recommendedOption) {
@@ -381,7 +381,7 @@ const AlertWizard = () => {
     if (!selectedPreset) return;
     setIsLoadingPreset(true);
     const selectedTemplate = auditLogTemplates?.find(
-      (template) => template.value === selectedPreset.value
+      (template) => template.value === selectedPreset.value,
     );
     if (!selectedTemplate) {
       setIsLoadingPreset(false);
@@ -412,7 +412,7 @@ const AlertWizard = () => {
     }
     setAddedEvent(formattedConditions.map((_, i) => ({ id: i })));
     prevOperatorValuesRef.current = formattedConditions.map((c) =>
-      (c.Operator?.value || "").toLowerCase()
+      (c.Operator?.value || "").toLowerCase(),
     );
     // Ensure React Hook Form registers nested fields before releasing the guard
     setTimeout(() => {
@@ -448,7 +448,7 @@ const AlertWizard = () => {
           // Prevent form reload after successful save
           setHasLoadedExistingAlert(true);
         },
-      }
+      },
     );
   };
 
@@ -493,7 +493,7 @@ const AlertWizard = () => {
           // Prevent form reload after successful save
           setHasLoadedExistingAlert(true);
         },
-      }
+      },
     );
   };
 
@@ -753,7 +753,7 @@ const AlertWizard = () => {
                                     creatable={true}
                                     options={
                                       propertyWatcher?.[event.id]?.Property?.value?.startsWith(
-                                        "List:"
+                                        "List:",
                                       )
                                         ? auditLogSchema[
                                             propertyWatcher?.[event.id]?.Property?.value
@@ -959,15 +959,13 @@ const AlertWizard = () => {
                                     formControl={formControl}
                                     label={commandValue.value?.inputLabel}
                                     required={commandValue.value?.required || false}
-                                    {...(commandValue.value?.inputType === 'autoComplete'
+                                    {...(commandValue.value?.inputType === "autoComplete"
                                       ? {
                                           options: commandValue.value?.options,
                                           creatable: commandValue.value?.creatable || true,
                                           multiple: commandValue.value?.multiple || true,
                                         }
-                                      : {}
-                                      )
-                                    }
+                                      : {})}
                                   />
                                 )}
                               {commandValue?.value?.multipleInput &&
@@ -985,15 +983,13 @@ const AlertWizard = () => {
                                         formControl={formControl}
                                         label={input.inputLabel}
                                         required={input.required || false}
-                                        {...(input.inputType === 'autoComplete'
+                                        {...(input.inputType === "autoComplete"
                                           ? {
                                               options: input.options,
                                               creatable: input.creatable ?? true,
                                               multiple: input.multiple ?? true,
                                             }
-                                          : {}
-                                          )
-                                        }
+                                          : {})}
                                       />
                                     </Grid>
                                   </Grid>


### PR DESCRIPTION
Enhance the InactiveLicensedUsers alert by allowing users to specify customizable days since last login. Update the alert label for clarity and improve user configuration with multiple input options.

Fixes #5273

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1794