### PR TITLE
feat: Add assignment filter options to policy forms

### DIFF
--- a/src/components/CippComponents/CippPolicyDeployDrawer.jsx
+++ b/src/components/CippComponents/CippPolicyDeployDrawer.jsx
@@ -12,6 +12,11 @@ import { CippApiResults } from "./CippApiResults";
 import { useSettings } from "../../hooks/use-settings";
 import { CippFormTenantSelector } from "./CippFormTenantSelector";
 
+const assignmentFilterTypeOptions = [
+  { label: "Include - Apply policy to devices matching filter", value: "include" },
+  { label: "Exclude - Apply policy to devices NOT matching filter", value: "exclude" },
+];
+
 export const CippPolicyDeployDrawer = ({
   buttonText = "Deploy Policy",
   requiredPermissions = [],
@@ -59,6 +64,10 @@ export const CippPolicyDeployDrawer = ({
     }
 
     const formData = formControl.getValues();
+    const assignmentFilterName = formData?.assignmentFilter?.value || null;
+    const assignmentFilterType = assignmentFilterName
+      ? formData?.assignmentFilterType || "include"
+      : null;
     console.log("Submitting form data:", formData);
     deployPolicy.mutate({
       url: "/api/AddPolicy",
@@ -68,7 +77,11 @@ export const CippPolicyDeployDrawer = ({
         "Compliance Policies",
         "Protection Policies",
       ],
-      data: { ...formData },
+      data: {
+        ...formData,
+        AssignmentFilterName: assignmentFilterName,
+        AssignmentFilterType: assignmentFilterType,
+      },
     });
   };
 
@@ -174,6 +187,40 @@ export const CippPolicyDeployDrawer = ({
                 name="customGroup"
                 formControl={formControl}
                 validators={{ required: "Please specify custom group names" }}
+              />
+            </Grid>
+          </CippFormCondition>
+          <CippFormCondition
+            formControl={formControl}
+            field="AssignTo"
+            compareType="isOneOf"
+            compareValue={["allLicensedUsers", "AllDevices", "AllDevicesAndUsers", "customGroup"]}
+          >
+            <Grid size={{ xs: 12 }}>
+              <CippFormComponent
+                type="autoComplete"
+                name="assignmentFilter"
+                label="Assignment Filter (Optional)"
+                multiple={false}
+                creatable={false}
+                formControl={formControl}
+                api={{
+                  url: "/api/ListAssignmentFilters",
+                  queryKey: `ListAssignmentFilters-${tenantFilter}`,
+                  labelField: (filter) => filter.displayName,
+                  valueField: "displayName",
+                }}
+              />
+            </Grid>
+            <Grid size={{ xs: 12 }}>
+              <CippFormComponent
+                type="radio"
+                name="assignmentFilterType"
+                label="Assignment Filter Mode"
+                options={assignmentFilterTypeOptions}
+                defaultValue="include"
+                helperText="Choose whether to include or exclude devices matching the filter."
+                formControl={formControl}
               />
             </Grid>
           </CippFormCondition>

--- a/src/components/CippWizard/CippIntunePolicy.jsx
+++ b/src/components/CippWizard/CippIntunePolicy.jsx
@@ -7,10 +7,17 @@ import { ApiGetCall } from "../../api/ApiCall";
 import { useEffect, useState } from "react";
 import { useWatch } from "react-hook-form";
 import { CippFormCondition } from "../CippComponents/CippFormCondition";
+import { useSettings } from "../../hooks/use-settings";
+
+const assignmentFilterTypeOptions = [
+  { label: "Include - Apply policy to devices matching filter", value: "include" },
+  { label: "Exclude - Apply policy to devices NOT matching filter", value: "exclude" },
+];
 
 export const CippIntunePolicy = (props) => {
   const { formControl, onPreviousStep, onNextStep, currentStep } = props;
   const values = formControl.getValues();
+  const tenantFilter = useSettings()?.currentTenant;
   const CATemplates = ApiGetCall({ url: "/api/ListIntuneTemplates", queryKey: "IntuneTemplates" });
   const [JSONData, setJSONData] = useState();
   const watcher = useWatch({ control: formControl.control, name: "TemplateList" });
@@ -108,6 +115,40 @@ export const CippIntunePolicy = (props) => {
               name="customGroup"
               formControl={formControl}
               validators={{ required: "Please specify custom group names" }}
+            />
+          </Grid>
+        </CippFormCondition>
+        <CippFormCondition
+          formControl={formControl}
+          field="AssignTo"
+          compareType="isOneOf"
+          compareValue={["allLicensedUsers", "AllDevices", "AllDevicesAndUsers", "customGroup"]}
+        >
+          <Grid size={{ xs: 12 }}>
+            <CippFormComponent
+              type="autoComplete"
+              name="assignmentFilter"
+              label="Assignment Filter (Optional)"
+              multiple={false}
+              creatable={false}
+              formControl={formControl}
+              api={{
+                url: "/api/ListAssignmentFilters",
+                queryKey: `ListAssignmentFilters-${tenantFilter}`,
+                labelField: (filter) => filter.displayName,
+                valueField: "displayName",
+              }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <CippFormComponent
+              type="radio"
+              name="assignmentFilterType"
+              label="Assignment Filter Mode"
+              options={assignmentFilterTypeOptions}
+              defaultValue="include"
+              helperText="Choose whether to include or exclude devices matching the filter."
+              formControl={formControl}
             />
           </Grid>
         </CippFormCondition>

--- a/src/pages/endpoint/MEM/list-appprotection-policies/index.js
+++ b/src/pages/endpoint/MEM/list-appprotection-policies/index.js
@@ -54,7 +54,43 @@ const Page = () => {
           helperText:
             "Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups.",
         },
+        {
+          type: "autoComplete",
+          name: "assignmentFilter",
+          label: "Assignment Filter (Optional)",
+          multiple: false,
+          creatable: false,
+          api: {
+            url: "/api/ListAssignmentFilters",
+            queryKey: `ListAssignmentFilters-${tenant}`,
+            labelField: (filter) => filter.displayName,
+            valueField: "displayName",
+          },
+        },
+        {
+          type: "radio",
+          name: "assignmentFilterType",
+          label: "Assignment Filter Mode",
+          options: assignmentFilterTypeOptions,
+          defaultValue: "include",
+          helperText: "Choose whether to include or exclude devices matching the filter.",
+        },
       ],
+      customDataformatter: (row, action, formData) => {
+        const tenantFilterValue = tenant === "AllTenants" && row?.Tenant ? row.Tenant : tenant;
+        return {
+          tenantFilter: tenantFilterValue,
+          ID: row?.id,
+          type: row?.URLName,
+          platformType: "deviceAppManagement",
+          AssignTo: "allLicensedUsers",
+          assignmentMode: formData?.assignmentMode || "replace",
+          AssignmentFilterName: formData?.assignmentFilter?.value || null,
+          AssignmentFilterType: formData?.assignmentFilter?.value
+            ? formData?.assignmentFilterType || "include"
+            : null,
+        };
+      },
       confirmText: 'Are you sure you want to assign "[displayName]" to all users?',
       icon: <UserIcon />,
       color: "info",
@@ -79,7 +115,43 @@ const Page = () => {
           helperText:
             "Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups.",
         },
+        {
+          type: "autoComplete",
+          name: "assignmentFilter",
+          label: "Assignment Filter (Optional)",
+          multiple: false,
+          creatable: false,
+          api: {
+            url: "/api/ListAssignmentFilters",
+            queryKey: `ListAssignmentFilters-${tenant}`,
+            labelField: (filter) => filter.displayName,
+            valueField: "displayName",
+          },
+        },
+        {
+          type: "radio",
+          name: "assignmentFilterType",
+          label: "Assignment Filter Mode",
+          options: assignmentFilterTypeOptions,
+          defaultValue: "include",
+          helperText: "Choose whether to include or exclude devices matching the filter.",
+        },
       ],
+      customDataformatter: (row, action, formData) => {
+        const tenantFilterValue = tenant === "AllTenants" && row?.Tenant ? row.Tenant : tenant;
+        return {
+          tenantFilter: tenantFilterValue,
+          ID: row?.id,
+          type: row?.URLName,
+          platformType: "deviceAppManagement",
+          AssignTo: "AllDevices",
+          assignmentMode: formData?.assignmentMode || "replace",
+          AssignmentFilterName: formData?.assignmentFilter?.value || null,
+          AssignmentFilterType: formData?.assignmentFilter?.value
+            ? formData?.assignmentFilterType || "include"
+            : null,
+        };
+      },
       confirmText: 'Are you sure you want to assign "[displayName]" to all devices?',
       icon: <LaptopChromebook />,
       color: "info",
@@ -104,7 +176,43 @@ const Page = () => {
           helperText:
             "Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups.",
         },
+        {
+          type: "autoComplete",
+          name: "assignmentFilter",
+          label: "Assignment Filter (Optional)",
+          multiple: false,
+          creatable: false,
+          api: {
+            url: "/api/ListAssignmentFilters",
+            queryKey: `ListAssignmentFilters-${tenant}`,
+            labelField: (filter) => filter.displayName,
+            valueField: "displayName",
+          },
+        },
+        {
+          type: "radio",
+          name: "assignmentFilterType",
+          label: "Assignment Filter Mode",
+          options: assignmentFilterTypeOptions,
+          defaultValue: "include",
+          helperText: "Choose whether to include or exclude devices matching the filter.",
+        },
       ],
+      customDataformatter: (row, action, formData) => {
+        const tenantFilterValue = tenant === "AllTenants" && row?.Tenant ? row.Tenant : tenant;
+        return {
+          tenantFilter: tenantFilterValue,
+          ID: row?.id,
+          type: row?.URLName,
+          platformType: "deviceAppManagement",
+          AssignTo: "AllDevicesAndUsers",
+          assignmentMode: formData?.assignmentMode || "replace",
+          AssignmentFilterName: formData?.assignmentFilter?.value || null,
+          AssignmentFilterType: formData?.assignmentFilter?.value
+            ? formData?.assignmentFilterType || "include"
+            : null,
+        };
+      },
       confirmText: 'Are you sure you want to assign "[displayName]" to all users and devices?',
       icon: <GlobeAltIcon />,
       color: "info",

--- a/src/pages/endpoint/MEM/list-compliance-policies/index.js
+++ b/src/pages/endpoint/MEM/list-compliance-policies/index.js
@@ -53,7 +53,42 @@ const Page = () => {
           helperText:
             "Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups.",
         },
+        {
+          type: "autoComplete",
+          name: "assignmentFilter",
+          label: "Assignment Filter (Optional)",
+          multiple: false,
+          creatable: false,
+          api: {
+            url: "/api/ListAssignmentFilters",
+            queryKey: `ListAssignmentFilters-${tenant}`,
+            labelField: (filter) => filter.displayName,
+            valueField: "displayName",
+          },
+        },
+        {
+          type: "radio",
+          name: "assignmentFilterType",
+          label: "Assignment Filter Mode",
+          options: assignmentFilterTypeOptions,
+          defaultValue: "include",
+          helperText: "Choose whether to include or exclude devices matching the filter.",
+        },
       ],
+      customDataformatter: (row, action, formData) => {
+        const tenantFilterValue = tenant === "AllTenants" && row?.Tenant ? row.Tenant : tenant;
+        return {
+          tenantFilter: tenantFilterValue,
+          ID: row?.id,
+          type: "deviceCompliancePolicies",
+          AssignTo: "allLicensedUsers",
+          assignmentMode: formData?.assignmentMode || "replace",
+          AssignmentFilterName: formData?.assignmentFilter?.value || null,
+          AssignmentFilterType: formData?.assignmentFilter?.value
+            ? formData?.assignmentFilterType || "include"
+            : null,
+        };
+      },
       confirmText: 'Are you sure you want to assign "[displayName]" to all users?',
       icon: <UserIcon />,
       color: "info",
@@ -77,7 +112,42 @@ const Page = () => {
           helperText:
             "Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups.",
         },
+        {
+          type: "autoComplete",
+          name: "assignmentFilter",
+          label: "Assignment Filter (Optional)",
+          multiple: false,
+          creatable: false,
+          api: {
+            url: "/api/ListAssignmentFilters",
+            queryKey: `ListAssignmentFilters-${tenant}`,
+            labelField: (filter) => filter.displayName,
+            valueField: "displayName",
+          },
+        },
+        {
+          type: "radio",
+          name: "assignmentFilterType",
+          label: "Assignment Filter Mode",
+          options: assignmentFilterTypeOptions,
+          defaultValue: "include",
+          helperText: "Choose whether to include or exclude devices matching the filter.",
+        },
       ],
+      customDataformatter: (row, action, formData) => {
+        const tenantFilterValue = tenant === "AllTenants" && row?.Tenant ? row.Tenant : tenant;
+        return {
+          tenantFilter: tenantFilterValue,
+          ID: row?.id,
+          type: "deviceCompliancePolicies",
+          AssignTo: "AllDevices",
+          assignmentMode: formData?.assignmentMode || "replace",
+          AssignmentFilterName: formData?.assignmentFilter?.value || null,
+          AssignmentFilterType: formData?.assignmentFilter?.value
+            ? formData?.assignmentFilterType || "include"
+            : null,
+        };
+      },
       confirmText: 'Are you sure you want to assign "[displayName]" to all devices?',
       icon: <LaptopChromebook />,
       color: "info",
@@ -101,7 +171,42 @@ const Page = () => {
           helperText:
             "Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups.",
         },
+        {
+          type: "autoComplete",
+          name: "assignmentFilter",
+          label: "Assignment Filter (Optional)",
+          multiple: false,
+          creatable: false,
+          api: {
+            url: "/api/ListAssignmentFilters",
+            queryKey: `ListAssignmentFilters-${tenant}`,
+            labelField: (filter) => filter.displayName,
+            valueField: "displayName",
+          },
+        },
+        {
+          type: "radio",
+          name: "assignmentFilterType",
+          label: "Assignment Filter Mode",
+          options: assignmentFilterTypeOptions,
+          defaultValue: "include",
+          helperText: "Choose whether to include or exclude devices matching the filter.",
+        },
       ],
+      customDataformatter: (row, action, formData) => {
+        const tenantFilterValue = tenant === "AllTenants" && row?.Tenant ? row.Tenant : tenant;
+        return {
+          tenantFilter: tenantFilterValue,
+          ID: row?.id,
+          type: "deviceCompliancePolicies",
+          AssignTo: "AllDevicesAndUsers",
+          assignmentMode: formData?.assignmentMode || "replace",
+          AssignmentFilterName: formData?.assignmentFilter?.value || null,
+          AssignmentFilterType: formData?.assignmentFilter?.value
+            ? formData?.assignmentFilterType || "include"
+            : null,
+        };
+      },
       confirmText: 'Are you sure you want to assign "[displayName]" to all users and devices?',
       icon: <GlobeAltIcon />,
       color: "info",

--- a/src/pages/endpoint/MEM/list-policies/index.js
+++ b/src/pages/endpoint/MEM/list-policies/index.js
@@ -53,7 +53,42 @@ const Page = () => {
           helperText:
             "Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups.",
         },
+        {
+          type: "autoComplete",
+          name: "assignmentFilter",
+          label: "Assignment Filter (Optional)",
+          multiple: false,
+          creatable: false,
+          api: {
+            url: "/api/ListAssignmentFilters",
+            queryKey: `ListAssignmentFilters-${tenant}`,
+            labelField: (filter) => filter.displayName,
+            valueField: "displayName",
+          },
+        },
+        {
+          type: "radio",
+          name: "assignmentFilterType",
+          label: "Assignment Filter Mode",
+          options: assignmentFilterTypeOptions,
+          defaultValue: "include",
+          helperText: "Choose whether to include or exclude devices matching the filter.",
+        },
       ],
+      customDataformatter: (row, action, formData) => {
+        const tenantFilterValue = tenant === "AllTenants" && row?.Tenant ? row.Tenant : tenant;
+        return {
+          tenantFilter: tenantFilterValue,
+          ID: row?.id,
+          type: row?.URLName,
+          AssignTo: "allLicensedUsers",
+          assignmentMode: formData?.assignmentMode || "replace",
+          AssignmentFilterName: formData?.assignmentFilter?.value || null,
+          AssignmentFilterType: formData?.assignmentFilter?.value
+            ? formData?.assignmentFilterType || "include"
+            : null,
+        };
+      },
       confirmText: 'Are you sure you want to assign "[displayName]" to all users?',
       icon: <UserIcon />,
       color: "info",
@@ -77,7 +112,42 @@ const Page = () => {
           helperText:
             "Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups.",
         },
+        {
+          type: "autoComplete",
+          name: "assignmentFilter",
+          label: "Assignment Filter (Optional)",
+          multiple: false,
+          creatable: false,
+          api: {
+            url: "/api/ListAssignmentFilters",
+            queryKey: `ListAssignmentFilters-${tenant}`,
+            labelField: (filter) => filter.displayName,
+            valueField: "displayName",
+          },
+        },
+        {
+          type: "radio",
+          name: "assignmentFilterType",
+          label: "Assignment Filter Mode",
+          options: assignmentFilterTypeOptions,
+          defaultValue: "include",
+          helperText: "Choose whether to include or exclude devices matching the filter.",
+        },
       ],
