### PR TITLE
fix: Remove 'scope' from Scheduler and add tenant name

### DIFF
--- a/src/layouts/config.js
+++ b/src/layouts/config.js
@@ -903,7 +903,6 @@ export const nativeMenuItems = [
         path: "/cipp/scheduler",
         roles: ["editor", "admin", "superadmin"],
         permissions: ["CIPP.Scheduler.*"],
-        scope: "global",
       },
     ],
   },

--- a/src/pages/cipp/scheduler/index.js
+++ b/src/pages/cipp/scheduler/index.js
@@ -66,7 +66,6 @@ const Page = () => {
             <CippSchedulerDrawer buttonText="Add Task" />
           </>
         }
-        tenantInTitle={false}
         title="Scheduled Tasks"
         apiUrl={
           showHiddenJobs ? `/api/ListScheduledItems?ShowHidden=true` : `/api/ListScheduledItems`


### PR DESCRIPTION
Removed 'scope' property from the Scheduler configuration.