### PR TITLE
Improved Bookmarks

### DIFF
--- a/src/components/CippComponents/CippSettingsSideBar.jsx
+++ b/src/components/CippComponents/CippSettingsSideBar.jsx
@@ -137,6 +137,9 @@ export const CippSettingsSideBar = (props) => {
               Settings on this page can be saved for the current user, or all users. Select the
               desired option below.
             </Typography>
+            <Alert severity="info" variant="outlined" icon={false} sx={{ py: 0.5, px: 2 }}>
+              Navigation settings are per-device and stored locally, regardless of the user selector.
+            </Alert>
             <CippFormComponent
               type="autoComplete"
               disableClearable={true}

--- a/src/contexts/settings-context.js
+++ b/src/contexts/settings-context.js
@@ -81,6 +81,8 @@ const initialSettings = {
   persistFilters: false,
   lastUsedFilters: {},
   breadcrumbMode: "hierarchical",
+  bookmarkSidebar: true,
+  bookmarkPopover: false,
 };
 
 const initialState = {

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -224,12 +224,24 @@ export const Layout = (props) => {
         }
         // get current devtools settings
         var showDevtools = settings.showDevtools;
-        // get current bookmarks
+        // get current bookmarks and navigation settings (device-local only)
         var bookmarks = settings.bookmarks;
+        var bookmarkSidebar = settings.bookmarkSidebar;
+        var bookmarkPopover = settings.bookmarkPopover;
+        var bookmarkReorderMode = settings.bookmarkReorderMode;
+        var bookmarkLocked = settings.bookmarkLocked;
+        var bookmarkSortOrder = settings.bookmarkSortOrder;
+        var bookmarksOpen = settings.bookmarksOpen;
 
         settings.handleUpdate({
           ...userSettingsAPI.data,
           bookmarks,
+          bookmarkSidebar,
+          bookmarkPopover,
+          bookmarkReorderMode,
+          bookmarkLocked,
+          bookmarkSortOrder,
+          bookmarksOpen,
           showDevtools,
         });
 

--- a/src/layouts/mobile-nav.js
+++ b/src/layouts/mobile-nav.js
@@ -1,12 +1,14 @@
 import NextLink from "next/link";
 import { usePathname } from "next/navigation";
 import PropTypes from "prop-types";
-import { Box, Drawer, Stack } from "@mui/material";
+import { Box, Divider, Drawer, Stack } from "@mui/material";
 import { Logo } from "../components/logo";
 import { Scrollbar } from "../components/scrollbar";
 import { paths } from "../paths";
 import { MobileNavItem } from "./mobile-nav-item";
+import { SideNavBookmarks } from "./side-nav-bookmarks";
 import { CippTenantSelector } from "../components/CippComponents/CippTenantSelector";
+import { useSettings } from "../hooks/use-settings";
 
 const MOBILE_NAV_WIDTH = "80%";
 
@@ -77,6 +79,8 @@ const reduceChildRoutes = ({ acc, depth, item, pathname }) => {
 export const MobileNav = (props) => {
   const { open, onClose, items } = props;
   const pathname = usePathname();
+  const settings = useSettings();
+  const showSidebarBookmarks = settings.bookmarkSidebar !== false;
 
   return (
     <Drawer
@@ -137,6 +141,14 @@ export const MobileNav = (props) => {
               p: 0,
             }}
           >
+            {/* Bookmarks section above Dashboard */}
+            {showSidebarBookmarks && (
+              <>
+                <SideNavBookmarks collapse={false} />
+                <Divider sx={{ my: 1 }} />
+              </>
+            )}
+            {/* Render all menu items */}
             {renderItems({
               depth: 0,
               items,

--- a/src/layouts/side-nav-bookmarks.js
+++ b/src/layouts/side-nav-bookmarks.js
@@ -1,0 +1,509 @@
+import { useCallback, useMemo, useState, useEffect, useRef } from "react";
+import NextLink from "next/link";
+import {
+  Box,
+  ButtonBase,
+  Collapse,
+  IconButton,
+  Stack,
+  SvgIcon,
+  Typography,
+} from "@mui/material";
+import BookmarkIcon from "@mui/icons-material/Bookmark";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import CloseIcon from "@mui/icons-material/Close";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
+import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+import LockIcon from "@mui/icons-material/Lock";
+import LockOpenIcon from "@mui/icons-material/LockOpen";
+import ChevronRightIcon from "@heroicons/react/24/outline/ChevronRightIcon";
+import ChevronDownIcon from "@heroicons/react/24/outline/ChevronDownIcon";
+import { useSettings } from "../hooks/use-settings";
+
+export const SideNavBookmarks = ({ collapse = false }) => {
+  const settings = useSettings();
+  const [open, setOpen] = useState(settings.bookmarksOpen ?? false);
+  const reorderMode = settings.bookmarkReorderMode || "arrows";
+  const locked = settings.bookmarkLocked ?? false;
+  const [sortOrder, setSortOrder] = useState(settings.bookmarkSortOrder || "custom");
+  const [dragIndex, setDragIndex] = useState(null);
+  const [dragOverIndex, setDragOverIndex] = useState(null);
+  const [animatingPair, setAnimatingPair] = useState(null);
+  const [flashSort, setFlashSort] = useState(false);
+  const [flashLock, setFlashLock] = useState(false);
+  const itemRefs = useRef({});
+  const touchDragRef = useRef({ startIdx: null, overIdx: null });
+
+  const handleToggle = useCallback(() => {
+    setOpen((prev) => {
+      const next = !prev;
+      settings.handleUpdate({ bookmarksOpen: next });
+      return next;
+    });
+  }, [settings]);
+
+  const moveBookmarkUp = useCallback(
+    (index) => {
+      if (index <= 0) return;
+      const updatedBookmarks = [...(settings.bookmarks || [])];
+      const temp = updatedBookmarks[index];
+      updatedBookmarks[index] = updatedBookmarks[index - 1];
+      updatedBookmarks[index - 1] = temp;
+      settings.handleUpdate({ bookmarks: updatedBookmarks });
+    },
+    [settings]
+  );
+
+  const moveBookmarkDown = useCallback(
+    (index) => {
+      const bookmarks = settings.bookmarks || [];
+      if (index >= bookmarks.length - 1) return;
+      const updatedBookmarks = [...bookmarks];
+      const temp = updatedBookmarks[index];
+      updatedBookmarks[index] = updatedBookmarks[index + 1];
+      updatedBookmarks[index + 1] = temp;
+      settings.handleUpdate({ bookmarks: updatedBookmarks });
+    },
+    [settings]
+  );
+
+  const removeBookmark = useCallback(
+    (path) => {
+      const updatedBookmarks = [...(settings.bookmarks || [])];
+      const origIdx = updatedBookmarks.findIndex((b) => b.path === path);
+      if (origIdx !== -1) {
+        updatedBookmarks.splice(origIdx, 1);
+        settings.handleUpdate({ bookmarks: updatedBookmarks });
+      }
+    },
+    [settings]
+  );
+
+  const animatedMoveUp = useCallback(
+    (index) => {
+      if (index <= 0 || animatingPair) return;
+      const el1 = itemRefs.current[index];
+      const el2 = itemRefs.current[index - 1];
+      if (!el1 || !el2) { moveBookmarkUp(index); return; }
+      const distance = el1.getBoundingClientRect().top - el2.getBoundingClientRect().top;
+      setAnimatingPair({ idx1: index, idx2: index - 1, offset1: -distance, offset2: distance });
+      setTimeout(() => {
+        moveBookmarkUp(index);
+        setAnimatingPair(null);
+      }, 250);
+    },
+    [animatingPair, moveBookmarkUp]
+  );
+
+  const animatedMoveDown = useCallback(
+    (index) => {
+      const bookmarks = settings.bookmarks || [];
+      if (index >= bookmarks.length - 1 || animatingPair) return;
+      const el1 = itemRefs.current[index];
+      const el2 = itemRefs.current[index + 1];
+      if (!el1 || !el2) { moveBookmarkDown(index); return; }
+      const distance = el2.getBoundingClientRect().top - el1.getBoundingClientRect().top;
+      setAnimatingPair({ idx1: index, idx2: index + 1, offset1: distance, offset2: -distance });
+      setTimeout(() => {
+        moveBookmarkDown(index);
+        setAnimatingPair(null);
+      }, 250);
+    },
+    [animatingPair, settings.bookmarks, moveBookmarkDown]
+  );
+
+  const triggerSortFlash = useCallback(() => {
+    setFlashSort(true);
+    setTimeout(() => setFlashSort(false), 600);
+  }, []);
+
+  const triggerLockFlash = useCallback(() => {
+    setFlashLock(true);
+    setTimeout(() => setFlashLock(false), 600);
+  }, []);
+
+  const handleToggleLock = useCallback(() => {
+    settings.handleUpdate({ bookmarkLocked: !locked });
+  }, [settings, locked]);
+
+  const handleDragStart = useCallback((index) => {
+    setDragIndex(index);
+  }, []);
+
+  const handleDragOver = useCallback((e, index) => {
+    e.preventDefault();
+    setDragOverIndex(index);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e, dropIndex) => {
+      e.preventDefault();
+      if (dragIndex === null || dragIndex === dropIndex) {
+        setDragIndex(null);
+        setDragOverIndex(null);
+        return;
+      }
+      const items = [...(settings.bookmarks || [])];
+      const [reordered] = items.splice(dragIndex, 1);
+      items.splice(dropIndex, 0, reordered);
+      settings.handleUpdate({ bookmarks: items });
+      setDragIndex(null);
+      setDragOverIndex(null);
+    },
+    [dragIndex, settings]
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDragIndex(null);
+    setDragOverIndex(null);
+  }, []);
+
+  const handleSortCycle = useCallback(() => {
+    const next = sortOrder === "custom" ? "asc" : sortOrder === "asc" ? "desc" : "custom";
+    setSortOrder(next);
+    settings.handleUpdate({ bookmarkSortOrder: next });
+  }, [sortOrder, settings]);
+
+  const displayBookmarks = useMemo(() => {
+    const bookmarks = settings.bookmarks || [];
+    if (sortOrder === "custom") return bookmarks;
+    return [...bookmarks].sort((a, b) => {
+      const cmp = (a.label || "").localeCompare(b.label || "");
+      return sortOrder === "asc" ? cmp : -cmp;
+    });
+  }, [settings.bookmarks, sortOrder]);
+
+  return (
+    <li>
+      <Stack direction="row" alignItems="center">
+        <ButtonBase
+          onClick={handleToggle}
+          sx={{
+            alignItems: "center",
+            borderRadius: 1,
+            display: "flex",
+            fontFamily: (theme) => theme.typography.fontFamily,
+            fontSize: 14,
+            fontWeight: 500,
+            justifyContent: "flex-start",
+            px: "6px",
+            py: "12px",
+            textAlign: "left",
+            whiteSpace: "nowrap",
+            width: "100%",
+          }}
+        >
+          <Box
+            component="span"
+            sx={{
+              alignItems: "center",
+              color: "neutral.400",
+              display: "inline-flex",
+              flexGrow: 0,
+              flexShrink: 0,
+              height: 24,
+              justifyContent: "center",
+              width: 24,
+            }}
+          >
+            <SvgIcon fontSize="small">
+              <BookmarkIcon />
+            </SvgIcon>
+          </Box>
+          <Box
+            component="span"
+            sx={{
+              color: "text.primary",
+              flexGrow: 1,
+              fontSize: 14,
+              mx: "12px",
+              transition: "opacity 250ms ease-in-out",
+              ...(collapse && {
+                opacity: 0,
+              }),
+            }}
+          >
+            Bookmarks
+          </Box>
+        </ButtonBase>
+        {!collapse && (
+          <>
+            <IconButton
+              size="small"
+              onClick={handleToggleLock}
+              sx={{
+                color: locked ? "warning.main" : "neutral.500",
+                p: "2px",
+                transition: "opacity 250ms ease-in-out",
+                ...(flashLock && {
+                  animation: "lockFlash 600ms ease-in-out",
+                  "@keyframes lockFlash": {
+                    "0%": { transform: "scale(1)" },
+                    "25%": { transform: "scale(1.5)", color: "#ff9800" },
+                    "50%": { transform: "scale(1)" },
+                    "75%": { transform: "scale(1.3)", color: "#ff9800" },
+                    "100%": { transform: "scale(1)" },
+                  },
+                }),
+              }}
+              title={locked ? "Unlock bookmarks" : "Lock bookmarks"}
+            >
+              {locked ? <LockIcon sx={{ fontSize: 16 }} /> : <LockOpenIcon sx={{ fontSize: 16 }} />}
+            </IconButton>
+            <IconButton
+              size="small"
+              onClick={handleSortCycle}
+              sx={{
+                color: sortOrder === "custom" ? "neutral.500" : "primary.main",
+                p: "2px",
+                transition: "opacity 250ms ease-in-out",
+                ...(flashSort && {
+                  animation: "sortFlash 600ms ease-in-out",
+                  "@keyframes sortFlash": {
+                    "0%": { transform: "scale(1)" },
+                    "25%": { transform: "scale(1.5)", color: "#ff9800" },
+                    "50%": { transform: "scale(1)" },
+                    "75%": { transform: "scale(1.3)", color: "#ff9800" },
+                    "100%": { transform: "scale(1)" },
+                  },
+                }),
+              }}
+              title={sortOrder === "custom" ? "Custom order" : sortOrder === "asc" ? "A > Z" : "Z > A"}
+            >
+              {sortOrder === "custom" && <SwapVertIcon sx={{ fontSize: 16 }} />}
+              {sortOrder === "asc" && <ArrowUpwardIcon sx={{ fontSize: 16 }} />}
+              {sortOrder === "desc" && <ArrowDownwardIcon sx={{ fontSize: 16 }} />}
+            </IconButton>
+          </>
+        )}
+        <Box
+          component="span"
+          onClick={handleToggle}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            cursor: "pointer",
+            color: "neutral.500",
+            pr: "6px",
+            transition: "opacity 250ms ease-in-out",
+            ...(collapse && {
+              opacity: 0,
+            }),
+          }}
+        >
+          <SvgIcon sx={{ fontSize: 16 }}>
+            {open ? <ChevronDownIcon /> : <ChevronRightIcon />}
+          </SvgIcon>
+        </Box>
+      </Stack>
+      <Collapse in={!collapse && open} unmountOnExit>
+        <Stack component="ul" spacing={0.5} sx={{ listStyle: "none", m: 0, p: 0 }}>
+          {displayBookmarks.length === 0 ? (
+            <li>
+              <Typography
+                variant="body2"
+                sx={{
+                  pl: "42px",
+                  pr: "8px",
+                  py: "8px",
+                  color: "text.secondary",
+                  fontSize: 13,
+                }}
+              >
+                No bookmarks added yet
+              </Typography>
+            </li>
+          ) : (
+            displayBookmarks.map((bookmark, idx) => (
+              <li
+                key={bookmark.path}
+                ref={(el) => { itemRefs.current[idx] = el; }}
+                data-bookmark-index={idx}
+                draggable={reorderMode === "drag" && sortOrder === "custom" && !locked}
+                {...(reorderMode === "drag" ? {
+                  onDragStart: (e) => {
+                    if (locked) { e.preventDefault(); triggerLockFlash(); return; }
+                    if (sortOrder !== "custom") { e.preventDefault(); triggerSortFlash(); return; }
+                    handleDragStart(idx);
+                  },
+                  onDragEnd: handleDragEnd,
+                  ...(sortOrder === "custom" && !locked ? {
+                    onDragOver: (e) => handleDragOver(e, idx),
+                    onDrop: (e) => handleDrop(e, idx),
+                  } : {}),
+                } : {})}
+                style={{
+                  ...(animatingPair && (animatingPair.idx1 === idx || animatingPair.idx2 === idx) ? {
+                    transform: `translateY(${animatingPair.idx1 === idx ? animatingPair.offset1 : animatingPair.offset2}px)`,
+                    transition: 'transform 250ms ease-in-out',
+                    position: 'relative',
+                    zIndex: animatingPair.idx1 === idx ? 1 : 0,
+                  } : {}),
+                }}
+              >
+                <Stack
+                  direction="row"
+                  alignItems="center"
+                  sx={{
+                    position: "relative",
+                    pl: "42px",
+                    pr: "8px",
+                    py: "2px",
+                    "&:hover .bookmark-controls": {
+                      opacity: 1,
+                    },
+                    ...(sortOrder === "custom" && reorderMode === "drag" && dragIndex === idx && {
+                      opacity: 0.4,
+                    }),
+                    ...(sortOrder === "custom" && reorderMode === "drag" && dragOverIndex === idx && dragIndex !== idx && {
+                      borderTop: "2px solid",
+                      borderColor: "primary.main",
+                    }),
+                  }}
+                >
+                  {reorderMode === "drag" && !locked && (
+                    <Box
+                      onTouchStart={() => {
+                        if (sortOrder !== "custom") { triggerSortFlash(); return; }
+                        touchDragRef.current.startIdx = idx;
+                        setDragIndex(idx);
+                      }}
+                      onTouchMove={(e) => {
+                        if (touchDragRef.current.startIdx === null) return;
+                        const touch = e.touches[0];
+                        const draggedLi = itemRefs.current[touchDragRef.current.startIdx];
+                        if (draggedLi) draggedLi.style.pointerEvents = "none";
+                        const el = document.elementFromPoint(touch.clientX, touch.clientY);
+                        if (draggedLi) draggedLi.style.pointerEvents = "";
+                        const li = el?.closest("[data-bookmark-index]");
+                        if (li) {
+                          const overIdx = parseInt(li.dataset.bookmarkIndex, 10);
+                          if (!isNaN(overIdx) && overIdx >= 0 && overIdx < (settings.bookmarks || []).length) {
+                            touchDragRef.current.overIdx = overIdx;
+                            setDragOverIndex(overIdx);
+                          }
+                        }
+                      }}
+                      onTouchEnd={() => {
+                        const { startIdx, overIdx } = touchDragRef.current;
+                        if (startIdx !== null && overIdx !== null && startIdx !== overIdx) {
+                          const items = [...(settings.bookmarks || [])];
+                          const [reordered] = items.splice(startIdx, 1);
+                          items.splice(overIdx, 0, reordered);
+                          settings.handleUpdate({ bookmarks: items });
+                        }
+                        touchDragRef.current = { startIdx: null, overIdx: null };
+                        setDragIndex(null);
+                        setDragOverIndex(null);
+                      }}
+                      sx={{
+                        touchAction: "none",
+                        display: "flex",
+                        alignItems: "center",
+                        color: "neutral.500",
+                        cursor: sortOrder === "custom" ? "grab" : "default",
+                        mr: 0.5,
+                      }}
+                    >
+                      <DragIndicatorIcon sx={{ fontSize: 16 }} />
+                    </Box>
+                  )}
+                  <ButtonBase
+                    component={NextLink}
+                    href={bookmark.path}
+                    sx={{
+                      alignItems: "center",
+                      borderRadius: 1,
+                      display: "flex",
+                      fontFamily: (theme) => theme.typography.fontFamily,
+                      fontSize: 13,
+                      fontWeight: 500,
+                      justifyContent: "flex-start",
+                      py: "6px",
+                      textAlign: "left",
+                      whiteSpace: "nowrap",
+                      flexGrow: 1,
+                      overflow: "hidden",
+                    }}
+                  >
+                    <Box
+                      component="span"
+                      sx={{
+                        color: "text.secondary",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                      }}
+                    >
+                      {bookmark.label}
+                    </Box>
+                  </ButtonBase>
+                  <Stack
+                    className="bookmark-controls"
+                    direction="row"
+                    spacing={0}
+                    sx={{
+                      position: "absolute",
+                      right: 8,
+                      opacity: 0,
+                      transition: "opacity 150ms ease-in-out",
+                      backgroundColor: "background.default",
+                      borderRadius: 1,
+                      "@media (hover: none)": {
+                        opacity: 1,
+                      },
+                    }}
+                  >
+                    {reorderMode === "arrows" && (
+                      <>
+                        <IconButton
+                          size="small"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            if (locked) { triggerLockFlash(); return; }
+                            sortOrder === "custom" ? animatedMoveUp(idx) : triggerSortFlash();
+                          }}
+                          disabled={sortOrder === "custom" && idx === 0}
+                          sx={{ p: "2px", opacity: sortOrder !== "custom" || locked ? 0.4 : 1 }}
+                        >
+                          <KeyboardArrowUpIcon sx={{ fontSize: 16 }} />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            if (locked) { triggerLockFlash(); return; }
+                            sortOrder === "custom" ? animatedMoveDown(idx) : triggerSortFlash();
+                          }}
+                          disabled={sortOrder === "custom" && idx === displayBookmarks.length - 1}
+                          sx={{ p: "2px", opacity: sortOrder !== "custom" || locked ? 0.4 : 1 }}
+                        >
+                          <KeyboardArrowDownIcon sx={{ fontSize: 16 }} />
+                        </IconButton>
+                      </>
+                    )}
+                    {!(reorderMode === "drag" && locked) && (
+                      <IconButton
+                        size="small"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          if (locked) { triggerLockFlash(); return; }
+                          removeBookmark(bookmark.path);
+                        }}
+                        sx={{ p: "2px", ...(locked && { opacity: 0.4 }) }}
+                      >
+                        <CloseIcon sx={{ fontSize: 16 }} />
+                      </IconButton>
+                    )}
+                  </Stack>
+                </Stack>
+              </li>
+            ))
+          )}
+        </Stack>
+      </Collapse>
+    </li>
+  );
+};