+      customDataformatter: (row, action, formData) => {
+        const tenantFilterValue = tenant === "AllTenants" && row?.Tenant ? row.Tenant : tenant;
+        return {
+          tenantFilter: tenantFilterValue,
+          ID: row?.id,
+          type: row?.URLName,
+          AssignTo: "AllDevices",
+          assignmentMode: formData?.assignmentMode || "replace",
+          AssignmentFilterName: formData?.assignmentFilter?.value || null,
+          AssignmentFilterType: formData?.assignmentFilter?.value
+            ? formData?.assignmentFilterType || "include"
+            : null,
+        };
+      },
       confirmText: 'Are you sure you want to assign "[displayName]" to all devices?',
       icon: <LaptopChromebook />,
       color: "info",
@@ -101,7 +171,42 @@ const Page = () => {
           helperText:
             "Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups.",
         },
+        {
+          type: "autoComplete",
+          name: "assignmentFilter",
+          label: "Assignment Filter (Optional)",
+          multiple: false,
+          creatable: false,
+          api: {
+            url: "/api/ListAssignmentFilters",
+            queryKey: `ListAssignmentFilters-${tenant}`,
+            labelField: (filter) => filter.displayName,
+            valueField: "displayName",
+          },
+        },
+        {
+          type: "radio",
+          name: "assignmentFilterType",
+          label: "Assignment Filter Mode",
+          options: assignmentFilterTypeOptions,
+          defaultValue: "include",
+          helperText: "Choose whether to include or exclude devices matching the filter.",
+        },
       ],
+      customDataformatter: (row, action, formData) => {
+        const tenantFilterValue = tenant === "AllTenants" && row?.Tenant ? row.Tenant : tenant;
+        return {
+          tenantFilter: tenantFilterValue,
+          ID: row?.id,
+          type: row?.URLName,
+          AssignTo: "AllDevicesAndUsers",
+          assignmentMode: formData?.assignmentMode || "replace",
+          AssignmentFilterName: formData?.assignmentFilter?.value || null,
+          AssignmentFilterType: formData?.assignmentFilter?.value
+            ? formData?.assignmentFilterType || "include"
+            : null,
+        };
+      },
       confirmText: 'Are you sure you want to assign "[displayName]" to all users and devices?',
       icon: <GlobeAltIcon />,
       color: "info",


### PR DESCRIPTION
- Introduced assignment filter and filter type options in CippPolicyDeployDrawer, CippIntunePolicy, and various policy list pages.
- Updated data formatting to include selected assignment filter and type in API requests.
- Enhanced user interface with radio buttons for filter mode selection.
Fixes #5377

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1827