### PR TITLE
Fix: fix Send from alias state saving issue by updating boolean values to strings in standards.json

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -2268,8 +2268,8 @@
         "label": "Select value",
         "name": "standards.SendFromAlias.state",
         "options": [
-          { "label": "Enabled", "value": true },
-          { "label": "Disabled", "value": false }
+          { "label": "Enabled", "value": "true" },
+          { "label": "Disabled", "value": "false" }
         ]
       }
     ],


### PR DESCRIPTION
Updating the values for the Send from alias state in standards.json from boolean to string format resolves the issue where the save button does not enable when "Disabled" is selected. This change ensures proper validation in the frontend. Fixes #5431