--- a/src/layouts/side-nav-item.js
+++ b/src/layouts/side-nav-item.js
@@ -37,7 +37,7 @@ export const SideNavItem = (props) => {
       handleUpdate({
         bookmarks: isBookmarked
           ? bookmarks.filter((bookmark) => bookmark.path !== path)
-          : [...bookmarks, { label: title, path }],
+          : bookmarks.length >= 50 ? bookmarks : [...bookmarks, { label: title, path }],
       });
     },
     [isBookmarked, bookmarks, handleUpdate, path, title]

--- a/src/layouts/side-nav.js
+++ b/src/layouts/side-nav.js
@@ -1,11 +1,13 @@
 import { useState } from "react";
 import { usePathname } from "next/navigation";
 import PropTypes from "prop-types";
-import { Box, Drawer, Stack } from "@mui/material";
+import { Box, Divider, Drawer, Stack } from "@mui/material";
 import { Scrollbar } from "../components/scrollbar";
 import { SideNavItem } from "./side-nav-item";
+import { SideNavBookmarks } from "./side-nav-bookmarks";
 import { ApiGetCall } from "../api/ApiCall.jsx";
 import { CippSponsor } from "../components/CippComponents/CippSponsor";
+import { useSettings } from "../hooks/use-settings";
 
 const SIDE_NAV_WIDTH = 270;
 const SIDE_NAV_COLLAPSED_WIDTH = 73; // icon size + padding + border right
