### PR TITLE
fix: group-templates: allow resubmit on template edit page

### DIFF
--- a/src/pages/identity/administration/group-templates/edit.jsx
+++ b/src/pages/identity/administration/group-templates/edit.jsx
@@ -46,6 +46,7 @@ const Page = () => {
           allowExternal: templateData.allowExternal,
           tenantFilter: userSettingsDefaults.currentTenant,
         });
+        formControl.trigger();
       }
     }
   }, [template, formControl, userSettingsDefaults.currentTenant]);


### PR DESCRIPTION
- Allow resubmit on group template edit page to prevent submit button from being permanently disabled after form data loads