### PR TITLE
Add username space handling and replacement

### DIFF
--- a/src/components/CippFormPages/CippAddEditUser.jsx
+++ b/src/components/CippFormPages/CippAddEditUser.jsx
@@ -86,7 +86,13 @@ const CippAddEditUser = (props) => {
   const watcher = useWatch({ control: formControl.control });
 
   // Helper function to generate username from template format
-  const generateUsername = (format, firstName, lastName) => {
+  const generateUsername = (
+    format,
+    firstName,
+    lastName,
+    spaceHandling = "keep",
+    spaceReplacement = "",
+  ) => {
     if (!format || !firstName || !lastName) return "";
 
     // Ensure format is a string
@@ -107,6 +113,13 @@ const CippAddEditUser = (props) => {
     // Replace %FirstName% and %LastName%
     username = username.replace(/%FirstName%/gi, firstName);
     username = username.replace(/%LastName%/gi, lastName);
+
+    // Apply optional space handling
+    if (spaceHandling === "remove") {
+      username = username.replace(/\s+/g, "");
+    } else if (spaceHandling === "replace") {
+      username = username.replace(/\s+/g, spaceReplacement || "");
+    }
 
     // Convert to lowercase
     return username.toLowerCase();
@@ -152,10 +165,26 @@ const CippAddEditUser = (props) => {
             : selectedTemplate.usernameFormat?.value || selectedTemplate.usernameFormat?.label;
 
         if (formatString) {
+          const spaceHandling =
+            typeof selectedTemplate.usernameSpaceHandling === "string"
+              ? selectedTemplate.usernameSpaceHandling
+              : selectedTemplate.usernameSpaceHandling?.value ||
+                selectedTemplate.usernameSpaceHandling?.label ||
+                "keep";
+
+          const spaceReplacement =
+            typeof selectedTemplate.usernameSpaceReplacement === "string"
+              ? selectedTemplate.usernameSpaceReplacement
+              : selectedTemplate.usernameSpaceReplacement?.value ||
+                selectedTemplate.usernameSpaceReplacement?.label ||
+                "";
+
           const generatedUsername = generateUsername(
             formatString,
             watcher.givenName,
             watcher.surname,
+            spaceHandling,
+            spaceReplacement,
           );
           if (generatedUsername) {
             formControl.setValue("username", generatedUsername, { shouldDirty: true });

--- a/src/pages/tenant/manage/user-defaults.js
+++ b/src/pages/tenant/manage/user-defaults.js
@@ -57,6 +57,25 @@ const Page = () => {
       creatable: true,
     },
     {
+      label: "Username Space Handling",
+      name: "usernameSpaceHandling",
+      type: "autoComplete",
+      options: [
+        { label: "Keep spaces", value: "keep" },
+        { label: "Remove spaces", value: "remove" },
+        { label: "Replace spaces", value: "replace" },
+      ],
+      helperText: "How spaces in the generated username should be handled.",
+      multiple: false,
+      creatable: false,
+    },
+    {
+      label: "Username Space Replacement",
+      name: "usernameSpaceReplacement",
+      type: "textField",
+      helperText: "Used when space handling is set to Replace spaces (example: _ or .).",
+    },
+    {
       label: "Primary Domain",
       name: "primDomain",
       type: "autoComplete",
@@ -184,6 +203,8 @@ const Page = () => {
       "defaultForTenant",
       "displayName",
       "usernameFormat",
+      "usernameSpaceHandling",
+      "usernameSpaceReplacement",
       "primDomain",
       "usageLocation",
       "licenses",
@@ -222,6 +243,7 @@ const Page = () => {
           "defaultForTenant",
           "displayName",
           "usernameFormat",
+          "usernameSpaceHandling",
           "usageLocation",
           "department",
         ]}


### PR DESCRIPTION
Allow username templates to control how spaces are handled when generating usernames. CippAddEditUser.generateUsername now accepts spaceHandling (keep|remove|replace) and spaceReplacement parameters and applies them before lowercasing. The user defaults page adds two new fields: usernameSpaceHandling (autoComplete with Keep/Remove/Replace) and usernameSpaceReplacement (textField), and includes these keys in the saved/default field lists. This enables admins to configure whether generated usernames keep, remove, or replace spaces (with a custom character).
API: https://github.com/KelvinTegelaar/CIPP-API/pull/1959
Fixes: https://github.com/KelvinTegelaar/CIPP/issues/5718