### PR TITLE
Fix: fix alert overflow in narrow drawers

### DIFF
--- a/src/components/CippComponents/CippApiResults.jsx
+++ b/src/components/CippComponents/CippApiResults.jsx
@@ -244,7 +244,7 @@ export const CippApiResults = (props) => {
 
   const hasVisibleResults = finalResults.some((r) => r.visible);
   return (
-    <Stack spacing={2}>
+    <Stack spacing={2} sx={{ minWidth: 0 }}>
       {/* Loading alert */}
       {!errorsOnly && (
         <Collapse in={fetchingVisible} unmountOnExit>


### PR DESCRIPTION
Prevent the alert from exceeding the drawer width on narrow screens by adding `minWidth: 0` to the Stack component. This change ensures that action buttons do not force the Alert wider than the drawer in mobile views.