### PR TITLE
feat: Add "Show Usage" toggle to Tenant Groups page

### DIFF
--- a/src/pages/tenant/administration/tenants/groups/index.js
+++ b/src/pages/tenant/administration/tenants/groups/index.js
@@ -2,7 +2,7 @@ import { Layout as DashboardLayout } from "../../../../../layouts/index.js";
 import { TabbedLayout } from "../../../../../layouts/TabbedLayout";
 import { CippTablePage } from "../../../../../components/CippComponents/CippTablePage.jsx";
 import tabOptions from "../tabOptions";
-import { Edit, PlayArrow, GroupAdd } from "@mui/icons-material";
+import { Edit, PlayArrow, GroupAdd, ViewList } from "@mui/icons-material";
 import { TrashIcon } from "@heroicons/react/24/outline";
 import { CippAddTenantGroupDrawer } from "../../../../../components/CippComponents/CippAddTenantGroupDrawer";
 import { CippApiLogsDrawer } from "../../../../../components/CippComponents/CippApiLogsDrawer";
@@ -10,12 +10,16 @@ import { CippTenantGroupOffCanvas } from "../../../../../components/CippComponen
 import { CippApiDialog } from "../../../../../components/CippComponents/CippApiDialog.jsx";
 import { Box, Button } from "@mui/material";
 import { useDialog } from "../../../../../hooks/use-dialog.js";
+import { useState } from "react"
 
 const Page = () => {
   const pageTitle = "Tenant Groups";
   const createDefaultGroupsDialog = useDialog();
+  const [showUsage, setShowUsage] = useState(false);
 
-  const simpleColumns = ["Name", "Description", "GroupType", "Members"];
+  const simpleColumns = showUsage
+    ? ["Name", "Description", "GroupType", "Members", "Usage"]
+    : ["Name", "Description", "GroupType", "Members"];
 
   const offcanvas = {
     children: (row) => {
@@ -57,12 +61,16 @@ const Page = () => {
         tenantInTitle={false}
         simpleColumns={simpleColumns}
         apiUrl="/api/ListTenantGroups"
-        queryKey="TenantGroupListPage"
+        apiData={{ includeUsage: showUsage }}
+        queryKey={showUsage ? "TenantGroupListPage-usage" : "TenantGroupListPage"}
         apiDataKey="Results"
         actions={actions}
         cardButton={
           <Box sx={{ display: "flex", gap: 1 }}>
             <CippAddTenantGroupDrawer />
+            <Button onClick={() => setShowUsage(!showUsage)} startIcon={<ViewList />}>
+              {showUsage ? "Hide Usage" : "Show Usage"}
+            </Button>
             <Button onClick={createDefaultGroupsDialog.handleOpen} startIcon={<GroupAdd />}>
               Create Default Groups
             </Button>


### PR DESCRIPTION
- Related to KelvinTegelaar/CIPP#5434
- Depends on KelvinTegelaar/CIPP-API#1912
- Add "Show Usage" toggle button to the Tenant Groups page that reveals a Usage column

<img width="2170" height="427" alt="image" src="https://github.com/user-attachments/assets/88a086a4-ded9-47d4-9a80-aec1745e3374" />
