### PR TITLE
Update GitHub Actions workflows and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "dev"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"

--- a/.github/workflows/CodeQL_Analyser.yml
+++ b/.github/workflows/CodeQL_Analyser.yml
@@ -1,10 +1,10 @@
 ---
-name: 'CodeQL'
+name: "CodeQL"
 on:
   pull_request:
     branches: [master, main, dev, react]
   schedule:
-    - cron: '26 17 * * 0'
+    - cron: "26 17 * * 0"
 jobs:
   analyze:
     if: github.repository_owner == 'KelvinTegelaar'
@@ -17,15 +17,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript']
+        language: ["javascript"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v4
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/Node_Project_Check.yml
+++ b/.github/workflows/Node_Project_Check.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: ["22.13.0"]
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install and Build Test


### PR DESCRIPTION
Enhance GitHub Actions workflows with weekly scheduling and update Node.js version to 22.13.0. Upgrade actions/checkout and actions/setup-node to v6, and improve CodeQL analysis actions to v4 for better functionality.