@@ -105,6 +107,8 @@ export const SideNav = (props) => {
   const [hovered, setHovered] = useState(false);
   const collapse = !(pinned || hovered);
   const { data: profile } = ApiGetCall({ url: "/api/me", queryKey: "authmecipp" });
+  const settings = useSettings();
+  const showSidebarBookmarks = settings.bookmarkSidebar !== false;
 
   // Preprocess items to mark which should be open
   const processedItems = markOpenItems(items, pathname);
@@ -159,6 +163,14 @@ export const SideNav = (props) => {
                   p: 0,
                 }}
               >
+                {/* Bookmarks section above Dashboard */}
+                {showSidebarBookmarks && (
+                  <>
+                    <SideNavBookmarks collapse={collapse} />
+                    <Divider sx={{ my: 1 }} />
+                  </>
+                )}
+                {/* Render all menu items */}
                 {renderItems({
                   collapse,
                   depth: 0,

--- a/src/layouts/top-nav.js
+++ b/src/layouts/top-nav.js
@@ -1,14 +1,19 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import NextLink from "next/link";
 import PropTypes from "prop-types";
 import Bars3Icon from "@heroicons/react/24/outline/Bars3Icon";
 import MoonIcon from "@heroicons/react/24/outline/MoonIcon";
 import SunIcon from "@heroicons/react/24/outline/SunIcon";
 import BookmarkIcon from "@mui/icons-material/Bookmark";
-import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
-import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import CloseIcon from "@mui/icons-material/Close";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
+import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+import LockIcon from "@mui/icons-material/Lock";
+import LockOpenIcon from "@mui/icons-material/LockOpen";
 import {
   Box,
   Divider,
@@ -31,16 +36,17 @@ import { NotificationsPopover } from "./notifications-popover";
 import { useDialog } from "../hooks/use-dialog";
 import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { CippCentralSearch } from "../components/CippComponents/CippCentralSearch";
-import { applySort } from "../utils/apply-sort";
 
 const TOP_NAV_HEIGHT = 64;
 
 export const TopNav = (props) => {
   const searchDialog = useDialog();
-  const tenantSelectorRef = useRef(null);
   const { onNavOpen } = props;
   const settings = useSettings();
   const mdDown = useMediaQuery((theme) => theme.breakpoints.down("md"));
+  const showPopoverBookmarks = settings.bookmarkPopover === true;
+  const reorderMode = settings.bookmarkReorderMode || "arrows";
+  const locked = settings.bookmarkLocked ?? false;
   const handleThemeSwitch = useCallback(() => {
     const themeName = settings.currentTheme?.value === "light" ? "dark" : "light";
     settings.handleUpdate({
@@ -50,7 +56,14 @@ export const TopNav = (props) => {
   }, [settings]);
 
   const [anchorEl, setAnchorEl] = useState(null);
-  const [sortOrder, setSortOrder] = useState("asc");
+  const [sortOrder, setSortOrder] = useState(settings.bookmarkSortOrder || "custom");
+  const [dragIndex, setDragIndex] = useState(null);
+  const [dragOverIndex, setDragOverIndex] = useState(null);
+  const [animatingPair, setAnimatingPair] = useState(null);
+  const [flashSort, setFlashSort] = useState(false);
+  const [flashLock, setFlashLock] = useState(false);
+  const itemRefs = useRef({});
+  const touchDragRef = useRef({ startIdx: null, overIdx: null });
 
   const handleBookmarkClick = (event) => {
     setAnchorEl(event.currentTarget);
@@ -60,53 +73,124 @@ export const TopNav = (props) => {
     setAnchorEl(null);
   };
 
-  const handleSortToggle = () => {
-    const newSortOrder = sortOrder === "asc" ? "desc" : "asc";
-    setSortOrder(newSortOrder);
-
-    // Save the new sort order and re-order bookmarks
-    const sortedBookmarks = applySort(settings.bookmarks || [], "label", newSortOrder);
-    settings.handleUpdate({
-      bookmarks: sortedBookmarks,
-      sortOrder: newSortOrder,
-    });
+  const handleDragStart = (index) => {
+    setDragIndex(index);
   };
 
-  // Move a bookmark up in the list
+  const handleDragOver = (e, index) => {
+    e.preventDefault();
+    setDragOverIndex(index);
+  };
+
+  const handleDrop = (e, dropIndex) => {
+    e.preventDefault();
+    if (dragIndex === null || dragIndex === dropIndex) {
+      setDragIndex(null);
+      setDragOverIndex(null);
+      return;
+    }
+    const items = [...(settings.bookmarks || [])];
+    const [reordered] = items.splice(dragIndex, 1);
+    items.splice(dropIndex, 0, reordered);
+    settings.handleUpdate({ bookmarks: items });
+    setDragIndex(null);
+    setDragOverIndex(null);
+  };
+
+  const handleDragEnd = () => {
+    setDragIndex(null);
+    setDragOverIndex(null);
+  };
+
   const moveBookmarkUp = (index) => {
     if (index <= 0) return;
-
     const updatedBookmarks = [...(settings.bookmarks || [])];
     const temp = updatedBookmarks[index];
     updatedBookmarks[index] = updatedBookmarks[index - 1];
     updatedBookmarks[index - 1] = temp;
-
     settings.handleUpdate({ bookmarks: updatedBookmarks });
   };
 
-  // Move a bookmark down in the list
   const moveBookmarkDown = (index) => {
     const bookmarks = settings.bookmarks || [];
     if (index >= bookmarks.length - 1) return;
-
     const updatedBookmarks = [...bookmarks];
     const temp = updatedBookmarks[index];
     updatedBookmarks[index] = updatedBookmarks[index + 1];
     updatedBookmarks[index + 1] = temp;
-
     settings.handleUpdate({ bookmarks: updatedBookmarks });
   };
 
-  const openSearch = useCallback(() => {
-    searchDialog.handleOpen();
-  }, [searchDialog.handleOpen]);
+  const removeBookmark = (path) => {
+    const updatedBookmarks = [...(settings.bookmarks || [])];
+    const origIdx = updatedBookmarks.findIndex((b) => b.path === path);
+    if (origIdx !== -1) {
+      updatedBookmarks.splice(origIdx, 1);
+      settings.handleUpdate({ bookmarks: updatedBookmarks });
+    }
+  };
+
+  const triggerSortFlash = () => {
+    setFlashSort(true);
+    setTimeout(() => setFlashSort(false), 600);
+  };
+
+  const triggerLockFlash = () => {
+    setFlashLock(true);
+    setTimeout(() => setFlashLock(false), 600);
+  };
+
+  const handleToggleLock = () => {
+    settings.handleUpdate({ bookmarkLocked: !locked });
+  };
+
+  const animatedMoveUp = (index) => {
+    if (index <= 0 || animatingPair) return;
+    const el1 = itemRefs.current[index];
+    const el2 = itemRefs.current[index - 1];
+    if (!el1 || !el2) { moveBookmarkUp(index); return; }
+    const distance = el1.getBoundingClientRect().top - el2.getBoundingClientRect().top;
+    setAnimatingPair({ idx1: index, idx2: index - 1, offset1: -distance, offset2: distance });
+    setTimeout(() => {
+      moveBookmarkUp(index);
+      setAnimatingPair(null);
+    }, 250);
+  };
+
+  const animatedMoveDown = (index) => {
+    const bookmarks = settings.bookmarks || [];
+    if (index >= bookmarks.length - 1 || animatingPair) return;
+    const el1 = itemRefs.current[index];
+    const el2 = itemRefs.current[index + 1];
+    if (!el1 || !el2) { moveBookmarkDown(index); return; }
+    const distance = el2.getBoundingClientRect().top - el1.getBoundingClientRect().top;
+    setAnimatingPair({ idx1: index, idx2: index + 1, offset1: distance, offset2: -distance });
+    setTimeout(() => {
+      moveBookmarkDown(index);
+      setAnimatingPair(null);
+    }, 250);
+  };
+
+  const handleSortCycle = () => {
+    const next = sortOrder === "custom" ? "asc" : sortOrder === "asc" ? "desc" : "custom";
+    setSortOrder(next);
+    settings.handleUpdate({ bookmarkSortOrder: next });
+  };
+
+  const displayBookmarks = useMemo(() => {
+    const bookmarks = settings.bookmarks || [];
+    if (sortOrder === "custom") return bookmarks;
+    return [...bookmarks].sort((a, b) => {
+      const cmp = (a.label || "").localeCompare(b.label || "");
+      return sortOrder === "asc" ? cmp : -cmp;
+    });
+  }, [settings.bookmarks, sortOrder]);
+  const popoverOpen = Boolean(anchorEl);
+  const popoverId = popoverOpen ? "bookmark-popover" : undefined;
 
   useEffect(() => {
     const handleKeyDown = (event) => {
-      if ((event.metaKey || event.ctrlKey) && event.altKey && event.key === "k") {
-        event.preventDefault();
-        tenantSelectorRef.current?.focus();
-      } else if ((event.metaKey || event.ctrlKey) && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         openSearch();
       }
@@ -115,19 +199,11 @@ export const TopNav = (props) => {
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [openSearch]);
+  }, []);
 
-  useEffect(() => {
-    if (settings.sortOrder) {
-      setSortOrder(settings.sortOrder);
-    }
-  }, [settings.sortOrder]);
-
-  // Use the sorted bookmarks if sorting is applied, otherwise use the bookmarks in their current order
-  const displayBookmarks = settings.bookmarks || [];
-
-  const open = Boolean(anchorEl);
-  const id = open ? "bookmark-popover" : undefined;
+  const openSearch = () => {
+    searchDialog.handleOpen();
+  };
 
   return (
     <Box
@@ -173,7 +249,7 @@ export const TopNav = (props) => {
           >
             <Logo />
           </Box>
-          {!mdDown && <CippTenantSelector ref={tenantSelectorRef} refreshButton={true} tenantButton={true} />}
+          {!mdDown && <CippTenantSelector refreshButton={true} tenantButton={true} />}
           {mdDown && (
             <IconButton color="inherit" onClick={onNavOpen}>
               <SvgIcon color="action" fontSize="small">
@@ -195,90 +271,248 @@ export const TopNav = (props) => {
               <MagnifyingGlassIcon />
             </SvgIcon>
           </IconButton>
-          <IconButton color="inherit" onClick={handleBookmarkClick}>
-            <SvgIcon color="action" fontSize="small">
-              <BookmarkIcon />
-            </SvgIcon>
-          </IconButton>
-          <Popover
-            id={id}
-            open={open}
-            anchorEl={anchorEl}
-            onClose={handleBookmarkClose}
-            anchorOrigin={{
-              vertical: "bottom",
-              horizontal: "center",
-            }}
-            transformOrigin={{
-              vertical: "top",
-              horizontal: "center",
-            }}
-          >
-            <List sx={{ minWidth: "220px" }}>
-              <ListItem>
-                <IconButton onClick={handleSortToggle}>
-                  <SvgIcon fontSize="small">
-                    {sortOrder === "asc" ? <ArrowUpwardIcon /> : <ArrowDownwardIcon />}
-                  </SvgIcon>
-                </IconButton>
-                <Typography variant="body2">Sort Alphabetically</Typography>
-              </ListItem>
-              {displayBookmarks.length === 0 ? (
-                <ListItem>
-                  <ListItemText
-                    primary={<Typography variant="body2">No bookmarks added yet</Typography>}
-                  />
-                </ListItem>
-              ) : (
-                displayBookmarks.map((bookmark, idx) => (
-                  <ListItem
-                    key={idx}
-                    sx={{
-                      color: "inherit",
-                      display: "flex",
-                      justifyContent: "space-between",
-                    }}
-                  >
-                    <Box
-                      component={NextLink}
-                      href={bookmark.path}
-                      onClick={() => handleBookmarkClose()}
+          {showPopoverBookmarks && (
+            <>
+              <IconButton color="inherit" onClick={handleBookmarkClick}>
+                <SvgIcon color="action" fontSize="small">
+                  <BookmarkIcon />
+                </SvgIcon>
+              </IconButton>
+              <Popover
+                id={popoverId}
+                open={popoverOpen}
+                anchorEl={anchorEl}
+                onClose={handleBookmarkClose}
+                disableScrollLock
+                anchorOrigin={{
+                  vertical: "bottom",
+                  horizontal: "center",
+                }}
+                transformOrigin={{
+                  vertical: "top",
+                  horizontal: "center",
+                }}
+              >
+                <List sx={{ minWidth: "220px" }}>
+                  <ListItem sx={{ py: 0.5 }}>
+                    <IconButton
+                      size="small"
+                      onClick={handleToggleLock}
                       sx={{
-                        textDecoration: "none",
-                        color: "inherit",
-                        flexGrow: 1,
-                        marginRight: 2,
+                        color: locked ? "warning.main" : "neutral.500",
+                        ...(flashLock && {
+                          animation: "lockFlash 600ms ease-in-out",
+                          "@keyframes lockFlash": {
+                            "0%": { transform: "scale(1)" },
+                            "25%": { transform: "scale(1.5)", color: "#ff9800" },
+                            "50%": { transform: "scale(1)" },
+                            "75%": { transform: "scale(1.3)", color: "#ff9800" },
+                            "100%": { transform: "scale(1)" },
+                          },
+                        }),
                       }}
+                      title={locked ? "Unlock bookmarks" : "Lock bookmarks"}
                     >
-                      <Typography variant="body2">{bookmark.label}</Typography>
-                    </Box>
-                    <Stack direction="row" spacing={1}>
-                      <IconButton
-                        size="small"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          moveBookmarkUp(idx);
-                        }}
-                        disabled={idx === 0}
-                      >
-                        <KeyboardArrowUpIcon fontSize="small" />
-                      </IconButton>
-                      <IconButton
-                        size="small"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          moveBookmarkDown(idx);
-                        }}
-                        disabled={idx === displayBookmarks.length - 1}
-                      >
-                        <KeyboardArrowDownIcon fontSize="small" />
-                      </IconButton>
-                    </Stack>
+                      {locked ? <LockIcon fontSize="small" /> : <LockOpenIcon fontSize="small" />}
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      onClick={handleSortCycle}
+                      sx={{
+                        color: sortOrder === "custom" ? "neutral.500" : "primary.main",
+                        ...(flashSort && {
+                          animation: "sortFlash 600ms ease-in-out",
+                          "@keyframes sortFlash": {
+                            "0%": { transform: "scale(1)" },
+                            "25%": { transform: "scale(1.5)", color: "#ff9800" },
+                            "50%": { transform: "scale(1)" },
+                            "75%": { transform: "scale(1.3)", color: "#ff9800" },
+                            "100%": { transform: "scale(1)" },
+                          },
+                        }),
+                      }}
+                      title={sortOrder === "custom" ? "Custom order" : sortOrder === "asc" ? "A > Z" : "Z > A"}
+                    >
+                      {sortOrder === "custom" && <SwapVertIcon fontSize="small" />}
+                      {sortOrder === "asc" && <ArrowUpwardIcon fontSize="small" />}
+                      {sortOrder === "desc" && <ArrowDownwardIcon fontSize="small" />}
+                    </IconButton>
+                    <Typography
+                      variant="body2"
+                      sx={{ ml: 0.5, color: "text.secondary", fontSize: 12 }}
+                    >
+                      {sortOrder === "custom" ? "Custom order" : sortOrder === "asc" ? "A > Z" : "Z > A"}
+                    </Typography>
                   </ListItem>
-                ))
-              )}
-            </List>
-          </Popover>
+                  <Divider />
+                  {displayBookmarks.length === 0 ? (
+                    <ListItem>
+                      <ListItemText
+                        primary={<Typography variant="body2">No bookmarks added yet</Typography>}
+                      />
+                    </ListItem>
+                  ) : (
+                    displayBookmarks.map((bookmark, idx) => (
+                      <ListItem
+                        key={bookmark.path}
+                        ref={(el) => { itemRefs.current[idx] = el; }}
+                        data-bookmark-index={idx}
+                        draggable={reorderMode === "drag" && sortOrder === "custom" && !locked}
+                        {...(reorderMode === "drag" ? {
+                          onDragStart: (e) => {
+                            if (locked) { e.preventDefault(); triggerLockFlash(); return; }
+                            if (sortOrder !== "custom") { e.preventDefault(); triggerSortFlash(); return; }
+                            handleDragStart(idx);
+                          },
+                          onDragEnd: handleDragEnd,
+                          ...(sortOrder === "custom" && !locked ? {
+                            onDragOver: (e) => handleDragOver(e, idx),
+                            onDrop: (e) => handleDrop(e, idx),
+                          } : {}),
+                        } : {})}
+                        sx={{
+                          color: "inherit",
+                          display: "flex",
+                          justifyContent: "space-between",
+                          "&:hover .bookmark-controls": {
+                            opacity: 1,
+                          },
+                          ...(sortOrder === "custom" && reorderMode === "drag" && dragIndex === idx && {
+                            opacity: 0.4,
+                          }),
+                          ...(sortOrder === "custom" && reorderMode === "drag" && dragOverIndex === idx && dragIndex !== idx && {
+                            borderTop: "2px solid",
+                            borderColor: "primary.main",
+                          }),
+                          ...(animatingPair && (animatingPair.idx1 === idx || animatingPair.idx2 === idx) && {
+                            transform: `translateY(${animatingPair.idx1 === idx ? animatingPair.offset1 : animatingPair.offset2}px)`,
+                            transition: 'transform 250ms ease-in-out',
+                            position: 'relative',
+                            zIndex: animatingPair.idx1 === idx ? 1 : 0,
+                          }),
+                        }}
+                      >
+                        {reorderMode === "drag" && !locked && (
+                          <Box
+                            onTouchStart={() => {
+                              if (sortOrder !== "custom") { triggerSortFlash(); return; }
+                              touchDragRef.current.startIdx = idx;
+                              setDragIndex(idx);
+                            }}
+                            onTouchMove={(e) => {
+                              if (touchDragRef.current.startIdx === null) return;
+                              const touch = e.touches[0];
+                              const draggedLi = itemRefs.current[touchDragRef.current.startIdx];
+                              if (draggedLi) draggedLi.style.pointerEvents = "none";
+                              const el = document.elementFromPoint(touch.clientX, touch.clientY);
+                              if (draggedLi) draggedLi.style.pointerEvents = "";
+                              const li = el?.closest("[data-bookmark-index]");
+                              if (li) {
+                                const overIdx = parseInt(li.dataset.bookmarkIndex, 10);
+                                if (!isNaN(overIdx) && overIdx >= 0 && overIdx < (settings.bookmarks || []).length) {
+                                  touchDragRef.current.overIdx = overIdx;
+                                  setDragOverIndex(overIdx);
+                                }
+                              }
+                            }}
+                            onTouchEnd={() => {
+                              const { startIdx, overIdx } = touchDragRef.current;
+                              if (startIdx !== null && overIdx !== null && startIdx !== overIdx) {
+                                const items = [...(settings.bookmarks || [])];
+                                const [reordered] = items.splice(startIdx, 1);
+                                items.splice(overIdx, 0, reordered);
+                                settings.handleUpdate({ bookmarks: items });
+                              }
+                              touchDragRef.current = { startIdx: null, overIdx: null };
+                              setDragIndex(null);
+                              setDragOverIndex(null);
+                            }}
+                            sx={{
+                              touchAction: "none",
+                              display: "flex",
+                              alignItems: "center",
+                              color: "neutral.500",
+                              cursor: sortOrder === "custom" ? "grab" : "default",
+                              mr: 1,
+                            }}
+                          >
+                            <DragIndicatorIcon fontSize="small" />
+                          </Box>
+                        )}
+                        <Box
+                          component={NextLink}
+                          href={bookmark.path}
+                          onClick={() => handleBookmarkClose()}
+                          sx={{
+                            textDecoration: "none",
+                            color: "inherit",
+                            flexGrow: 1,
+                            marginRight: 2,
+                          }}
+                        >
+                          <Typography variant="body2">{bookmark.label}</Typography>
+                        </Box>
+                        <Stack
+                          className="bookmark-controls"
+                          direction="row"
+                          spacing={0}
+                          sx={{
+                            opacity: 0,
+                            transition: "opacity 150ms ease-in-out",
+                            "@media (hover: none)": {
+                              opacity: 1,
+                            },
+                          }}
+                        >
+                          {reorderMode === "arrows" && (
+                            <>
+                              <IconButton
+                                size="small"
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  if (locked) { triggerLockFlash(); return; }
+                                  sortOrder === "custom" ? animatedMoveUp(idx) : triggerSortFlash();
+                                }}
+                                disabled={sortOrder === "custom" && idx === 0}
+                                sx={{ opacity: sortOrder !== "custom" || locked ? 0.4 : 1 }}
+                              >
+                                <KeyboardArrowUpIcon fontSize="small" />
+                              </IconButton>
+                              <IconButton
+                                size="small"
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  if (locked) { triggerLockFlash(); return; }
+                                  sortOrder === "custom" ? animatedMoveDown(idx) : triggerSortFlash();
+                                }}
+                                disabled={sortOrder === "custom" && idx === displayBookmarks.length - 1}
+                                sx={{ opacity: sortOrder !== "custom" || locked ? 0.4 : 1 }}
+                              >
+                                <KeyboardArrowDownIcon fontSize="small" />
+                              </IconButton>
+                            </>
+                          )}
+                          {!(reorderMode === "drag" && locked) && (
+                            <IconButton
+                              size="small"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                if (locked) { triggerLockFlash(); return; }
+                                removeBookmark(bookmark.path);
+                              }}
+                              sx={{ ...(locked && { opacity: 0.4 }) }}
+                            >
+                              <CloseIcon fontSize="small" />
+                            </IconButton>
+                          )}
+                        </Stack>
+                      </ListItem>
+                    ))
+                  )}
+                </List>
+              </Popover>
+            </>
+          )}
           <CippCentralSearch open={searchDialog.open} handleClose={searchDialog.handleClose} />
           <NotificationsPopover />
           <AccountPopover

--- a/src/pages/cipp/preferences.js
+++ b/src/pages/cipp/preferences.js
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { Box, Container, Stack } from "@mui/material";
+import { Alert, Box, Container, Stack } from "@mui/material";
 import { Grid } from "@mui/system";
 import { Layout as DashboardLayout } from "../../layouts/index.js";
 import { CippPropertyListCard } from "../../components/CippCards/CippPropertyListCard";
@@ -98,6 +98,27 @@ const Page = () => {
     control: formcontrol.control,
     name: "user",
   });
+
+  // Watch navigation settings and apply immediately (device-local, no server save needed)
+  const watchedBookmarkSidebar = useWatch({ control: formcontrol.control, name: "bookmarkSidebar" });
+  const watchedBookmarkPopover = useWatch({ control: formcontrol.control, name: "bookmarkPopover" });
+  const watchedBookmarkReorderMode = useWatch({ control: formcontrol.control, name: "bookmarkReorderMode" });
+
+  useEffect(() => {
+    const updates = {};
+    if (watchedBookmarkSidebar !== undefined && watchedBookmarkSidebar !== settings.bookmarkSidebar) {
+      updates.bookmarkSidebar = watchedBookmarkSidebar;
+    }
+    if (watchedBookmarkPopover !== undefined && watchedBookmarkPopover !== settings.bookmarkPopover) {
+      updates.bookmarkPopover = watchedBookmarkPopover;
+    }
+    if (watchedBookmarkReorderMode !== undefined && watchedBookmarkReorderMode !== settings.bookmarkReorderMode) {
+      updates.bookmarkReorderMode = watchedBookmarkReorderMode;
+    }
+    if (Object.keys(updates).length > 0) {
+      settings.handleUpdate(updates);
+    }
+  }, [watchedBookmarkSidebar, watchedBookmarkPopover, watchedBookmarkReorderMode]);
 
   // Update form when initial user type is determined
   useEffect(() => {
@@ -306,6 +327,48 @@ const Page = () => {
                               type="switch"
                               name="persistFilters"
                               formControl={formcontrol}
+                            />
+                          ),
+                        },
+                      ]}
+                    />
+                    <CippPropertyListCard
+                      layout="two"
+                      showDivider={false}
+                      title="Navigation Settings - Per Device (Local Storage)"
+                      propertyItems={[
+                        {
+                          label: "Show Sidebar Bookmarks",
+                          value: (
+                            <CippFormComponent
+                              type="switch"
+                              name="bookmarkSidebar"
+                              formControl={formcontrol}
+                            />
+                          ),
+                        },
+                        {
+                          label: "Show Popover Bookmarks",
+                          value: (
+                            <CippFormComponent
+                              type="switch"
+                              name="bookmarkPopover"
+                              formControl={formcontrol}
+                            />
+                          ),
+                        },
+                        {
+                          label: "Bookmark Reorder Mode",
+                          value: (
+                            <CippFormComponent
+                              type="radio"
+                              name="bookmarkReorderMode"
+                              formControl={formcontrol}
+                              row={true}
+                              options={[
+                                { value: "arrows", label: "Arrow Buttons" },
+                                { value: "drag", label: "Drag and Drop" },
+                              ]}
                             />
                           ),
                         },


### PR DESCRIPTION
![vivaldi_ntyANMgkYZ](https://github.com/user-attachments/assets/2d540e7d-9461-4e47-bcaf-e3172d08e29e)


- Add SideNavBookmarks component with collapsible bookmark list in sidebar and mobile nav
- Rewrite top-nav bookmark popover with non-destructive sort (custom/asc/desc),
  configurable reorder mode (arrows/drag-and-drop), and animated arrow reorder mode transitions
- Add lock toggle to prevent accidental reorder/removal with flash feedback of the icon to bring it to user's attention
- Add mobile touch drag-and-drop support via drag handle icon (if drag and drop enabled, users on mobile can only use the drag handle to rearange bookmarks)
- Fix bookmark removal bug: use path-based lookup instead of display index
- Add Navigation Settings UI in User preferences (sidebar toggle, popover toggle, reorder mode) with immediate apply via localStorage
- Store all navigation/bookmark settings per-device only (localStorage), excluded from server sync to prevent cross-device/user overwrite
- Fix popover disabling overflow for the page while open
- Add info alert about per-device scope in settings sidebar
- Enforce maximum bookmark limit of 50
- Add bounds validation for touch drag indices