### PR TITLE
Fix API endpoint for adding standards template in CippPolicyImportDrawer

### DIFF
--- a/src/components/CippComponents/CippPolicyImportDrawer.jsx
+++ b/src/components/CippComponents/CippPolicyImportDrawer.jsx
@@ -130,7 +130,7 @@ export const CippPolicyImportDrawer = ({
         } else if (mode === "Standards") {
           // For Standards templates, clone the template
           importPolicy.mutate({
-            url: "/api/AddStandardTemplate",
+            url: "/api/AddStandardsTemplate",
             data: {
               tenantFilter: tenantFilter?.value,
               templateId: policy.GUID,


### PR DESCRIPTION
File erroneously calls AddStandardTemplate when the correct API endpoint is AddStandardsTemplate