### PR TITLE
Feat: Add SmtpAuthSuccess input and validators

### DIFF
--- a/src/data/alerts.json
+++ b/src/data/alerts.json
@@ -26,6 +26,20 @@
   {
     "name": "SmtpAuthSuccess",
     "label": "Alert on SMTP AUTH usage with success, helps to phase out SMTP AUTH (Entra P1 Required)",
+    "requiresInput": true,
+    "inputType": "number",
+    "inputLabel": "Days to look back (default: 7, max: 30)",
+    "inputName": "SmtpAuthSuccessDays",
+    "validators": {
+      "min": {
+        "value": 7,
+        "message": "Days must be at least 7"
+      },
+      "max": {
+        "value": 30,
+        "message": "Days cannot exceed 30"
+      }
+    },
     "recommendedRunInterval": "1d"
   },
   {

--- a/src/pages/tenant/administration/alert-configuration/alert.jsx
+++ b/src/pages/tenant/administration/alert-configuration/alert.jsx
@@ -968,6 +968,17 @@ const AlertWizard = () => {
                                     formControl={formControl}
                                     label={commandValue.value?.inputLabel}
                                     required={commandValue.value?.required || false}
+                                    validators={{
+                                      ...(commandValue.value?.validators || {}),
+                                      ...(commandValue.value?.required
+                                        ? {
+                                            required: {
+                                              value: true,
+                                              message: "This field is required",
+                                            },
+                                          }
+                                        : {}),
+                                    }}
                                     {...(commandValue.value?.inputType === "autoComplete"
                                       ? {
                                           options: commandValue.value?.options,
@@ -992,6 +1003,17 @@ const AlertWizard = () => {
                                         formControl={formControl}
                                         label={input.inputLabel}
                                         required={input.required || false}
+                                        validators={{
+                                          ...(input.validators || {}),
+                                          ...(input.required
+                                            ? {
+                                                required: {
+                                                  value: true,
+                                                  message: "This field is required",
+                                                },
+                                              }
+                                            : {}),
+                                        }}
                                         {...(input.inputType === "autoComplete"
                                           ? {
                                               options: input.options,


### PR DESCRIPTION
Add a numeric input configuration for the SmtpAuthSuccess alert in alerts.json (requiresInput, inputType number, inputLabel, inputName SmtpAuthSuccessDays) with min/max validators (min 7, max 30). Update AlertWizard to pass a validators prop to form controls and inputs by merging existing validators and automatically adding a required validator when the field is marked required, ensuring consistent validation messages for required and ranged fields.
API: https://github.com/KelvinTegelaar/CIPP-API/pull/1962