### PR TITLE
fix: resolve SharePoint User Information List by template instead of localized display name

### DIFF
--- a/src/pages/teams-share/sharepoint/index.js
+++ b/src/pages/teams-share/sharepoint/index.js
@@ -199,11 +199,9 @@ const Page = () => {
         title="Site Members"
         queryKey={`site-members-${row.siteId}`}
         api={{
-          url: "/api/ListGraphRequest",
+          url: "/api/ListSiteMembers",
           data: {
-            Endpoint: `/sites/${row.siteId}/lists/User%20Information%20List/items`,
-            AsApp: "true",
-            expand: "fields",
+            SiteId: row.siteId,
             tenantFilter: tenantFilter,
           },
           dataKey: "Results",


### PR DESCRIPTION
- Resolves KelvinTegelaar/CIPP#5532
- Depends on: KelvinTegelaar/CIPP-API#1891

Use new /api/ListSiteMembers endpoint instead of hardcoded User Information List name for SharePoint site members.