### PR TITLE
Fix: fix focus loss in retention settings number field

### DIFF
--- a/src/components/CippSettings/CippBackupRetentionSettings.jsx
+++ b/src/components/CippSettings/CippBackupRetentionSettings.jsx
@@ -1,8 +1,7 @@
-import { Button, ButtonGroup, SvgIcon, Typography, TextField, Box } from "@mui/material";
+import { Button, Typography, TextField, Box } from "@mui/material";
 import CippButtonCard from "../CippCards/CippButtonCard";
 import { ApiGetCall, ApiPostCall } from "../../api/ApiCall";
 import { CippApiResults } from "../CippComponents/CippApiResults";
-import { History } from "@mui/icons-material";
 import { useState, useEffect } from "react";
 
 const CippBackupRetentionSettings = () => {
@@ -55,40 +54,36 @@ const CippBackupRetentionSettings = () => {
     }
   };
 
-  const RetentionControls = () => {
-    return (
-      <Box sx={{ display: "flex", gap: 1, alignItems: "flex-start" }}>
-        <TextField
-          size="small"
-          type="number"
-          value={retentionDays}
-          onChange={handleInputChange}
-          disabled={retentionChange.isPending || retentionSetting.isLoading}
-          inputProps={{ min: 7 }}
-          error={!!error}
-          helperText={error}
-          sx={{ width: "120px" }}
-          label="Days"
-        />
-        <Button
-          variant="contained"
-          color="primary"
-          size="small"
-          disabled={retentionChange.isPending || retentionSetting.isLoading || !!error}
-          onClick={handleRetentionChange}
-          sx={{ mt: 0.5 }}
-        >
-          Save
-        </Button>
-      </Box>
-    );
-  };
-
   return (
     <CippButtonCard
       title="Backup Retention"
       cardSx={{ display: "flex", flexDirection: "column", height: "100%" }}
-      CardButton={<RetentionControls />}
+      CardButton={
+        <Box sx={{ display: "flex", gap: 1, alignItems: "flex-start" }}>
+          <TextField
+            size="small"
+            type="number"
+            value={retentionDays}
+            onChange={handleInputChange}
+            disabled={retentionChange.isPending || retentionSetting.isLoading}
+            inputProps={{ min: 7 }}
+            error={!!error}
+            helperText={error}
+            sx={{ width: "120px" }}
+            label="Days"
+          />
+          <Button
+            variant="contained"
+            color="primary"
+            size="small"
+            disabled={retentionChange.isPending || retentionSetting.isLoading || !!error}
+            onClick={handleRetentionChange}
+            sx={{ mt: 0.5 }}
+          >
+            Save
+          </Button>
+        </Box>
+      }
     >
       <Typography variant="body2">
         Configure how long to keep backup files. Both CIPP system backups and tenant backups will be

--- a/src/components/CippSettings/CippLogRetentionSettings.jsx
+++ b/src/components/CippSettings/CippLogRetentionSettings.jsx
@@ -61,40 +61,36 @@ const CippLogRetentionSettings = () => {
     }
   };
 
-  const RetentionControls = () => {
-    return (
-      <Box sx={{ display: "flex", gap: 1, alignItems: "flex-start" }}>
-        <TextField
-          size="small"
-          type="number"
-          value={retentionDays}
-          onChange={handleInputChange}
-          disabled={retentionChange.isPending || retentionSetting.isLoading}
-          inputProps={{ min: 7, max: 365 }}
-          error={!!error}
-          helperText={error}
-          sx={{ width: "120px" }}
-          label="Days"
-        />
-        <Button
-          variant="contained"
-          color="primary"
-          size="small"
-          disabled={retentionChange.isPending || retentionSetting.isLoading || !!error}
-          onClick={handleRetentionChange}
-          sx={{ mt: 0.5 }}
-        >
-          Save
-        </Button>
-      </Box>
-    );
-  };
-
   return (
     <CippButtonCard
       title="Log Retention"
       cardSx={{ display: "flex", flexDirection: "column", height: "100%" }}
-      CardButton={<RetentionControls />}
+      CardButton={
+        <Box sx={{ display: "flex", gap: 1, alignItems: "flex-start" }}>
+          <TextField
+            size="small"
+            type="number"
+            value={retentionDays}
+            onChange={handleInputChange}
+            disabled={retentionChange.isPending || retentionSetting.isLoading}
+            inputProps={{ min: 7, max: 365 }}
+            error={!!error}
+            helperText={error}
+            sx={{ width: "120px" }}
+            label="Days"
+          />
+          <Button
+            variant="contained"
+            color="primary"
+            size="small"
+            disabled={retentionChange.isPending || retentionSetting.isLoading || !!error}
+            onClick={handleRetentionChange}
+            sx={{ mt: 0.5 }}
+          >
+            Save
+          </Button>
+        </Box>
+      }
     >
       <Typography variant="body2">
         Configure how long to keep CIPP log entries. Logs will be automatically deleted after this


### PR DESCRIPTION
Fixes a bug where typing in the Days number field on the Backup Retention
and Log Retention settings cards immediately lost focus after each keystroke.

aka this annoyance
![2026-03-09_22-24-18_CIPP_og_11_flere_sider_-_Arbejde_-_Microsoft​_Edge](https://github.com/user-attachments/assets/03362392-f6a5-4a36-be9a-0715058d207b)
