### PR TITLE
CI: Stop closing stale PR's

### DIFF
--- a/.github/workflows/Close_Stale_Issues.yml
+++ b/.github/workflows/Close_Stale_Issues.yml
@@ -1,5 +1,5 @@
 ---
-name: "Close stale issues and PRs"
+name: "Close stale issues"
 on:
   schedule:
     - cron: "30 1 * * *"
@@ -16,3 +16,5 @@ jobs:
           exempt-issue-labels: "planned,bug,roadmap"
           days-before-stale: 9
           days-before-close: 5
+          days-before-pr-stale: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
Remove PR's from being closed for being stale. 
Would help giving more time for you guys to review the changes in the bigger PR's like https://github.com/KelvinTegelaar/CIPP/pull/5190

If you dont want this, you can just close it