### PR TITLE
fix(edit): trigger form validation on room info update

### DIFF
--- a/src/pages/email/resources/management/list-rooms/edit.jsx
+++ b/src/pages/email/resources/management/list-rooms/edit.jsx
@@ -115,6 +115,7 @@ const EditRoomMailbox = () => {
             }
           : null,
       });
+      void formControl.trigger();
     }
   }, [roomInfo.isSuccess, roomInfo.data]);
 


### PR DESCRIPTION
This pull request introduces a minor update to the `EditRoomMailbox` component to improve form validation behavior. The change ensures that the form is re-validated after room information is successfully loaded.

A POC of mine had noticed this issue while using CIPP to manage rooms that were created with powershell (with values above the maximum)

* Form validation:
  * [`src/pages/email/resources/management/list-rooms/edit.jsx`](diffhunk://#diff-46f15458773be00aff3a70fdb8bc974cd1a9813bf070d05f00c130ebbe9d74bdR118): Added a call to `formControl.trigger()` after updating form values to trigger validation when `roomInfo` is successfully loaded.