### PR TITLE
feat: add "Create Template from User" action

### DIFF
--- a/src/components/CippComponents/CippUserActions.jsx
+++ b/src/components/CippComponents/CippUserActions.jsx
@@ -4,6 +4,7 @@ import {
   Archive,
   Clear,
   CloudDone,
+  ContentCopy,
   Edit,
   Email,
   ForwardToInbox,
@@ -285,6 +286,55 @@ export const useCippUserActions = () => {
       icon: <Edit />,
       color: "success",
       target: "_self",
+      condition: () => canWriteUser,
+    },
+    {
+      label: "Create Template from User",
+      type: "POST",
+      icon: <ContentCopy />,
+      url: "/api/AddUserDefaults",
+      fields: [
+        {
+          type: "textField",
+          name: "templateName",
+          label: "Template Name",
+          validators: { required: "Please enter a template name" },
+        },
+        {
+          type: "switch",
+          name: "defaultForTenant",
+          label: "Default for Tenant",
+        },
+      ],
+      customDataformatter: (row, action, formData) => {
+        const user = Array.isArray(row) ? row[0] : row;
+        const licenses =
+          user.assignedLicenses?.map((l) => ({
+            label: getCippLicenseTranslation([l])?.[0] || l.skuId,
+            value: l.skuId,
+          })) || [];
+        return {
+          tenantFilter: tenant,
+          templateName: formData.templateName,
+          defaultForTenant: formData.defaultForTenant || false,
+          sourceUserId: user.id,
+          jobTitle: user.jobTitle || "",
+          department: user.department || "",
+          streetAddress: user.streetAddress || "",
+          city: user.city || "",
+          state: user.state || "",
+          postalCode: user.postalCode || "",
+          country: user.country || "",
+          companyName: user.companyName || "",
+          mobilePhone: user.mobilePhone || "",
+          "businessPhones[0]": user.businessPhones?.[0] || "",
+          usageLocation: user.usageLocation || "",
+          licenses: licenses,
+        };
+      },
+      confirmText:
+        "Create a new user default template based on [displayName]'s properties (job title, department, location, licenses, and group memberships).",
+      multiPost: false,
       condition: () => canWriteUser,
     },
     {

--- a/src/components/CippFormPages/CippAddEditUser.jsx
+++ b/src/components/CippFormPages/CippAddEditUser.jsx
@@ -249,6 +249,11 @@ const CippAddEditUser = (props) => {
       if (template.licenses && Array.isArray(template.licenses)) {
         setFieldIfEmpty("licenses", template.licenses);
       }
+
+      // Pass stored group memberships from template to user creation
+      if (template.groupMemberships && Array.isArray(template.groupMemberships) && template.groupMemberships.length > 0) {
+        formControl.setValue("groupMemberships", template.groupMemberships);
+      }
     }
   }, [watcher.userTemplate, formType]);
 


### PR DESCRIPTION
- Implements KelvinTegelaar/CIPP#5595
- Depends on KelvinTegelaar/CIPP-API#1941
- Copies user properties (job title, department, location, etc.), assigned licenses, and group memberships into a new user default template