### PR TITLE
Default values bug fix

### DIFF
--- a/src/components/CippComponents/CippApiDialog.jsx
+++ b/src/components/CippComponents/CippApiDialog.jsx
@@ -52,7 +52,7 @@ export const CippApiDialog = (props) => {
   useEffect(() => {
     if (createDialog.open) {
       setIsFormSubmitted(false);
-      formHook.reset(defaultvalues || {});
+      formHook.reset(typeof defaultvalues === "function" ? defaultvalues(row) : defaultvalues || {});
     }
   }, [createDialog.open, defaultvalues]);
 


### PR DESCRIPTION
When defaultvalues is a function, the reset call on dialog open was passing the function itself instead of calling it with the current row. This meant React Hook Form had no valid values to reset to, so it fell back to whatever was set when the dialog first mounted — keeping the first row's data stuck in the form no matter which row you clicked after that.

Tested by opening the edit template name and description dialog on one Intune Template, closing it, then opening the edit template name and description on a different template — the first template's name and description stayed in the fields instead of updating.

The fix is to call defaultvalues(row) when it's a function, which is the same pattern already used one line above it for the initial form setup.

Closes #5608 