### PR TITLE
chore: Remove 'recipientType' from table

### DIFF
--- a/src/pages/email/administration/mailboxes/index.js
+++ b/src/pages/email/administration/mailboxes/index.js
@@ -61,7 +61,6 @@ const Page = () => {
         "recipientTypeDetails", // Recipient Type Details
         "UPN", // User Principal Name
         "primarySmtpAddress", // Primary Email Address
-        "recipientType", // Recipient Type
         "AdditionalEmailAddresses", // Additional Email Addresses
         "CacheTimestamp", // Cache Timestamp
       ]
@@ -70,7 +69,6 @@ const Page = () => {
         "recipientTypeDetails", // Recipient Type Details
         "UPN", // User Principal Name
         "primarySmtpAddress", // Primary Email Address
-        "recipientType", // Recipient Type
         "AdditionalEmailAddresses", // Additional Email Addresses
         "CacheTimestamp", // Cache Timestamp
       ];


### PR DESCRIPTION
Removed 'recipientType' from the email display fields. 'recipientTypeDetails' is still there and should be used instead.