### PR TITLE
Fix: Send defaultDomainName in offboarding updates

### DIFF
--- a/src/pages/tenant/manage/edit.js
+++ b/src/pages/tenant/manage/edit.js
@@ -136,6 +136,15 @@ const Page = () => {
     };
 
     offboardingFormControl.reset({ offboardingDefaults: defaultOffboardingValues });
+
+    updateOffboardingDefaults.mutate({
+      url: "/api/EditTenantOffboardingDefaults",
+      data: {
+        customerId: tenantDetails.data?.id || currentTenant,
+        defaultDomainName: tenantDetails.data?.defaultDomainName || currentTenant,
+        offboardingDefaults: null,
+      },
+    });
   };
 
   const title = "Manage Tenant";
@@ -275,7 +284,8 @@ const Page = () => {
                   onClick={offboardingFormControl.handleSubmit((values) => {
                     const offboardingSettings = values.offboardingDefaults || values;
                     const formattedValues = {
-                      customerId: currentTenant,
+                      customerId: tenantDetails.data?.id || currentTenant,
+                      defaultDomainName: tenantDetails.data?.defaultDomainName || currentTenant,
                       offboardingDefaults: offboardingSettings,
                     };
                     updateOffboardingDefaults.mutate({
@@ -309,6 +319,7 @@ const Page = () => {
                   <Button
                     variant="outlined"
                     onClick={handleResetOffboardingDefaults}
+                    disabled={updateOffboardingDefaults.isPending || tenantDetails.isFetching}
                     sx={{ mr: 2 }}
                   >
                     Reset All to Off


### PR DESCRIPTION
Include tenant defaultDomainName in offboarding update payloads and use the customerId fallback. Add an updateOffboardingDefaults.mutate call on reset to clear offboardingDefaults, and disable the Reset button while an update is pending or tenant details are fetching to avoid concurrent actions.
API: https://github.com/KelvinTegelaar/CIPP-API/pull/1849