### PR TITLE
Feat: Add RouteMessageOutboundConnector support

### DIFF
--- a/src/components/CippComponents/CippTransportRuleDrawer.jsx
+++ b/src/components/CippComponents/CippTransportRuleDrawer.jsx
@@ -143,6 +143,7 @@ export const CippTransportRuleDrawer = ({
       DeleteMessage: "Delete the message without notifying anyone",
       Quarantine: "Quarantine the message",
       RedirectMessageTo: "Redirect the message to...",
+      RouteMessageOutboundConnector: "Route the message using the connector named...",
       BlindCopyTo: "Add recipients to the Bcc box...",
       CopyTo: "Add recipients to the Cc box...",
       ModerateMessageByUser: "Forward the message for approval to...",
@@ -206,7 +207,7 @@ export const CippTransportRuleDrawer = ({
     // Build form data
     const formData = {
       Name: rule.Name || "",
-      Priority: rule.Priority || "",
+      Priority: rule.Priority ?? "",
       Comments: rule.Comments || "",
       Enabled: boolHelper(rule.State),
       Mode: rule.Mode ? { value: rule.Mode, label: rule.Mode } : { value: "Enforce", label: "Enforce" },
@@ -294,6 +295,8 @@ export const CippTransportRuleDrawer = ({
       if (rule[field] !== null && rule[field] !== undefined && !formData[field]) {
         if (field === "SetSCL" && rule[field] !== null) {
           formData[field] = { value: rule[field].toString(), label: rule[field].toString() };
+        } else if (field === "RouteMessageOutboundConnector") {
+          formData[field] = { value: rule[field], label: rule[field] };
         } else {
           formData[field] = rule[field];
         }
@@ -667,6 +670,7 @@ export const CippTransportRuleDrawer = ({
     { value: "DeleteMessage", label: "Delete the message without notifying anyone" },
     { value: "Quarantine", label: "Quarantine the message" },
     { value: "RedirectMessageTo", label: "Redirect the message to..." },
+    { value: "RouteMessageOutboundConnector", label: "Route the message using the connector named..." },
     { value: "BlindCopyTo", label: "Add recipients to the Bcc box..." },
     { value: "CopyTo", label: "Add recipients to the Cc box..." },
     { value: "ModerateMessageByUser", label: "Forward the message for approval to..." },
@@ -704,6 +708,7 @@ export const CippTransportRuleDrawer = ({
               creatable={true}
               api={{
                 url: "/api/ListGraphRequest",
+                queryKey: `Users-TransportRules-${currentTenant}`,
                 data: {
                   Endpoint: "users",
                   tenantFilter: currentTenant,
@@ -734,6 +739,7 @@ export const CippTransportRuleDrawer = ({
               creatable={true}
               api={{
                 url: "/api/ListGraphRequest",
+                queryKey: `Groups-TransportRules-${currentTenant}`,
                 data: {
                   Endpoint: "groups",
                   tenantFilter: currentTenant,
@@ -950,6 +956,7 @@ export const CippTransportRuleDrawer = ({
               multiple={true}
               api={{
                 url: "/api/ListGraphRequest",
+                queryKey: `Users-TransportRules-${currentTenant}`,
                 data: {
                   Endpoint: "users",
                   tenantFilter: currentTenant,
@@ -959,6 +966,28 @@ export const CippTransportRuleDrawer = ({
                 labelField: (option) => `${option.displayName} (${option.userPrincipalName})`,
                 valueField: "userPrincipalName",
                 dataKey: "Results",
+              }}
+            />
+          </Grid>
+        );
+
+      case "RouteMessageOutboundConnector":
+        return (
+          <Grid size={12} key={actionValue}>
+            <CippFormComponent
+              type="autoComplete"
+              label={actionLabel}
+              name={actionValue}
+              formControl={formControl}
+              multiple={false}
+              creatable={false}
+              api={{
+                url: "/api/ListExchangeConnectors",
+                queryKey: `exchangeConnectors-${currentTenant}`,
+                labelField: (option) => `${option.Name}`,
+                valueField: "Name",
+                dataFilter: (options) =>
+                  options.filter((option) => option.rawData?.cippconnectortype === "outbound"),
               }}
             />
           </Grid>
@@ -1260,6 +1289,7 @@ export const CippTransportRuleDrawer = ({
                 type="number"
                 label="Priority"
                 name="Priority"
+                required
                 formControl={formControl}
                 placeholder="0 (lowest priority)"
               />


### PR DESCRIPTION
Register and render the new RouteMessageOutboundConnector transport rule action and improve related form handling.

- Add action label and include it in the actions list.
- Populate form data for RouteMessageOutboundConnector when loading rules.
- Render a dedicated autoComplete field that queries /api/ListExchangeConnectors filtered to outbound connectors.
- Add distinct queryKey values for user/group ListGraphRequest usages to avoid cache collisions.
- Use nullish coalescing for Priority (preserve 0), and mark the Priority input as required.
fixes: https://github.com/KelvinTegelaar/CIPP/issues/5481
API: https://github.com/KelvinTegelaar/CIPP-API/pull/1851