### PR TITLE
Fix: HTML escaping of URLs in action links

### DIFF
--- a/src/components/CippComponents/CippApiDialog.jsx
+++ b/src/components/CippComponents/CippApiDialog.jsx
@@ -269,10 +269,14 @@ export const CippApiDialog = (props) => {
     return div.innerHTML;
   };
 
-  const getNestedValue = (obj, path) => {
-    const value = path
+  const getRawNestedValue = (obj, path) => {
+    return path
       .split(".")
       .reduce((acc, key) => (acc && acc[key] !== undefined ? acc[key] : undefined), obj);
+  };
+
+  const getNestedValue = (obj, path) => {
+    const value = getRawNestedValue(obj, path);
     return typeof value === "string" ? escapeHtml(value) : value;
   };
 
@@ -288,7 +292,7 @@ export const CippApiDialog = (props) => {
       linkOpenedRef.current = true;
       const linkWithData = api.link.replace(
         /\[([^\]]+)\]/g,
-        (_, key) => getNestedValue(row, key) || `[${key}]`,
+        (_, key) => getRawNestedValue(row, key) || `[${key}]`,
       );
       if (linkWithData.startsWith("/") && !api?.external) {
         router.push(linkWithData, undefined, { shallow: true });


### PR DESCRIPTION
Prevent HTML encoding of URLs in action links to ensure proper handling of consent URLs with query parameters, resolving issues with Microsoft OAuth.