### PR TITLE
fix(reusable-settings): normalize RawJSON casing in templates

### DIFF
--- a/src/components/CippComponents/CippReusableSettingsDeployDrawer.jsx
+++ b/src/components/CippComponents/CippReusableSettingsDeployDrawer.jsx
@@ -27,11 +27,14 @@ export const CippReusableSettingsDeployDrawer = ({
 
   const templates = ApiGetCall({ url: "/api/ListIntuneReusableSettingTemplates", queryKey: "ListIntuneReusableSettingTemplates" });
 
+  const getRawJson = (source) => source?.RawJSON ?? source?.RAWJson ?? source?.rawJSON ?? "";
+
   useEffect(() => {
     if (templates.isSuccess && selectedTemplate?.value) {
       const match = templates.data?.find((t) => t.GUID === selectedTemplate.value);
       if (match) {
-        formControl.setValue("rawJSON", match.RawJSON || "");
+        const rawJsonValue = getRawJson(match);
+        formControl.setValue("rawJSON", rawJsonValue);
         formControl.setValue("TemplateId", match.GUID);
       }
     }

--- a/src/pages/endpoint/MEM/reusable-settings-templates/edit.jsx
+++ b/src/pages/endpoint/MEM/reusable-settings-templates/edit.jsx
@@ -117,7 +117,7 @@ const EditReusableSettingsTemplate = () => {
     return {
       ...templateData,
       // Normalize all known casing variants to the canonical RawJSON property
-      RawJSON: templateData.RawJSON ?? templateData.RAWJson ?? templateData.RAWJSON,
+      RawJSON: templateData.RawJSON ?? templateData.RAWJson ?? templateData.rawJSON,
     };
   }, [templateData]);
 

--- a/src/pages/endpoint/MEM/reusable-settings/edit.jsx
+++ b/src/pages/endpoint/MEM/reusable-settings/edit.jsx
@@ -36,22 +36,26 @@ const EditReusableSetting = () => {
 
   const record = Array.isArray(settingQuery.data) ? settingQuery.data[0] : settingQuery.data;
 
+  const getRawJson = (source) => source?.RawJSON ?? "";
+
   useEffect(() => {
     if (record) {
+      const rawJsonValue = getRawJson(record);
       reset({
         tenantFilter: effectiveTenant,
         ID: record.id,
         displayName: record.displayName,
         description: record.description,
-        rawJSON: record.RawJSON,
+        rawJSON: rawJsonValue,
       });
     }
   }, [record, effectiveTenant, reset]);
 
   const safeJson = () => {
-    if (!record?.RawJSON) return null;
+    const rawJsonValue = getRawJson(record);
+    if (!rawJsonValue) return null;
     try {
-      return JSON.parse(record.RawJSON);
+      return JSON.parse(rawJsonValue);
     } catch (e) {
       console.error("Failed to parse RawJSON for reusable setting preview", {
         error: e,


### PR DESCRIPTION
This pull request standardizes the way the `RawJSON` property is accessed and normalized across components and pages that handle reusable settings and templates. The main focus is to handle inconsistencies in casing for the `RawJSON` property, ensuring that the correct data is used regardless of how it is named in the source.

**DEPENDS ON:** https://github.com/KelvinTegelaar/CIPP-API/pull/1861
**FIXES:** Currently untracked bug, Intune policy deployment throwing `Failed to sync reusable policy settings for template : The property 'RawJSON' cannot be found on this object.`

Standardization of RawJSON property access:

* Added a helper function `getRawJson` in both `CippReusableSettingsDeployDrawer` and `EditReusableSetting` components to consistently retrieve the `RawJSON` property, regardless of casing variants (`RawJSON`, `RAWJson`, `rawJSON`). [[1]](diffhunk://#diff-f229a8509e07f1df491ed4ea4abe9ac555f0a582445624caa481c9f330c2209eR30-R37) [[2]](diffhunk://#diff-d88b2291f858335f7ef5947364e175812a1c03733b1daa209810f690db811966R39-R58)
* Updated the normalization logic in `EditReusableSettingsTemplate` to include the `rawJSON` variant when assigning the canonical `RawJSON` property.

Refactoring for consistency:

* Refactored usages of the `RawJSON` property in form initialization and JSON parsing to use the new helper function, reducing the risk of missing data due to inconsistent casing. [[1]](diffhunk://#diff-f229a8509e07f1df491ed4ea4abe9ac555f0a582445624caa481c9f330c2209eR30-R37) [[2]](diffhunk://#diff-d88b2291f858335f7ef5947364e175812a1c03733b1daa209810f690db811966R39-R58)