### PR TITLE
fix: Ensure dependencies are updated before starting emulators

### DIFF
--- a/Tools/Start-CippDevEmulators.ps1
+++ b/Tools/Start-CippDevEmulators.ps1
@@ -8,6 +8,9 @@ Get-Process node -ErrorAction SilentlyContinue | Stop-Process -ErrorAction Silen
 
 # Get paths
 $Path = (Get-Item $PSScriptRoot).Parent.Parent.FullName
+
+# Run installation script to ensure dependencies are installed and updated before starting emulators
+pwsh -File (Join-Path $PSScriptRoot 'Start-CippDevInstallation.ps1')
 $ApiPath = Join-Path -Path $Path -ChildPath 'CIPP-API'
 $FrontendPath = Join-Path -Path $Path -ChildPath 'CIPP'
 

--- a/Tools/Start-CippDevInstallation.ps1
+++ b/Tools/Start-CippDevInstallation.ps1
@@ -29,4 +29,5 @@ if (-not(yarn global list | Select-String -Pattern 'next')) {
   yarn global add 'next'
 }
 
-yarn install --cwd (Join-Path $Path "CIPP") --network-timeout 500000
+Write-Host 'Running yarn install for CIPP frontend...' -ForegroundColor Cyan
+yarn install --cwd (Join-Path $Path 'CIPP') --network-timeout 500000


### PR DESCRIPTION
Reintroduce the `Start-CippDevInstallation` script in the emulator startup process to guarantee that all dependencies are installed and up to date prior to launching the emulators. 