### PR TITLE
feat: add "Include disabled admin accounts" option to MFAAdmins alert

### DIFF
--- a/src/data/alerts.json
+++ b/src/data/alerts.json
@@ -7,7 +7,11 @@
   {
     "name": "MFAAdmins",
     "label": "Alert on admins without any form of MFA",
-    "recommendedRunInterval": "1d"
+    "recommendedRunInterval": "1d",
+    "requiresInput": true,
+    "inputType": "switch",
+    "inputLabel": "Include disabled admin accounts?",
+    "inputName": "IncludeDisabled"
   },
   {
     "name": "NewMFADevice",


### PR DESCRIPTION
Adds an IncludeDisabled switch to the MFAAdmins alert. Off by default.

Fixes #5448

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1876