### PR TITLE
Add DeviceRegLocalAdmins Standard

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -3989,6 +3989,34 @@
     "recommendedBy": []
   },
   {
+    "name": "standards.intuneDeviceRegLocalAdmins",
+    "cat": "Entra (AAD) Standards",
+    "tag": [],
+    "helpText": "Controls whether users who register Microsoft Entra joined devices are granted local administrator rights on those devices and if Global Administrators are added as local admins.",
+    "docsDescription": "Configures the Device Registration Policy local administrator behavior for registering users. When enabled, users who register devices are not granted local administrator rights, you can also configure if Global Administrators are added as local admins.",
+    "executiveText": "Controls whether employees who enroll devices automatically receive local administrator access. Disabling registering-user admin rights follows least-privilege principles and reduces security risk from over-privileged endpoints.",
+    "addedComponent": [
+      {
+        "type": "switch",
+        "name": "standards.intuneDeviceRegLocalAdmins.disableRegisteringUsers",
+        "label": "Disable registering users as local administrators",
+        "defaultValue": true
+      },
+      {
+        "type": "switch",
+        "name": "standards.intuneDeviceRegLocalAdmins.enableGlobalAdmins",
+        "label": "Allow Global Administrators to be local administrators",
+        "defaultValue": true
+      }
+    ],
+    "label": "Configure local administrator rights for users joining devices",
+    "impact": "Medium Impact",
+    "impactColour": "warning",
+    "addedDate": "2026-02-23",
+    "powershellEquivalent": "Update-MgBetaPolicyDeviceRegistrationPolicy",
+    "recommendedBy": []
+  },
+  {
     "name": "standards.intuneRequireMFA",
     "cat": "Intune Standards",
     "tag": ["ZTNA21782", "ZTNA21796", "ZTNA21872"],


### PR DESCRIPTION
Control whether users who register/enroll devices are granted local admin rights and whether Global Administrators are added as local admins.
API: https://github.com/KelvinTegelaar/CIPP-API/pull/1843