### PR TITLE
Fix: fix SpeedDial close behavior on X click when hovering

### DIFF
--- a/src/components/CippComponents/CippSpeedDial.jsx
+++ b/src/components/CippComponents/CippSpeedDial.jsx
@@ -39,7 +39,12 @@ const CippSpeedDial = ({
     return acc;
   }, {});
 
-  const handleSpeedDialClose = () => {
+  const handleSpeedDialClose = (event, reason) => {
+    if (reason === "toggle") {
+      setSpeedDialOpen(false);
+      setIsHovering(false);
+      return;
+    }
     if (!isHovering) {
       setTimeout(() => {
         setSpeedDialOpen(false);


### PR DESCRIPTION
Ensure the SpeedDial closes correctly when the close button is clicked while hovering.