### PR TITLE
feat: Update button link to new "add a tenant" wizard

### DIFF
--- a/src/pages/tenant/gdap-management/index.js
+++ b/src/pages/tenant/gdap-management/index.js
@@ -167,7 +167,7 @@ const Page = () => {
         <Grid size={12}>
           <Button
             LinkComponent={Link}
-            href="/tenant/gdap-management/invites/add"
+            href="/onboardingv2"
             startIcon={<Add />}
             variant="contained"
           >


### PR DESCRIPTION
Change the button link to direct users to the new onboarding wizard for adding a tenant.
As discused on/in office hours