### PR TITLE
Feat: Integrate Universal Search dialog in TopNav

### DIFF
--- a/src/components/CippCards/CippUniversalSearchV2.jsx
+++ b/src/components/CippCards/CippUniversalSearchV2.jsx
@@ -20,7 +20,7 @@ import { CippOffCanvas } from "../CippComponents/CippOffCanvas";
 import { CippBitlockerKeySearch } from "../CippComponents/CippBitlockerKeySearch";
 
 export const CippUniversalSearchV2 = React.forwardRef(
-  ({ onConfirm = () => {}, onChange = () => {}, maxResults = 10, value = "" }, ref) => {
+  ({ onConfirm = () => {}, onChange = () => {}, maxResults = 10, value = "", autoFocus = false }, ref) => {
     const [searchValue, setSearchValue] = useState(value);
     const [searchType, setSearchType] = useState("Users");
     const [bitlockerLookupType, setBitlockerLookupType] = useState("keyId");
@@ -104,7 +104,9 @@ export const CippUniversalSearchV2 = React.forwardRef(
           `/identity/administration/groups/group?groupId=${itemData.id}&tenantFilter=${tenantDomain}`,
         );
       }
+      setSearchValue("");
       setShowDropdown(false);
+      onConfirm(match);
     };
 
     const handleTypeChange = (type) => {
@@ -124,7 +126,9 @@ export const CippUniversalSearchV2 = React.forwardRef(
         searchType: bitlockerLookupType,
       });
       setBitlockerDrawerVisible(true);
+      setSearchValue("");
       setShowDropdown(false);
+      onConfirm(match);
     };
 
     const typeMenuActions = [
@@ -216,7 +220,7 @@ export const CippUniversalSearchV2 = React.forwardRef(
 
     return (
       <>
-        <Box ref={containerRef} sx={{ width: "100%", display: "flex", gap: 1 }}>
+        <Box ref={containerRef} sx={{ width: "100%", display: "flex", gap: 1, alignItems: "flex-start" }}>
           <BulkActionsMenu
             buttonName={searchType}
             actions={typeMenuActions}
@@ -238,7 +242,8 @@ export const CippUniversalSearchV2 = React.forwardRef(
             }}
             fullWidth
             type="text"
-            label={getLabel()}
+            placeholder={getLabel()}
+            autoFocus={autoFocus}
             onKeyDown={handleKeyDown}
             onChange={handleChange}
             value={searchValue}

--- a/src/layouts/top-nav.js
+++ b/src/layouts/top-nav.js
@@ -16,7 +16,11 @@ import LockIcon from "@mui/icons-material/Lock";
 import LockOpenIcon from "@mui/icons-material/LockOpen";
 import {
   Box,
+  Button,
   Divider,
+  Dialog,
+  DialogContent,
+  DialogTitle,
   IconButton,
   Stack,
   SvgIcon,
@@ -37,11 +41,13 @@ import { NotificationsPopover } from "./notifications-popover";
 import { useDialog } from "../hooks/use-dialog";
 import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { CippCentralSearch } from "../components/CippComponents/CippCentralSearch";
+import { CippUniversalSearchV2 } from "../components/CippCards/CippUniversalSearchV2";
 
 const TOP_NAV_HEIGHT = 64;
 
 export const TopNav = (props) => {
   const searchDialog = useDialog();
+  const universalSearchDialog = useDialog();
   const { onNavOpen } = props;
   const settings = useSettings();
   const { bookmarks, setBookmarks } = useUserBookmarks();
@@ -64,6 +70,7 @@ export const TopNav = (props) => {
   const [animatingPair, setAnimatingPair] = useState(null);
   const [flashSort, setFlashSort] = useState(false);
   const [flashLock, setFlashLock] = useState(false);
+  const [universalSearchKey, setUniversalSearchKey] = useState(0);
   const itemRefs = useRef({});
   const touchDragRef = useRef({ startIdx: null, overIdx: null });
   const tenantSelectorRef = useRef(null);
@@ -198,11 +205,23 @@ export const TopNav = (props) => {
     searchDialog.handleOpen();
   }, [searchDialog.handleOpen]);
 
+  const openUniversalSearch = useCallback(() => {
+    universalSearchDialog.handleOpen();
+  }, [universalSearchDialog.handleOpen]);
+
+  const closeUniversalSearch = useCallback(() => {
+    universalSearchDialog.handleClose();
+    setUniversalSearchKey((prev) => prev + 1);
+  }, [universalSearchDialog.handleClose]);
+
   useEffect(() => {
     const handleKeyDown = (event) => {
       if ((event.metaKey || event.ctrlKey) && event.altKey && event.key === "k") {
         event.preventDefault();
         tenantSelectorRef.current?.focus();
+      } else if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key === "K") {
+        event.preventDefault();
+        openUniversalSearch();
       } else if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         openSearch();
@@ -212,7 +231,7 @@ export const TopNav = (props) => {
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [openSearch]);
+  }, [openSearch, openUniversalSearch]);
 
   return (
     <Box
@@ -228,6 +247,7 @@ export const TopNav = (props) => {
       <Stack
         direction="row"
         justifyContent="space-between"
+        alignItems="center"
         sx={{
           minHeight: TOP_NAV_HEIGHT,
           px: 3,
@@ -269,6 +289,34 @@ export const TopNav = (props) => {
             </IconButton>
           )}
         </Stack>
+        {!mdDown && (
+          <Box sx={{ flex: 1, mx: 2, display: "flex", justifyContent: "center" }}>
+            <Button
+              variant="outlined"
+              color="inherit"
+              onClick={universalSearchDialog.handleOpen}
+              title="Open CIPP Search (Ctrl/Cmd+Shift+K)"
+              startIcon={
+                <SvgIcon color="inherit" fontSize="small">
+                  <MagnifyingGlassIcon />
+                </SvgIcon>
+              }
+              sx={{
+                textTransform: "none",
+                whiteSpace: "nowrap",
+                borderColor: "neutral.500",
+                borderRadius: 999,
+                px: 2,
+                "&:hover": {
+                  borderColor: "neutral.300",
+                  backgroundColor: "rgba(255, 255, 255, 0.08)",
+                },
+              }}
+            >
+              Universal Search
+            </Button>
+          </Box>
+        )}
         <Stack alignItems="center" direction="row" spacing={1.5}>
           {!mdDown && (
             <IconButton color="inherit" onClick={handleThemeSwitch}>
@@ -570,6 +618,32 @@ export const TopNav = (props) => {
               </Popover>
             </>
           )}
+          <Dialog
+            open={universalSearchDialog.open}
+            onClose={closeUniversalSearch}
+            fullWidth
+            maxWidth="md"
+            sx={{
+              "& .MuiDialog-container": {
+                alignItems: "flex-start",
+              },
+              "& .MuiDialog-paper": {
+                mt: 8,
+              },
+            }}
+          >
+            <DialogTitle sx={{ px: 3, pt: 2, pb: 1 }}>Universal Search</DialogTitle>
+            <DialogContent sx={{ px: 3, pt: 1, pb: 3 }}>
+              <Box>
+                <CippUniversalSearchV2
+                  key={universalSearchKey}
+                  maxResults={12}
+                  autoFocus={true}
+                  onConfirm={closeUniversalSearch}
+                />
+              </Box>
+            </DialogContent>
+          </Dialog>
           <CippCentralSearch open={searchDialog.open} handleClose={searchDialog.handleClose} />
           <NotificationsPopover />
           <AccountPopover

--- a/src/layouts/top-nav.js
+++ b/src/layouts/top-nav.js
@@ -5,6 +5,7 @@ import Bars3Icon from "@heroicons/react/24/outline/Bars3Icon";
 import MoonIcon from "@heroicons/react/24/outline/MoonIcon";
 import SunIcon from "@heroicons/react/24/outline/SunIcon";
 import BookmarkIcon from "@mui/icons-material/Bookmark";
+import TravelExploreIcon from "@mui/icons-material/TravelExplore";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
@@ -16,7 +17,6 @@ import LockIcon from "@mui/icons-material/Lock";
 import LockOpenIcon from "@mui/icons-material/LockOpen";
 import {
   Box,
-  Button,
   Divider,
   Dialog,
   DialogContent,
@@ -30,6 +30,7 @@ import {
   ListItem,
   ListItemText,
   Typography,
+  TravelExplore,
 } from "@mui/material";
 import { Logo } from "../components/logo";
 import { useSettings } from "../hooks/use-settings";
@@ -289,35 +290,16 @@ export const TopNav = (props) => {
             </IconButton>
           )}
         </Stack>
-        {!mdDown && (
-          <Box sx={{ flex: 1, mx: 2, display: "flex", justifyContent: "center" }}>
-            <Button
-              variant="outlined"
-              color="inherit"
-              onClick={universalSearchDialog.handleOpen}
-              title="Open CIPP Search (Ctrl/Cmd+Shift+K)"
-              startIcon={
-                <SvgIcon color="inherit" fontSize="small">
-                  <MagnifyingGlassIcon />
-                </SvgIcon>
-              }
-              sx={{
-                textTransform: "none",
-                whiteSpace: "nowrap",
-                borderColor: "neutral.500",
-                borderRadius: 999,
-                px: 2,
-                "&:hover": {
-                  borderColor: "neutral.300",
-                  backgroundColor: "rgba(255, 255, 255, 0.08)",
-                },
-              }}
-            >
-              Universal Search
-            </Button>
-          </Box>
-        )}
         <Stack alignItems="center" direction="row" spacing={1.5}>
+          {!mdDown && (
+            <IconButton
+              color="inherit"
+              onClick={openUniversalSearch}
+              title="Open Universal Search (Ctrl/Cmd+Shift+K)"
+            >
+              <TravelExploreIcon color="action" fontSize="small" />
+            </IconButton>
+          )}
           {!mdDown && (
             <IconButton color="inherit" onClick={handleThemeSwitch}>
               <SvgIcon color="action" fontSize="small">

--- a/src/pages/dashboardv2/index.js
+++ b/src/pages/dashboardv2/index.js
@@ -8,7 +8,6 @@ import { ApiGetCall } from "../../api/ApiCall.jsx";
 import Portals from "../../data/portals";
 import { BulkActionsMenu } from "../../components/bulk-actions-menu.js";
 import { ExecutiveReportButton } from "../../components/ExecutiveReportButton.js";
-import { CippUniversalSearchV2 } from "../../components/CippCards/CippUniversalSearchV2.jsx";
 import { TabbedLayout } from "../../layouts/TabbedLayout";
 import { Layout as DashboardLayout } from "../../layouts/index.js";
 import tabOptions from "./tabOptions";
@@ -208,13 +207,6 @@ const Page = () => {
   return (
     <Container maxWidth={false} sx={{ mt: 12, mb: 6 }}>
       <Box sx={{ width: "100%", mx: "auto" }}>
-        {/* Universal Search */}
-        <Card sx={{ mb: 3 }}>
-          <CardContent sx={{ px: 2, py: 1.5, "&:last-child": { pb: 1.5 } }}>
-            <CippUniversalSearchV2 />
-          </CardContent>
-        </Card>
-
         <Grid container spacing={3} sx={{ mb: 4 }}>
           <Grid size={{ xs: 12, md: 5 }}>
             <Card sx={{ height: "100%" }}>


### PR DESCRIPTION
Add a Universal Search dialog to the top navigation and wire up CippUniversalSearchV2. This change introduces a button and Ctrl/Cmd+Shift+K keyboard shortcut to open the dialog, passes autoFocus to the search component, and resets the component via a key increment on close. CippUniversalSearchV2 was updated to support autoFocus, use placeholder instead of label, clear its input and call onConfirm when items are selected, and adjust internal layout alignment. The standalone Universal Search card was removed from the dashboard page.
Fixes: https://github.com/KelvinTegelaar/CIPP/issues/5716