### PR TITLE
feat: Add date range filter for incidents list

### DIFF
--- a/src/pages/security/incidents/list-incidents/index.js
+++ b/src/pages/security/incidents/list-incidents/index.js
@@ -1,9 +1,133 @@
+import { useState } from "react";
 import { Layout as DashboardLayout } from "../../../../layouts/index.js";
 import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
 import { PersonAdd, PlayArrow, Assignment, Done } from "@mui/icons-material";
+import {
+  Button,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Typography,
+  SvgIcon,
+  Stack,
+  Box,
+} from "@mui/material";
+import { Grid } from "@mui/system";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { useForm } from "react-hook-form";
+import CippFormComponent from "../../../../components/CippComponents/CippFormComponent";
+import { FunnelIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { useSettings } from "../../../../hooks/use-settings";
+
+const defaultStartDate = (() => {
+  const d = new Date();
+  d.setDate(d.getDate() - 30);
+  d.setHours(0, 0, 0, 0);
+  return Math.floor(d.getTime() / 1000);
+})();
 
 const Page = () => {
   const pageTitle = "Incidents List";
+  const userSettingsDefaults = useSettings();
+
+  const formControl = useForm({ defaultValues: { startDate: defaultStartDate, endDate: null } });
+  const [expanded, setExpanded] = useState(false);
+  const [filterEnabled, setFilterEnabled] = useState(true);
+  const [startDate, setStartDate] = useState(
+    new Date(defaultStartDate * 1000).toISOString().split("T")[0].replace(/-/g, ""),
+  );
+  const [endDate, setEndDate] = useState(null);
+
+  const onSubmit = (data) => {
+    setStartDate(
+      data.startDate
+        ? new Date(data.startDate * 1000).toISOString().split("T")[0].replace(/-/g, "")
+        : null,
+    );
+    setEndDate(
+      data.endDate
+        ? new Date(data.endDate * 1000).toISOString().split("T")[0].replace(/-/g, "")
+        : null,
+    );
+    setFilterEnabled(data.startDate !== null || data.endDate !== null);
+    setExpanded(false);
+  };
+
+  const clearFilters = () => {
+    formControl.reset({ startDate: null, endDate: null });
+    setFilterEnabled(false);
+    setStartDate(null);
+    setEndDate(null);
+    setExpanded(false);
+  };
+
+  const fmt = (yyyymmdd) =>
+    yyyymmdd
+      ? new Date(
+          yyyymmdd.replace(/(\d{4})(\d{2})(\d{2})/, "$1-$2-$3") + "T00:00:00",
+        ).toLocaleDateString()
+      : null;
+
+  const tableFilter = (
+    <Accordion expanded={expanded} onChange={(_, v) => setExpanded(v)}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <SvgIcon fontSize="small">
+            <FunnelIcon />
+          </SvgIcon>
+          <Typography variant="body2">
+            {filterEnabled && (startDate || endDate)
+              ? startDate && endDate
+                ? `Date Filter: ${fmt(startDate)} — ${fmt(endDate)}`
+                : startDate
+                  ? `Date Filter: From ${fmt(startDate)}`
+                  : `Date Filter: Up to ${fmt(endDate)}`
+              : "Date Filter"}
+          </Typography>
+        </Box>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Grid container spacing={2} alignItems="flex-end">
+          <Grid size={{ xs: 12, md: 4 }}>
+            <CippFormComponent
+              type="datePicker"
+              name="startDate"
+              label="Start Date"
+              dateTimeType="date"
+              formControl={formControl}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <CippFormComponent
+              type="datePicker"
+              name="endDate"
+              label="End Date"
+              dateTimeType="date"
+              formControl={formControl}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, md: 4 }}>
+            <Stack direction="row" spacing={1}>
+              <Button variant="contained" onClick={formControl.handleSubmit(onSubmit)}>
+                Apply
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={
+                  <SvgIcon fontSize="small">
+                    <XMarkIcon />
+                  </SvgIcon>
+                }
+                onClick={clearFilters}
+              >
+                Clear
+              </Button>
+            </Stack>
+          </Grid>
+        </Grid>
+      </AccordionDetails>
+    </Accordion>
+  );
 
   // Define actions for incidents
   const actions = [
@@ -95,6 +219,9 @@ const Page = () => {
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={simpleColumns}
+      tableFilter={tableFilter}
+      queryKey={`ExecIncidentsList-${userSettingsDefaults.currentTenant}-${startDate}-${endDate}`}
+      apiData={{ StartDate: startDate, EndDate: endDate }}
     />
   );
 };

--- a/src/utils/get-cipp-formatting.js
+++ b/src/utils/get-cipp-formatting.js
@@ -110,12 +110,15 @@ export const getCippFormatting = (data, cellName, type, canReceive, flatten = tr
       const label = data.label ?? data;
       const severityColor = {
         info: "info",
+        informational: "info",
         warn: "warning",
         warning: "warning",
         error: "error",
         critical: "error",
         alert: "warning",
         debug: "default",
+        medium: "warning",
+        high: "error",
       };
       const color = severityColor[String(label).toLowerCase()] ?? "info";
       return <Chip variant="outlined" label={label} size="small" color={color} />;
@@ -430,7 +433,12 @@ export const getCippFormatting = (data, cellName, type, canReceive, flatten = tr
     );
   }
 
-  if (cellName === "ClientId" || cellName === "role" || cellName === "appId" || cellName === "SID") {
+  if (
+    cellName === "ClientId" ||
+    cellName === "role" ||
+    cellName === "appId" ||
+    cellName === "SID"
+  ) {
     return isText ? data : <CippCopyToClipBoard text={data} type="chip" />;
   }
 
@@ -906,6 +914,18 @@ export const getCippFormatting = (data, cellName, type, canReceive, flatten = tr
       case "warning":
       case "skipped":
         color = "warning";
+        break;
+      case "active":
+        color = "warning";
+        break;
+      case "inprogress":
+        color = "warning";
+        break;
+      case "resolved":
+        color = "success";
+        break;
+      case "redirected":
+        color = "success";
         break;
       default:
         color = "default";


### PR DESCRIPTION
Implement date range filtering on the incidents list page, allowing users to select start and end dates with apply and clear options. Update the table to display results based on the selected date range.

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1927