### PR TITLE
Update README for universal search feature

### DIFF
--- a/user-documentation/dashboard/README.md
+++ b/user-documentation/dashboard/README.md
@@ -21,14 +21,10 @@ The data CIPP uses to display the dashboard is cached in a database that gets up
 
 <summary>Universal Search</summary>
 
-This is a universal search bar that allows you to quickly find the information you need using Lighthouse.  For example, enter a first name of a user. CIPP will return a list of all users in your connected tenants with that first name. You can toggle between "Users", "Groups", and "BitLocker" to alter what the search is looking for. When you select "BitLocker" you also have the option to search by "Key ID" or "Device ID".
+This is a universal search bar that allows you to quickly find the information you need. For example, enter a first name of a user. CIPP will return a list of all users in your connected tenants with that first name. You can toggle between "Users", "Groups", and "BitLocker" to alter what the search is looking for. When you select "BitLocker" you also have the option to search by "Key ID" or "Device ID".
 
 {% hint style="info" %}
 This feature relies on the cached data from the CIPP reporting database. You can force a databse refresh using the "Update Report" button in [#report-control](./#report-control "mention")
-{% endhint %}
-
-{% hint style="warning" %}
-To utilize this search, you must have onboarded Lighthouse on your partner tenant.
 {% endhint %}
 
 </details>


### PR DESCRIPTION
Removed warning about onboarding Lighthouse for search functionality with the new Universal Search as it only uses the DB.