### PR TITLE
Fix Alternate Email Addresses validator blocking edit user submission

### DIFF
--- a/src/components/CippComponents/CippAddTenantGroupDrawer.jsx
+++ b/src/components/CippComponents/CippAddTenantGroupDrawer.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Button, Box } from "@mui/material";
 import { useForm, useFormState } from "react-hook-form";
 import { GroupAdd } from "@mui/icons-material";
@@ -6,7 +6,6 @@ import { CippOffCanvas } from "./CippOffCanvas";
 import { CippApiResults } from "./CippApiResults";
 import { ApiPostCall } from "../../api/ApiCall";
 import CippAddEditTenantGroups from "./CippAddEditTenantGroups";
-import { getCippValidator } from "../../utils/get-cipp-validator";
 
 export const CippAddTenantGroupDrawer = ({
   buttonText = "Add Tenant Group",

--- a/src/components/CippFormPages/CippAddEditUser.jsx
+++ b/src/components/CippFormPages/CippAddEditUser.jsx
@@ -112,6 +112,21 @@ const CippAddEditUser = (props) => {
     return username.toLowerCase();
   };
 
+  const validateOtherMails = (value) => {
+    if (!value || (Array.isArray(value) && value.length === 0)) {
+      return true;
+    }
+
+    const emailList = (Array.isArray(value) ? value.join(",") : value)
+      .split(",")
+      .map((email) => email.trim())
+      .filter(Boolean);
+
+    const invalidEmail = emailList.find((email) => getCippValidator(email, "email") !== true);
+
+    return !invalidEmail || `This is not a valid email: ${invalidEmail}`;
+  };
+
   useEffect(() => {
     //if watch.firstname changes, and watch.lastname changes, set displayname to firstname + lastname
     if (watcher.givenName && watcher.surname && formType === "add") {
@@ -331,7 +346,6 @@ const CippAddEditUser = (props) => {
             setDisplayNameManuallySet(true);
           }}
           required={true}
-          validators={{ required: "Display Name is required" }}
         />
       </Grid>
       <Grid size={{ md: 6, xs: 12 }}>
@@ -356,7 +370,6 @@ const CippAddEditUser = (props) => {
             setUsernameManuallySet(true);
           }}
           required={true}
-          validators={{ required: "Username is required" }}
         />
       </Grid>
       <Grid size={{ md: 6, xs: 12 }}>
@@ -603,10 +616,10 @@ const CippAddEditUser = (props) => {
         <CippFormComponent
           type="textField"
           fullWidth
-          label="Alternate Email Address"
+          label="Alternate Email Addresses (comma separated)"
           name="otherMails"
           formControl={formControl}
-          validators={{ validate: (value) => !value || getCippValidator(value, "email") }}
+          validators={{ validate: validateOtherMails }}
         />
       </Grid>
       {userSettingsDefaults?.userAttributes

--- a/src/pages/identity/administration/users/add.jsx
+++ b/src/pages/identity/administration/users/add.jsx
@@ -2,13 +2,13 @@ import { Box } from "@mui/material";
 import CippFormPage from "../../../../components/CippFormPages/CippFormPage";
 import { Layout as DashboardLayout } from "../../../../layouts/index.js";
 import { useForm, useWatch } from "react-hook-form";
-import { CippFormUserSelector } from "../../../../components/CippComponents/CippFormUserSelector";
 import { useSettings } from "../../../../hooks/use-settings";
 import { useEffect } from "react";
 
 import CippAddEditUser from "../../../../components/CippFormPages/CippAddEditUser";
 const Page = () => {
   const userSettingsDefaults = useSettings();
+  const tenantDomain = useSettings().currentTenant;
 
   const formControl = useForm({
     mode: "onBlur",
@@ -54,6 +54,7 @@ const Page = () => {
         title="User"
         backButtonTitle="User Overview"
         postUrl="/api/AddUser"
+        relatedQueryKeys={`Users - ${tenantDomain}`}
       >
         <Box sx={{ my: 2 }}>
           <CippAddEditUser formControl={formControl} userSettingsDefaults={userSettingsDefaults} />


### PR DESCRIPTION
This was blocking submission of the edit user page, also its a comma separated list so corrected validator and backend apis. Tested with new users with 0,1 and 2 emails set as alternatives in both the user creator and the user editor pages.

API: https://github.com/KelvinTegelaar/CIPP-API/pull/1880