### PR TITLE
fix: User Management filters for Business Phone and Assigned Licenses

### DIFF
--- a/src/utils/get-cipp-filter-variant.js
+++ b/src/utils/get-cipp-filter-variant.js
@@ -50,6 +50,12 @@ export const getCippFilterVariant = (providedColumnKeys, arg) => {
         }));
       }
 
+      // Add "No Licenses Assigned" option at beginning
+      filterSelectOptions.unshift({
+        label: "No Licenses Assigned",
+        value: "__no_license__",
+      });
+
       return {
         filterVariant: "multi-select",
         sortingFn: "alphanumeric",
@@ -58,11 +64,28 @@ export const getCippFilterVariant = (providedColumnKeys, arg) => {
           if (!filterValue || !Array.isArray(filterValue) || filterValue.length === 0) {
             return true;
           }
-          if (!userLicenses || !Array.isArray(userLicenses) || userLicenses.length === 0) {
+
+          const hasNoLicenseFilter = filterValue.includes("__no_license__");
+          const otherFilters = filterValue.filter((v) => v !== "__no_license__");
+          const isUnlicensed = !userLicenses || !Array.isArray(userLicenses) || userLicenses.length === 0;
+
+          // If user selected "No Licenses Assigned" and this user is unlicensed → match
+          if (hasNoLicenseFilter && isUnlicensed) {
+            return true;
+          }
+
+          // If only "No Licenses Assigned" is selected and user has licenses → no match
+          if (hasNoLicenseFilter && otherFilters.length === 0 && !isUnlicensed) {
             return false;
           }
+
+          // Check other license filters
+          if (isUnlicensed) {
+            return false;
+          }
+
           const userSkuIds = userLicenses.map((license) => license.skuId).filter(Boolean);
-          return filterValue.some((selectedSkuId) => userSkuIds.includes(selectedSkuId));
+          return otherFilters.some((selectedSkuId) => userSkuIds.includes(selectedSkuId));
         },
         filterSelectOptions: filterSelectOptions,
       };

--- a/src/utils/get-cipp-formatting.js
+++ b/src/utils/get-cipp-formatting.js
@@ -643,6 +643,23 @@ export const getCippFormatting = (data, cellName, type, canReceive, flatten = tr
     );
   }
 
+  // Handle businessPhones
+  if (cellName === "businessPhones") {
+    if (!Array.isArray(data)) {
+      data = [data];
+    }
+
+    if (data.length === 0) {
+      return isText ? (
+        "No data"
+      ) : (
+        <Chip variant="outlined" label="No data" size="small" color="info" />
+      );
+    }
+
+    return isText ? data.join(", ") : renderChipList(data);
+  }
+
   //handle assignedUsers
   if (cellName === "AssignedUsers" || cellName === "assignedUsers") {
     //show the display name in text. otherwise, just return the obj.


### PR DESCRIPTION
- Resolves KelvinTegelaar/CIPP#5634
- `Business Phone`: Empty arrays now return `"No data"
- `Assigned Licenses`: Added `No Licenses Assigned` option to the multi-select filter