### PR TITLE
Improve sidebar scroll behavior and close popover on navigation

### DIFF
--- a/src/layouts/account-popover.js
+++ b/src/layouts/account-popover.js
@@ -146,7 +146,7 @@ export const AccountPopover = (props) => {
                     secondary={orgData?.data?.Org?.Domain}
                   />
                 </ListItem>
-                <ListItemButton onClick={onThemeSwitch}>
+                <ListItemButton onClick={() => { popover.handleClose(); onThemeSwitch(); }}>
                   <ListItemIcon>
                     <SvgIcon fontSize="small">
                       {paletteMode === "dark" ? <SunIcon /> : <MoonIcon />}
@@ -156,7 +156,7 @@ export const AccountPopover = (props) => {
                 </ListItemButton>
               </>
             )}
-            <ListItemButton onClick={() => router.push("/cipp/preferences")}>
+            <ListItemButton onClick={() => { popover.handleClose(); router.push("/cipp/preferences"); }}>
               <ListItemIcon>
                 <SvgIcon fontSize="small">
                   <CogIcon />

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -64,6 +64,8 @@ const LayoutRoot = styled("div")(({ theme }) => ({
   display: "flex",
   flex: "1 1 auto",
   maxWidth: "100%",
+  height: "100vh",
+  overflow: "hidden",
   paddingTop: TOP_NAV_HEIGHT,
   [theme.breakpoints.up("lg")]: {
     paddingLeft: SIDE_NAV_WIDTH,
@@ -75,6 +77,8 @@ const LayoutContainer = styled("div")({
   flex: "1 1 auto",
   flexDirection: "column",
   width: "100%",
+  overflowY: "auto",
+  overscrollBehavior: "contain",
 });
 
 export const Layout = (props) => {

--- a/src/layouts/side-nav.js
+++ b/src/layouts/side-nav.js
@@ -1,8 +1,7 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import PropTypes from "prop-types";
 import { Box, Divider, Drawer, Stack } from "@mui/material";
-import { Scrollbar } from "../components/scrollbar";
 import { SideNavItem } from "./side-nav-item";
 import { SideNavBookmarks } from "./side-nav-bookmarks";
 import { ApiGetCall } from "../api/ApiCall.jsx";
@@ -109,6 +108,43 @@ export const SideNav = (props) => {
   const { data: profile } = ApiGetCall({ url: "/api/me", queryKey: "authmecipp" });
   const settings = useSettings();
   const showSidebarBookmarks = settings.bookmarkSidebar !== false;
+  const paperRef = useRef(null);
+
+  // Intercept wheel events on the side nav to fully isolate scroll.
+  // preventDefault stops wheel events from reaching the main content,
+  // and manual scrollTop has no momentum so it stops instantly when the cursor leaves.
+  // Uses RAF-based easing to smooth out discrete mouse wheel jumps.
+  useEffect(() => {
+    const el = paperRef.current;
+    if (!el) return;
+
+    let targetScrollTop = el.scrollTop;
+    let animating = false;
+
+    const animate = () => {
+      const diff = targetScrollTop - el.scrollTop;
+      if (Math.abs(diff) < 0.5) {
+        el.scrollTop = targetScrollTop;
+        animating = false;
+        return;
+      }
+      el.scrollTop += diff * 0.25;
+      requestAnimationFrame(animate);
+    };
+
+    const handleWheel = (e) => {
+      e.preventDefault();
+      const maxScroll = el.scrollHeight - el.clientHeight;
+      targetScrollTop = Math.max(0, Math.min(maxScroll, targetScrollTop + e.deltaY));
+      if (!animating) {
+        animating = true;
+        requestAnimationFrame(animate);
+      }
+    };
+
+    el.addEventListener("wheel", handleWheel, { passive: false });
+    return () => el.removeEventListener("wheel", handleWheel);
+  }, []);
 
   // Preprocess items to mark which should be open
   const processedItems = markOpenItems(items, pathname);
@@ -119,16 +155,15 @@ export const SideNav = (props) => {
           open
           variant="permanent"
           PaperProps={{
-            onMouseEnter: () => {
-              setHovered(true);
-            },
-            onMouseLeave: () => {
-              setHovered(false);
-            },
+            ref: paperRef,
+            onMouseEnter: () => setHovered(true),
+            onMouseLeave: () => setHovered(false),
             sx: {
               backgroundColor: "background.default",
               height: `calc(100% - ${TOP_NAV_HEIGHT}px)`,
               overflowX: "hidden",
+              overflowY: "auto",
+              scrollbarGutter: "stable",
               top: TOP_NAV_HEIGHT,
               transition: "width 250ms ease-in-out",
               width: collapse ? SIDE_NAV_COLLAPSED_WIDTH : SIDE_NAV_WIDTH,
@@ -136,15 +171,6 @@ export const SideNav = (props) => {
             },
           }}
         >
-          <Scrollbar
-            sx={{
-              height: "100%",
-              overflowX: "hidden",
-              "& .simplebar-content": {
-                height: "100%",
-              },
-            }}
-          >
             <Box
               component="nav"
               sx={{
@@ -182,7 +208,6 @@ export const SideNav = (props) => {
               {profile?.clientPrincipal && <CippSponsor />}
             </Box>{" "}
             {/* Closing tag for the parent Box */}
-          </Scrollbar>
         </Drawer>
       )}
     </>


### PR DESCRIPTION
This PR enhances the user experience by improving sidebar scroll and main page scroll behaviour

Current sidemenu scroll implementation causes scroll bleed between sidemenu and the main page. It causes the menu or the page to become "sticky" when the mouse cursor moves from one to the other mid-scroll. Additionally if the cursor positioned in certain sections of the menu, scrolling up or down affects the main page instead.
See below. 

Old                                |  New
:-------------------------:|:-------------------------:
![old menu](https://github.com/user-attachments/assets/7947f450-308c-4674-8320-35d0611ca884)  |  ![new menu](https://github.com/user-attachments/assets/365cdf3c-4a90-408d-99bb-1d328e41da5b)





- Replace Scrollbar component with native overflow for better control
- Implement custom wheel event handling in the sidebar to prevent scroll events from propagating to the main content area
- Add RAF-based (RequestAnimationFrame) easing to smooth out discrete mouse wheel jumps, providing a more polished scrolling experience
- Add viewport constraints to prevent body scroll interference
- Set overscroll-behaviour to contain scroll within layout container

- Close account popover when switching theme or navigating to preferences