### PR TITLE
feat: Add validation to user forms and update form modes

### DIFF
--- a/src/components/CippComponents/CippBulkInviteGuestDrawer.jsx
+++ b/src/components/CippComponents/CippBulkInviteGuestDrawer.jsx
@@ -9,6 +9,7 @@ import { CippDataTable } from "../CippTable/CippDataTable";
 import { CippApiResults } from "./CippApiResults";
 import { useSettings } from "../../hooks/use-settings";
 import { ApiPostCall } from "../../api/ApiCall";
+import { getCippValidator } from "../../utils/get-cipp-validator";
 
 export const CippBulkInviteGuestDrawer = ({
   buttonText = "Bulk Invite Guests",
@@ -22,7 +23,7 @@ export const CippBulkInviteGuestDrawer = ({
   const fields = ["displayName", "mail", "redirectUri"];
 
   const formControl = useForm({
-    mode: "onChange",
+    mode: "onBlur",
     defaultValues: {
       tenantFilter: initialState.currentTenant,
       sendInvite: true,
@@ -255,6 +256,10 @@ export const CippBulkInviteGuestDrawer = ({
                   label="E-mail Address"
                   type="textField"
                   formControl={formControl}
+                  validators={{
+                    required: "E-mail address is required",
+                    validate: (value) => !value || getCippValidator(value, "email"),
+                  }}
                 />
               </Grid>
               <Grid size={{ xs: 12 }}>

--- a/src/components/CippComponents/CippBulkUserDrawer.jsx
+++ b/src/components/CippComponents/CippBulkUserDrawer.jsx
@@ -43,8 +43,34 @@ export const CippBulkUserDrawer = ({
     ...addedFields,
   ];
 
+  const fieldValidators = {
+    givenName: { maxLength: { value: 64, message: "First Name cannot exceed 64 characters" } },
+    surName: { maxLength: { value: 64, message: "Last Name cannot exceed 64 characters" } },
+    displayName: {
+      required: "Display Name is required",
+      maxLength: { value: 256, message: "Display Name cannot exceed 256 characters" },
+    },
+    mailNickName: {
+      required: "Username is required",
+      maxLength: { value: 64, message: "Username cannot exceed 64 characters" },
+      pattern: {
+        value: /^[A-Za-z0-9'.\-_!#^~]+$/,
+        message: "Username can only contain letters, numbers, and ' . - _ ! # ^ ~ characters",
+      },
+    },
+    JobTitle: { maxLength: { value: 128, message: "Job Title cannot exceed 128 characters" } },
+    streetAddress: {
+      maxLength: { value: 1024, message: "Street Address cannot exceed 1024 characters" },
+    },
+    PostalCode: { maxLength: { value: 40, message: "Postal Code cannot exceed 40 characters" } },
+    City: { maxLength: { value: 128, message: "City cannot exceed 128 characters" } },
+    State: { maxLength: { value: 128, message: "State/Province cannot exceed 128 characters" } },
+    Department: { maxLength: { value: 64, message: "Department cannot exceed 64 characters" } },
+    MobilePhone: { maxLength: { value: 64, message: "Mobile # cannot exceed 64 characters" } },
+  };
+
   const formControl = useForm({
-    mode: "onChange",
+    mode: "onBlur",
     defaultValues: {
       tenantFilter: initialState.currentTenant,
       usageLocation: initialState.usageLocation || "US",
@@ -141,8 +167,8 @@ export const CippBulkUserDrawer = ({
               {createBulkUsers.isLoading
                 ? "Creating Users..."
                 : createBulkUsers.isSuccess
-                ? "Create More Users"
-                : "Create Users"}
+                  ? "Create More Users"
+                  : "Create Users"}
             </Button>
             <Button variant="outlined" onClick={handleCloseDrawer}>
               Close
@@ -179,7 +205,7 @@ export const CippBulkUserDrawer = ({
           <Grid size={{ xs: 12 }}>
             <Link
               href={`data:text/csv;charset=utf-8,%EF%BB%BF${encodeURIComponent(
-                fields.join(",") + "\n"
+                fields.join(",") + "\n",
               )}`}
               download="BulkUser.csv"
             >
@@ -227,6 +253,7 @@ export const CippBulkUserDrawer = ({
                     label={getCippTranslation(field)}
                     type="textField"
                     formControl={formControl}
+                    validators={fieldValidators[field]}
                   />
                 </Grid>
               ))}

--- a/src/components/CippComponents/CippFormComponent.jsx
+++ b/src/components/CippComponents/CippFormComponent.jsx
@@ -153,6 +153,7 @@ export const CippFormComponent = (props) => {
                       label={label}
                       value={field.value || ""}
                       onChange={field.onChange}
+                      onBlur={field.onBlur}
                       includeSystemVariables={includeSystemVariables}
                     />
                   ) : (
@@ -166,6 +167,7 @@ export const CippFormComponent = (props) => {
                       label={label}
                       value={field.value || ""}
                       onChange={field.onChange}
+                      onBlur={field.onBlur}
                     />
                   )
                 }
@@ -205,6 +207,7 @@ export const CippFormComponent = (props) => {
                     label={label}
                     value={field.value || ""}
                     onChange={field.onChange}
+                    onBlur={field.onBlur}
                     tenantFilter={tenantFilter}
                     includeSystemVariables={includeSystemVariables}
                   />
@@ -358,6 +361,7 @@ export const CippFormComponent = (props) => {
                     row={row}
                     value={field.value || ""}
                     onChange={(e) => field.onChange(e.target.value)}
+                    onBlur={field.onBlur}
                     {...other}
                   >
                     {props.options.map((option, idx) => (
@@ -398,6 +402,7 @@ export const CippFormComponent = (props) => {
                   label={label}
                   multiple={false}
                   onChange={(value) => field.onChange(value?.value)}
+                  onBlur={field.onBlur}
                 />
               )}
             />
@@ -441,6 +446,7 @@ export const CippFormComponent = (props) => {
                 defaultValue={field.value}
                 label={label}
                 onChange={(value) => field.onChange(value)}
+                onBlur={field.onBlur}
               />
             )}
           />
@@ -616,6 +622,7 @@ export const CippFormComponent = (props) => {
                           field.onChange(null); // Handle the case where no date is selected
                         }
                       }}
+                      onClose={field.onBlur}
                       ampm={false}
                       minutesStep={15}
                       inputFormat="yyyy/MM/dd HH:mm" // Display format
@@ -721,6 +728,7 @@ export const CippFormComponent = (props) => {
                         other.onChange(file);
                       }
                     }}
+                    onBlur={field.onBlur}
                   />
                 </Box>
               )}

--- a/src/components/CippComponents/CippInviteGuestDrawer.jsx
+++ b/src/components/CippComponents/CippInviteGuestDrawer.jsx
@@ -8,6 +8,7 @@ import CippFormComponent from "./CippFormComponent";
 import { CippApiResults } from "./CippApiResults";
 import { useSettings } from "../../hooks/use-settings";
 import { ApiPostCall } from "../../api/ApiCall";
+import { getCippValidator } from "../../utils/get-cipp-validator";
 
 export const CippInviteGuestDrawer = ({
   buttonText = "Invite Guest",
@@ -18,7 +19,7 @@ export const CippInviteGuestDrawer = ({
   const userSettingsDefaults = useSettings();
 
   const formControl = useForm({
-    mode: "onChange",
+    mode: "onBlur",
     defaultValues: {
       tenantFilter: userSettingsDefaults.currentTenant,
       displayName: "",
@@ -123,10 +124,7 @@ export const CippInviteGuestDrawer = ({
               formControl={formControl}
               validators={{
                 required: "Email address is required",
-                pattern: {
-                  value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-                  message: "Invalid email address",
-                },
+                validate: (value) => !value || getCippValidator(value, "email"),
               }}
             />
           </Grid>

--- a/src/components/CippFormPages/CippAddEditUser.jsx
+++ b/src/components/CippFormPages/CippAddEditUser.jsx
@@ -1,5 +1,6 @@
 import { Alert, Divider, InputAdornment, Typography } from "@mui/material";
 import CippFormComponent from "../CippComponents/CippFormComponent";
+import { getCippValidator } from "../../utils/get-cipp-validator";
 import { CippFormCondition } from "../CippComponents/CippFormCondition";
 import { CippFormDomainSelector } from "../CippComponents/CippFormDomainSelector";
 import { CippFormUserSelector } from "../CippComponents/CippFormUserSelector";
@@ -298,6 +299,9 @@ const CippAddEditUser = (props) => {
           label="First Name"
           name="givenName"
           formControl={formControl}
+          validators={{
+            maxLength: { value: 64, message: "First Name cannot exceed 64 characters" },
+          }}
         />
       </Grid>
       <Grid size={{ md: 6, xs: 12 }}>
@@ -307,6 +311,9 @@ const CippAddEditUser = (props) => {
           label="Last Name"
           name="surname"
           formControl={formControl}
+          validators={{
+            maxLength: { value: 64, message: "Last Name cannot exceed 64 characters" },
+          }}
         />
       </Grid>
       <Grid size={{ xs: 12 }}>
@@ -316,6 +323,10 @@ const CippAddEditUser = (props) => {
           label="Display Name"
           name="displayName"
           formControl={formControl}
+          validators={{
+            required: "Display Name is required",
+            maxLength: { value: 256, message: "Display Name cannot exceed 256 characters" },
+          }}
           onChange={(e) => {
             setDisplayNameManuallySet(true);
           }}
@@ -333,6 +344,14 @@ const CippAddEditUser = (props) => {
           }}
           name="username"
           formControl={formControl}
+          validators={{
+            required: "Username is required",
+            maxLength: { value: 64, message: "Username cannot exceed 64 characters" },
+            pattern: {
+              value: /^[A-Za-z0-9'.\-_!#^~]+$/,
+              message: "Username can only contain letters, numbers, and ' . - _ ! # ^ ~ characters",
+            },
+          }}
           onChange={(e) => {
             setUsernameManuallySet(true);
           }}
@@ -345,6 +364,7 @@ const CippAddEditUser = (props) => {
           formControl={formControl}
           name="primDomain"
           label="Primary Domain name"
+          validators={{ required: "Primary Domain is required" }}
         />
       </Grid>
       <Grid size={{ xs: 12 }}>
@@ -476,6 +496,9 @@ const CippAddEditUser = (props) => {
           label="Job Title"
           name="jobTitle"
           formControl={formControl}
+          validators={{
+            maxLength: { value: 128, message: "Job Title cannot exceed 128 characters" },
+          }}
         />
       </Grid>
       <Grid size={{ md: 6, xs: 12 }}>
@@ -485,6 +508,9 @@ const CippAddEditUser = (props) => {
           label="Street"
           name="streetAddress"
           formControl={formControl}
+          validators={{
+            maxLength: { value: 1024, message: "Street Address cannot exceed 1024 characters" },
+          }}
         />
       </Grid>
       <Grid size={{ md: 6, xs: 12 }}>
@@ -494,6 +520,7 @@ const CippAddEditUser = (props) => {
           label="City"
           name="city"
           formControl={formControl}
+          validators={{ maxLength: { value: 128, message: "City cannot exceed 128 characters" } }}
         />
       </Grid>
       <Grid size={{ md: 6, xs: 12 }}>
@@ -503,6 +530,9 @@ const CippAddEditUser = (props) => {
           label="State/Province"
           name="state"
           formControl={formControl}
+          validators={{
+            maxLength: { value: 128, message: "State/Province cannot exceed 128 characters" },
+          }}
         />
       </Grid>
       <Grid size={{ md: 6, xs: 12 }}>
@@ -512,6 +542,9 @@ const CippAddEditUser = (props) => {
           label="Postal Code"
           name="postalCode"
           formControl={formControl}
+          validators={{
+            maxLength: { value: 40, message: "Postal Code cannot exceed 40 characters" },
+          }}
         />
       </Grid>
       <Grid size={{ md: 6, xs: 12 }}>
@@ -530,6 +563,9 @@ const CippAddEditUser = (props) => {
           label="Company Name"
           name="companyName"
           formControl={formControl}
+          validators={{
+            maxLength: { value: 64, message: "Company Name cannot exceed 64 characters" },
+          }}
         />
       </Grid>
       <Grid size={{ md: 6, xs: 12 }}>
@@ -539,6 +575,9 @@ const CippAddEditUser = (props) => {
           label="Department"
           name="department"
           formControl={formControl}
+          validators={{
+            maxLength: { value: 64, message: "Department cannot exceed 64 characters" },
+          }}
         />
       </Grid>
       <Grid size={{ md: 6, xs: 12 }}>
@@ -548,6 +587,7 @@ const CippAddEditUser = (props) => {
           label="Mobile #"
           name="mobilePhone"
           formControl={formControl}
+          validators={{ maxLength: { value: 64, message: "Mobile # cannot exceed 64 characters" } }}
         />
       </Grid>
       <Grid size={{ md: 6, xs: 12 }}>
@@ -566,6 +606,7 @@ const CippAddEditUser = (props) => {
           label="Alternate Email Address"
           name="otherMails"
           formControl={formControl}
+          validators={{ validate: (value) => !value || getCippValidator(value, "email") }}
         />
       </Grid>
       {userSettingsDefaults?.userAttributes


### PR DESCRIPTION
Enhance user forms by implementing field validation and changing the form control mode to "onBlur" for improved user experience.
Fix a bug in `CippFormComponent` where `field.onBlur` was never wired for any `Controller`-based field type, meaning `onBlur` validation mode silently never fired for `textField`, `textFieldWithVariables`, `radio`, `select`, `autoComplete`, `datePicker`, and `file` types