### PR TITLE
feat: Add allTenants support across various pages

### DIFF
--- a/src/components/CippComponents/CippTransportRuleDrawer.jsx
+++ b/src/components/CippComponents/CippTransportRuleDrawer.jsx
@@ -1,18 +1,18 @@
-import React, { useState, useEffect, useMemo, useCallback, cloneElement } from "react";
-import { Button, Divider, Typography, Alert, Box } from "@mui/material";
-import { Grid } from "@mui/system";
-import { useForm, useWatch } from "react-hook-form";
-import { RocketLaunch, Edit } from "@mui/icons-material";
-import { CippOffCanvas } from "./CippOffCanvas";
-import CippFormComponent from "./CippFormComponent";
-import { CippFormDomainSelector } from "./CippFormDomainSelector";
-import { CippApiResults } from "./CippApiResults";
-import { useSettings } from "../../hooks/use-settings";
-import { ApiGetCall, ApiPostCall } from "../../api/ApiCall";
-import { useQueryClient } from "@tanstack/react-query";
+import React, { useState, useEffect, useMemo, useCallback, cloneElement } from 'react'
+import { Button, Divider, Typography, Alert, Box } from '@mui/material'
+import { Grid } from '@mui/system'
+import { useForm, useWatch } from 'react-hook-form'
+import { RocketLaunch, Edit } from '@mui/icons-material'
+import { CippOffCanvas } from './CippOffCanvas'
+import CippFormComponent from './CippFormComponent'
+import { CippFormDomainSelector } from './CippFormDomainSelector'
+import { CippApiResults } from './CippApiResults'
+import { useSettings } from '../../hooks/use-settings'
+import { ApiGetCall, ApiPostCall } from '../../api/ApiCall'
+import { useQueryClient } from '@tanstack/react-query'
 
 export const CippTransportRuleDrawer = ({
-  buttonText = "New Transport Rule",
+  buttonText = 'New Transport Rule',
   isEditMode = false,
   ruleId = null,
   requiredPermissions = [],
@@ -22,214 +22,235 @@ export const CippTransportRuleDrawer = ({
   setDrawerVisible: controlledSetDrawerVisible,
   rowAction = false,
 }) => {
-  const currentTenant = useSettings().currentTenant;
-  const [internalDrawerVisible, internalSetDrawerVisible] = useState(false);
-  const drawerVisible = controlledDrawerVisible !== undefined ? controlledDrawerVisible : internalDrawerVisible;
-  const setDrawerVisible = controlledSetDrawerVisible !== undefined ? controlledSetDrawerVisible : internalSetDrawerVisible;
+  const currentTenant = useSettings().currentTenant
+  const [internalDrawerVisible, internalSetDrawerVisible] = useState(false)
+  const drawerVisible =
+    controlledDrawerVisible !== undefined ? controlledDrawerVisible : internalDrawerVisible
+  const setDrawerVisible =
+    controlledSetDrawerVisible !== undefined ? controlledSetDrawerVisible : internalSetDrawerVisible
 
   // Fetch existing rule data in edit mode
   const ruleInfo = ApiGetCall({
     url: `/api/ListTransportRules?tenantFilter=${currentTenant}&id=${ruleId}`,
     queryKey: `ListTransportRules-${ruleId}`,
     waiting: !!drawerVisible || !!isEditMode || !!ruleId,
-  });
+  })
 
   // Fetch all rules for priority suggestion in create mode (shares cache key with list page)
   const allRulesInfo = ApiGetCall({
     url: `/api/ListTransportRules?tenantFilter=${currentTenant}`,
     queryKey: `List Transport Rules For Priority - ${currentTenant}`,
     waiting: !!drawerVisible,
-  });
+  })
 
   // Default form values
   const defaultFormValues = useMemo(
     () => ({
       Enabled: true,
-      Mode: { value: "Enforce", label: "Enforce" },
+      Mode: { value: 'Enforce', label: 'Enforce' },
       StopRuleProcessing: false,
-      SenderAddressLocation: { value: "Header", label: "Header" },
+      SenderAddressLocation: { value: 'Header', label: 'Header' },
       applyToAllMessages: false,
       tenantFilter: currentTenant,
-      Name: "",
-      Priority: "",
-      Comments: "",
+      Name: '',
+      Priority: '',
+      Comments: '',
       conditionType: [],
       actionType: [],
       exceptionType: [],
     }),
     [currentTenant]
-  );
+  )
 
   const formControl = useForm({
-    mode: "onChange",
+    mode: 'onChange',
     defaultValues: defaultFormValues,
-  });
+  })
 
-  const [selectedConditions, setSelectedConditions] = useState([]);
-  const [selectedActions, setSelectedActions] = useState([]);
-  const [selectedExceptions, setSelectedExceptions] = useState([]);
+  const [selectedConditions, setSelectedConditions] = useState([])
+  const [selectedActions, setSelectedActions] = useState([])
+  const [selectedExceptions, setSelectedExceptions] = useState([])
 
-  const conditionTypeWatch = useWatch({ control: formControl.control, name: "conditionType" });
-  const actionTypeWatch = useWatch({ control: formControl.control, name: "actionType" });
-  const exceptionTypeWatch = useWatch({ control: formControl.control, name: "exceptionType" });
-  const applyToAllMessagesWatch = useWatch({ control: formControl.control, name: "applyToAllMessages" });
+  const conditionTypeWatch = useWatch({ control: formControl.control, name: 'conditionType' })
+  const actionTypeWatch = useWatch({ control: formControl.control, name: 'actionType' })
+  const exceptionTypeWatch = useWatch({ control: formControl.control, name: 'exceptionType' })
+  const applyToAllMessagesWatch = useWatch({
+    control: formControl.control,
+    name: 'applyToAllMessages',
+  })
 
   // API call for submit
   const submitRule = ApiPostCall({
     urlFromData: true,
-  });
+  })
 
   // Helper to convert ISO8601 date string to Unix timestamp (seconds)
   const iso8601ToUnixTimestamp = (dateString) => {
-    if (!dateString) return "";
-    const d = new Date(dateString);
-    if (isNaN(d.getTime())) return "";
-    return Math.floor(d.getTime() / 1000);
-  };
+    if (!dateString) return ''
+    const d = new Date(dateString)
+    if (isNaN(d.getTime())) return ''
+    return Math.floor(d.getTime() / 1000)
+  }
 
   // Helper to convert Enable/Disable into a usable bool for switches
   const boolHelper = (boolValue) => {
-    if (boolValue === "Enabled") return true;
-    return false;
-  };
+    if (boolValue === 'Enabled') return true
+    return false
+  }
 
   // Memoize processed rule data
   const processedRuleData = useMemo(() => {
     if (!ruleInfo.isSuccess || !ruleInfo.data || !isEditMode) {
-      return null;
+      return null
     }
 
-    const rule = ruleInfo.data?.Results 
-      ? (Array.isArray(ruleInfo.data.Results) ? ruleInfo.data.Results[0] : ruleInfo.data.Results)
-      : (Array.isArray(ruleInfo.data) ? ruleInfo.data[0] : ruleInfo.data);
+    const rule = ruleInfo.data?.Results
+      ? Array.isArray(ruleInfo.data.Results)
+        ? ruleInfo.data.Results[0]
+        : ruleInfo.data.Results
+      : Array.isArray(ruleInfo.data)
+        ? ruleInfo.data[0]
+        : ruleInfo.data
 
     if (!rule) {
-      return null;
+      return null
     }
 
     // Map of condition field names to their display labels
     const conditionFieldMap = {
-      From: "The sender is...",
-      FromScope: "The sender is located...",
-      FromMemberOf: "The sender is a member of...",
-      SentTo: "The recipient is...",
-      SentToScope: "The recipient is located...",
-      SentToMemberOf: "The recipient is a member of...",
-      SubjectContainsWords: "Subject contains words...",
-      SubjectMatchesPatterns: "Subject matches patterns...",
-      SubjectOrBodyContainsWords: "Subject or body contains words...",
-      SubjectOrBodyMatchesPatterns: "Subject or body matches patterns...",
-      FromAddressContainsWords: "Sender address contains words...",
-      FromAddressMatchesPatterns: "Sender address matches patterns...",
-      AttachmentContainsWords: "Attachment content contains words...",
-      AttachmentMatchesPatterns: "Attachment content matches patterns...",
-      AttachmentNameMatchesPatterns: "Attachment name matches patterns...",
-      AttachmentPropertyContainsWords: "Attachment properties contain words...",
-      AttachmentExtensionMatchesWords: "Attachment extension is...",
-      AttachmentHasExecutableContent: "Attachment has executable content",
-      AttachmentIsPasswordProtected: "Attachment is password protected",
-      AttachmentIsUnsupported: "Attachment type is unsupported",
-      AttachmentProcessingLimitExceeded: "Attachment processing limit exceeded",
-      AttachmentSizeOver: "Attachment size is greater than...",
-      MessageSizeOver: "Message size is greater than...",
-      SCLOver: "SCL is greater than or equal to...",
-      WithImportance: "Message importance is...",
-      MessageTypeMatches: "Message type is...",
-      SenderDomainIs: "Sender domain is...",
-      RecipientDomainIs: "Recipient domain is...",
-      SenderIpRanges: "Sender IP address belongs to any of these ranges...",
-      HeaderContainsWords: "Message header contains words...",
-      HeaderMatchesPatterns: "Message header matches patterns...",
-      AnyOfToHeader: "Any To header contains...",
-      AnyOfToHeaderMemberOf: "Any To header is a member of...",
-      AnyOfCcHeader: "Any Cc header contains...",
-      AnyOfCcHeaderMemberOf: "Any Cc header is a member of...",
-      AnyOfToCcHeader: "Any To or Cc header contains...",
-      AnyOfToCcHeaderMemberOf: "Any To or Cc header is a member of...",
-      RecipientAddressContainsWords: "Recipient address contains words...",
-      RecipientAddressMatchesPatterns: "Recipient address matches patterns...",
-      AnyOfRecipientAddressContainsWords: "Any recipient address contains words...",
-      AnyOfRecipientAddressMatchesPatterns: "Any recipient address matches patterns...",
-    };
+      From: 'The sender is...',
+      FromScope: 'The sender is located...',
+      FromMemberOf: 'The sender is a member of...',
+      SentTo: 'The recipient is...',
+      SentToScope: 'The recipient is located...',
+      SentToMemberOf: 'The recipient is a member of...',
+      SubjectContainsWords: 'Subject contains words...',
+      SubjectMatchesPatterns: 'Subject matches patterns...',
+      SubjectOrBodyContainsWords: 'Subject or body contains words...',
+      SubjectOrBodyMatchesPatterns: 'Subject or body matches patterns...',
+      FromAddressContainsWords: 'Sender address contains words...',
+      FromAddressMatchesPatterns: 'Sender address matches patterns...',
+      AttachmentContainsWords: 'Attachment content contains words...',
+      AttachmentMatchesPatterns: 'Attachment content matches patterns...',
+      AttachmentNameMatchesPatterns: 'Attachment name matches patterns...',
+      AttachmentPropertyContainsWords: 'Attachment properties contain words...',
+      AttachmentExtensionMatchesWords: 'Attachment extension is...',
+      AttachmentHasExecutableContent: 'Attachment has executable content',
+      AttachmentIsPasswordProtected: 'Attachment is password protected',
+      AttachmentIsUnsupported: 'Attachment type is unsupported',
+      AttachmentProcessingLimitExceeded: 'Attachment processing limit exceeded',
+      AttachmentSizeOver: 'Attachment size is greater than...',
+      MessageSizeOver: 'Message size is greater than...',
+      SCLOver: 'SCL is greater than or equal to...',
+      WithImportance: 'Message importance is...',
+      MessageTypeMatches: 'Message type is...',
+      SenderDomainIs: 'Sender domain is...',
+      RecipientDomainIs: 'Recipient domain is...',
+      SenderIpRanges: 'Sender IP address belongs to any of these ranges...',
+      HeaderContainsWords: 'Message header contains words...',
+      HeaderMatchesPatterns: 'Message header matches patterns...',
+      AnyOfToHeader: 'Any To header contains...',
+      AnyOfToHeaderMemberOf: 'Any To header is a member of...',
+      AnyOfCcHeader: 'Any Cc header contains...',
+      AnyOfCcHeaderMemberOf: 'Any Cc header is a member of...',
+      AnyOfToCcHeader: 'Any To or Cc header contains...',
+      AnyOfToCcHeaderMemberOf: 'Any To or Cc header is a member of...',
+      RecipientAddressContainsWords: 'Recipient address contains words...',
+      RecipientAddressMatchesPatterns: 'Recipient address matches patterns...',
+      AnyOfRecipientAddressContainsWords: 'Any recipient address contains words...',
+      AnyOfRecipientAddressMatchesPatterns: 'Any recipient address matches patterns...',
+    }
 
     const actionFieldMap = {
-      DeleteMessage: "Delete the message without notifying anyone",
-      Quarantine: "Quarantine the message",
-      RedirectMessageTo: "Redirect the message to...",
-      RouteMessageOutboundConnector: "Route the message using the connector named...",
-      BlindCopyTo: "Add recipients to the Bcc box...",
-      CopyTo: "Add recipients to the Cc box...",
-      ModerateMessageByUser: "Forward the message for approval to...",
+      DeleteMessage: 'Delete the message without notifying anyone',
+      Quarantine: 'Quarantine the message',
+      RedirectMessageTo: 'Redirect the message to...',
+      RouteMessageOutboundConnector: 'Route the message using the connector named...',
+      BlindCopyTo: 'Add recipients to the Bcc box...',
+      CopyTo: 'Add recipients to the Cc box...',
+      ModerateMessageByUser: 'Forward the message for approval to...',
       ModerateMessageByManager: "Forward the message for approval to the sender's manager",
-      RejectMessageReasonText: "Reject the message with explanation...",
-      PrependSubject: "Prepend the subject with...",
-      SetSCL: "Set spam confidence level (SCL) to...",
-      SetHeaderName: "Set message header...",
-      RemoveHeader: "Remove message header...",
-      ApplyClassification: "Apply message classification...",
-      ApplyHtmlDisclaimerText: "Apply HTML disclaimer...",
-      GenerateIncidentReport: "Generate incident report and send to...",
-      GenerateNotification: "Notify the sender with a message...",
-      ApplyOME: "Apply Office 365 Message Encryption",
-    };
+      RejectMessageReasonText: 'Reject the message with explanation...',
+      PrependSubject: 'Prepend the subject with...',
+      SetSCL: 'Set spam confidence level (SCL) to...',
+      SetHeaderName: 'Set message header...',
+      RemoveHeader: 'Remove message header...',
+      ApplyClassification: 'Apply message classification...',
+      ApplyHtmlDisclaimerText: 'Apply HTML disclaimer...',
+      GenerateIncidentReport: 'Generate incident report and send to...',
+      GenerateNotification: 'Notify the sender with a message...',
+      ApplyOME: 'Apply Office 365 Message Encryption',
+    }
 
     // Detect active conditions
-    const activeConditions = [];
-    Object.keys(conditionFieldMap).forEach(field => {
-      const value = rule[field];
-      if (value !== null && value !== undefined && value !== false && value !== "") {
+    const activeConditions = []
+    Object.keys(conditionFieldMap).forEach((field) => {
+      const value = rule[field]
+      if (value !== null && value !== undefined && value !== false && value !== '') {
         activeConditions.push({
           value: field,
-          label: conditionFieldMap[field]
-        });
+          label: conditionFieldMap[field],
+        })
       }
-    });
+    })
 
     // Detect active actions
-    const activeActions = [];
-    Object.keys(actionFieldMap).forEach(field => {
-      const value = rule[field];
-      if (field === "RejectMessageReasonText" && (rule.RejectMessageReasonText || rule.RejectMessageEnhancedStatusCode)) {
-        activeActions.push({ value: "RejectMessage", label: actionFieldMap[field] });
-      } else if (field === "SetHeaderName" && (rule.SetHeaderName || rule.SetHeaderValue)) {
-        activeActions.push({ value: "SetHeader", label: actionFieldMap[field] });
-      } else if (field === "ApplyHtmlDisclaimerText" && rule.ApplyHtmlDisclaimerText) {
-        activeActions.push({ value: "ApplyHtmlDisclaimer", label: actionFieldMap[field] });
-      } else if (field === "ModerateMessageByManager" && value === true) {
-        activeActions.push({ value: field, label: actionFieldMap[field] });
-      } else if (value !== null && value !== undefined && value !== false && value !== "" && 
-                 field !== "RejectMessageReasonText" && field !== "SetHeaderName" && 
-                 field !== "ApplyHtmlDisclaimerText" && field !== "ModerateMessageByManager") {
-        activeActions.push({ value: field, label: actionFieldMap[field] });
+    const activeActions = []
+    Object.keys(actionFieldMap).forEach((field) => {
+      const value = rule[field]
+      if (
+        field === 'RejectMessageReasonText' &&
+        (rule.RejectMessageReasonText || rule.RejectMessageEnhancedStatusCode)
+      ) {
+        activeActions.push({ value: 'RejectMessage', label: actionFieldMap[field] })
+      } else if (field === 'SetHeaderName' && (rule.SetHeaderName || rule.SetHeaderValue)) {
+        activeActions.push({ value: 'SetHeader', label: actionFieldMap[field] })
+      } else if (field === 'ApplyHtmlDisclaimerText' && rule.ApplyHtmlDisclaimerText) {
+        activeActions.push({ value: 'ApplyHtmlDisclaimer', label: actionFieldMap[field] })
+      } else if (field === 'ModerateMessageByManager' && value === true) {
+        activeActions.push({ value: field, label: actionFieldMap[field] })
+      } else if (
+        value !== null &&
+        value !== undefined &&
+        value !== false &&
+        value !== '' &&
+        field !== 'RejectMessageReasonText' &&
+        field !== 'SetHeaderName' &&
+        field !== 'ApplyHtmlDisclaimerText' &&
+        field !== 'ModerateMessageByManager'
+      ) {
+        activeActions.push({ value: field, label: actionFieldMap[field] })
       }
-    });
+    })
 
     // Detect active exceptions
-    const activeExceptions = [];
-    Object.keys(conditionFieldMap).forEach(field => {
-      const exceptionField = `ExceptIf${field}`;
-      const value = rule[exceptionField];
-      if (value !== null && value !== undefined && value !== false && value !== "") {
+    const activeExceptions = []
+    Object.keys(conditionFieldMap).forEach((field) => {
+      const exceptionField = `ExceptIf${field}`
+      const value = rule[exceptionField]
+      if (value !== null && value !== undefined && value !== false && value !== '') {
         activeExceptions.push({
           value: exceptionField,
-          label: conditionFieldMap[field]
-        });
+          label: conditionFieldMap[field],
+        })
       }
-    });
+    })
 
     // Build form data
     const formData = {
-      Name: rule.Name || "",
-      Priority: rule.Priority ?? "",
-      Comments: rule.Comments || "",
+      Name: rule.Name || '',
+      Priority: rule.Priority ?? '',
+      Comments: rule.Comments || '',
       Enabled: boolHelper(rule.State),
-      Mode: rule.Mode ? { value: rule.Mode, label: rule.Mode } : { value: "Enforce", label: "Enforce" },
-      SetAuditSeverity: rule.SetAuditSeverity 
+      Mode: rule.Mode
+        ? { value: rule.Mode, label: rule.Mode }
+        : { value: 'Enforce', label: 'Enforce' },
+      SetAuditSeverity: rule.SetAuditSeverity
         ? { value: rule.SetAuditSeverity, label: rule.SetAuditSeverity }
         : undefined,
       SenderAddressLocation: rule.SenderAddressLocation
         ? { value: rule.SenderAddressLocation, label: rule.SenderAddressLocation }
-        : { value: "Header", label: "Header" },
+        : { value: 'Header', label: 'Header' },
       StopRuleProcessing: rule.StopRuleProcessing || false,
       ActivationDate: iso8601ToUnixTimestamp(rule.ActivationDate),
       ExpiryDate: iso8601ToUnixTimestamp(rule.ExpiryDate),
@@ -238,547 +259,628 @@ export const CippTransportRuleDrawer = ({
       actionType: activeActions,
       exceptionType: activeExceptions,
       tenantFilter: currentTenant,
-    };
+    }
 
     // Add all condition values
-    Object.keys(conditionFieldMap).forEach(field => {
+    Object.keys(conditionFieldMap).forEach((field) => {
       if (rule[field] !== null && rule[field] !== undefined) {
-        if (field === "FromScope" || field === "SentToScope") {
-          formData[field] = rule[field] 
-            ? { value: rule[field], label: rule[field] === "InOrganization" ? "Inside the organization" : "Outside the organization" }
-            : undefined;
-        } else if (field === "WithImportance") {
-          formData[field] = rule[field] 
-            ? { value: rule[field], label: rule[field] }
-            : undefined;
-        } else if (field === "MessageTypeMatches") {
-          formData[field] = rule[field] 
-            ? { value: rule[field], label: rule[field] }
-            : undefined;
-        } else if (field === "SCLOver") {
-          formData[field] = rule[field] !== null
-            ? { value: rule[field].toString(), label: rule[field].toString() }
-            : undefined;
-        } else if (field === "SenderIpRanges") {
+        if (field === 'FromScope' || field === 'SentToScope') {
+          formData[field] = rule[field]
+            ? {
+                value: rule[field],
+                label:
+                  rule[field] === 'InOrganization'
+                    ? 'Inside the organization'
+                    : 'Outside the organization',
+              }
+            : undefined
+        } else if (field === 'WithImportance') {
+          formData[field] = rule[field] ? { value: rule[field], label: rule[field] } : undefined
+        } else if (field === 'MessageTypeMatches') {
+          formData[field] = rule[field] ? { value: rule[field], label: rule[field] } : undefined
+        } else if (field === 'SCLOver') {
+          formData[field] =
+            rule[field] !== null
+              ? { value: rule[field].toString(), label: rule[field].toString() }
+              : undefined
+        } else if (field === 'SenderIpRanges') {
           // Transform array of IP strings to autocomplete format
           if (Array.isArray(rule[field])) {
-            formData[field] = rule[field].map(ip => ({ value: ip, label: ip }));
+            formData[field] = rule[field].map((ip) => ({ value: ip, label: ip }))
           } else {
-            formData[field] = rule[field];
+            formData[field] = rule[field]
           }
         } else if (
           // Fields that use creatable autocomplete with API (users/groups)
-          field === "From" || field === "SentTo" || 
-          field === "AnyOfToHeader" || field === "AnyOfCcHeader" || field === "AnyOfToCcHeader" ||
-          field === "FromMemberOf" || field === "SentToMemberOf" || 
-          field === "AnyOfToHeaderMemberOf" || field === "AnyOfCcHeaderMemberOf" || field === "AnyOfToCcHeaderMemberOf"
+          field === 'From' ||
+          field === 'SentTo' ||
+          field === 'AnyOfToHeader' ||
+          field === 'AnyOfCcHeader' ||
+          field === 'AnyOfToCcHeader' ||
+          field === 'FromMemberOf' ||
+          field === 'SentToMemberOf' ||
+          field === 'AnyOfToHeaderMemberOf' ||
+          field === 'AnyOfCcHeaderMemberOf' ||
+          field === 'AnyOfToCcHeaderMemberOf'
         ) {
           // Transform array of email/UPN strings to autocomplete format
           if (Array.isArray(rule[field])) {
-            formData[field] = rule[field].map(item => ({ value: item, label: item }));
+            formData[field] = rule[field].map((item) => ({ value: item, label: item }))
           } else {
-            formData[field] = rule[field];
+            formData[field] = rule[field]
           }
         } else {
-          formData[field] = rule[field];
+          formData[field] = rule[field]
         }
       }
-      if (field === "HeaderContainsWords" && rule.HeaderContainsMessageHeader) {
-        formData.HeaderContainsWordsMessageHeader = rule.HeaderContainsMessageHeader;
+      if (field === 'HeaderContainsWords' && rule.HeaderContainsMessageHeader) {
+        formData.HeaderContainsWordsMessageHeader = rule.HeaderContainsMessageHeader
       }
-      if (field === "HeaderMatchesPatterns" && rule.HeaderMatchesMessageHeader) {
-        formData.HeaderMatchesPatternsMessageHeader = rule.HeaderMatchesMessageHeader;
+      if (field === 'HeaderMatchesPatterns' && rule.HeaderMatchesMessageHeader) {
+        formData.HeaderMatchesPatternsMessageHeader = rule.HeaderMatchesMessageHeader
       }
-    });
+    })
 
     // Add all action values
-    if (rule.RejectMessageReasonText) formData.RejectMessageReasonText = rule.RejectMessageReasonText;
-    if (rule.RejectMessageEnhancedStatusCode) formData.RejectMessageEnhancedStatusCode = rule.RejectMessageEnhancedStatusCode;
-    if (rule.SetHeaderName) formData.SetHeaderName = rule.SetHeaderName;
-    if (rule.SetHeaderValue) formData.SetHeaderValue = rule.SetHeaderValue;
-    if (rule.ApplyHtmlDisclaimerText) formData.ApplyHtmlDisclaimerText = rule.ApplyHtmlDisclaimerText;
+    if (rule.RejectMessageReasonText)
+      formData.RejectMessageReasonText = rule.RejectMessageReasonText
+    if (rule.RejectMessageEnhancedStatusCode)
+      formData.RejectMessageEnhancedStatusCode = rule.RejectMessageEnhancedStatusCode
+    if (rule.SetHeaderName) formData.SetHeaderName = rule.SetHeaderName
+    if (rule.SetHeaderValue) formData.SetHeaderValue = rule.SetHeaderValue
+    if (rule.ApplyHtmlDisclaimerText)
+      formData.ApplyHtmlDisclaimerText = rule.ApplyHtmlDisclaimerText
     if (rule.ApplyHtmlDisclaimerLocation) {
-      formData.ApplyHtmlDisclaimerLocation = { value: rule.ApplyHtmlDisclaimerLocation, label: rule.ApplyHtmlDisclaimerLocation };
+      formData.ApplyHtmlDisclaimerLocation = {
+        value: rule.ApplyHtmlDisclaimerLocation,
+        label: rule.ApplyHtmlDisclaimerLocation,
+      }
     }
     if (rule.ApplyHtmlDisclaimerFallbackAction) {
-      formData.ApplyHtmlDisclaimerFallbackAction = { value: rule.ApplyHtmlDisclaimerFallbackAction, label: rule.ApplyHtmlDisclaimerFallbackAction };
+      formData.ApplyHtmlDisclaimerFallbackAction = {
+        value: rule.ApplyHtmlDisclaimerFallbackAction,
+        label: rule.ApplyHtmlDisclaimerFallbackAction,
+      }
     }
     if (rule.IncidentReportContent) {
       const incidentReportContentValues = Array.isArray(rule.IncidentReportContent)
         ? rule.IncidentReportContent
-        : rule.IncidentReportContent
-          .split(",")
-          .map((item) => item.trim())
-          .filter(Boolean);
-      formData.IncidentReportContent = incidentReportContentValues.map((item) => ({ value: item, label: item }));
+        : rule.IncidentReportContent.split(',')
+            .map((item) => item.trim())
+            .filter(Boolean)
+      formData.IncidentReportContent = incidentReportContentValues.map((item) => ({
+        value: item,
+        label: item,
+      }))
     }
-    
-    Object.keys(actionFieldMap).forEach(field => {
+
+    Object.keys(actionFieldMap).forEach((field) => {
       if (rule[field] !== null && rule[field] !== undefined && !formData[field]) {
-        if (field === "SetSCL" && rule[field] !== null) {
-          formData[field] = { value: rule[field].toString(), label: rule[field].toString() };
-        } else if (field === "RouteMessageOutboundConnector") {
-          formData[field] = { value: rule[field], label: rule[field] };
+        if (field === 'SetSCL' && rule[field] !== null) {
+          formData[field] = { value: rule[field].toString(), label: rule[field].toString() }
+        } else if (field === 'RouteMessageOutboundConnector') {
+          formData[field] = { value: rule[field], label: rule[field] }
         } else {
-          formData[field] = rule[field];
+          formData[field] = rule[field]
         }
       }
-    });
+    })
 
     // Add all exception values
-    Object.keys(conditionFieldMap).forEach(field => {
-      const exceptionField = `ExceptIf${field}`;
+    Object.keys(conditionFieldMap).forEach((field) => {
+      const exceptionField = `ExceptIf${field}`
       if (rule[exceptionField] !== null && rule[exceptionField] !== undefined) {
-        if (field === "FromScope" || field === "SentToScope") {
-          formData[exceptionField] = rule[exceptionField] 
-            ? { value: rule[exceptionField], label: rule[exceptionField] === "InOrganization" ? "Inside the organization" : "Outside the organization" }
-            : undefined;
-        } else if (field === "WithImportance") {
-          formData[exceptionField] = rule[exceptionField] 
+        if (field === 'FromScope' || field === 'SentToScope') {
+          formData[exceptionField] = rule[exceptionField]
+            ? {
+                value: rule[exceptionField],
+                label:
+                  rule[exceptionField] === 'InOrganization'
+                    ? 'Inside the organization'
+                    : 'Outside the organization',
+              }
+            : undefined
+        } else if (field === 'WithImportance') {
+          formData[exceptionField] = rule[exceptionField]
             ? { value: rule[exceptionField], label: rule[exceptionField] }
-            : undefined;
-        } else if (field === "MessageTypeMatches") {
-          formData[exceptionField] = rule[exceptionField] 
+            : undefined
+        } else if (field === 'MessageTypeMatches') {
+          formData[exceptionField] = rule[exceptionField]
             ? { value: rule[exceptionField], label: rule[exceptionField] }
-            : undefined;
-        } else if (field === "SCLOver") {
-          formData[exceptionField] = rule[exceptionField] !== null
-            ? { value: rule[exceptionField].toString(), label: rule[exceptionField].toString() }
-            : undefined;
-        } else if (field === "SenderIpRanges") {
+            : undefined
+        } else if (field === 'SCLOver') {
+          formData[exceptionField] =
+            rule[exceptionField] !== null
+              ? { value: rule[exceptionField].toString(), label: rule[exceptionField].toString() }
+              : undefined
+        } else if (field === 'SenderIpRanges') {
           // Transform array of IP strings to autocomplete format
           if (Array.isArray(rule[exceptionField])) {
-            formData[exceptionField] = rule[exceptionField].map(ip => ({ value: ip, label: ip }));
+            formData[exceptionField] = rule[exceptionField].map((ip) => ({ value: ip, label: ip }))
           } else {
-            formData[exceptionField] = rule[exceptionField];
+            formData[exceptionField] = rule[exceptionField]
           }
         } else if (
           // Fields that use creatable autocomplete with API (users/groups)
-          field === "From" || field === "SentTo" || 
-          field === "AnyOfToHeader" || field === "AnyOfCcHeader" || field === "AnyOfToCcHeader" ||
-          field === "FromMemberOf" || field === "SentToMemberOf" || 
-          field === "AnyOfToHeaderMemberOf" || field === "AnyOfCcHeaderMemberOf" || field === "AnyOfToCcHeaderMemberOf"
+          field === 'From' ||
+          field === 'SentTo' ||
+          field === 'AnyOfToHeader' ||
+          field === 'AnyOfCcHeader' ||
+          field === 'AnyOfToCcHeader' ||
+          field === 'FromMemberOf' ||
+          field === 'SentToMemberOf' ||
+          field === 'AnyOfToHeaderMemberOf' ||
+          field === 'AnyOfCcHeaderMemberOf' ||
+          field === 'AnyOfToCcHeaderMemberOf'
         ) {
           // Transform array of email/UPN strings to autocomplete format
           if (Array.isArray(rule[exceptionField])) {
-            formData[exceptionField] = rule[exceptionField].map(item => ({ value: item, label: item }));
+            formData[exceptionField] = rule[exceptionField].map((item) => ({
+              value: item,
+              label: item,
+            }))
           } else {
-            formData[exceptionField] = rule[exceptionField];
+            formData[exceptionField] = rule[exceptionField]
           }
         } else {
-          formData[exceptionField] = rule[exceptionField];
+          formData[exceptionField] = rule[exceptionField]
         }
       }
-      if (field === "HeaderContainsWords" && rule[`ExceptIfHeaderContainsMessageHeader`]) {
-        formData.ExceptIfHeaderContainsWordsMessageHeader = rule.ExceptIfHeaderContainsMessageHeader;
+      if (field === 'HeaderContainsWords' && rule[`ExceptIfHeaderContainsMessageHeader`]) {
+        formData.ExceptIfHeaderContainsWordsMessageHeader = rule.ExceptIfHeaderContainsMessageHeader
       }
-      if (field === "HeaderMatchesPatterns" && rule[`ExceptIfHeaderMatchesMessageHeader`]) {
-        formData.ExceptIfHeaderMatchesPatternsMessageHeader = rule.ExceptIfHeaderMatchesMessageHeader;
+      if (field === 'HeaderMatchesPatterns' && rule[`ExceptIfHeaderMatchesMessageHeader`]) {
+        formData.ExceptIfHeaderMatchesPatternsMessageHeader =
+          rule.ExceptIfHeaderMatchesMessageHeader
       }
-    });
+    })
 
-    return formData;
-  }, [ruleInfo.isSuccess, ruleInfo.data, currentTenant, isEditMode]);
+    return formData
+  }, [ruleInfo.isSuccess, ruleInfo.data, currentTenant, isEditMode])
 
   // Reset form with processed data
   const resetForm = useCallback(() => {
     if (processedRuleData) {
-      formControl.reset(processedRuleData);
+      formControl.reset(processedRuleData)
     }
-  }, [processedRuleData, formControl]);
+  }, [processedRuleData, formControl])
 
   useEffect(() => {
     if (drawerVisible && isEditMode) {
-      resetForm();
+      resetForm()
     }
-  }, [resetForm, drawerVisible, isEditMode]);
+  }, [resetForm, drawerVisible, isEditMode])
 
   useEffect(() => {
     if (!drawerVisible || isEditMode || !Array.isArray(allRulesInfo.data?.Results)) {
-      return;
+      return
     }
 
-    const priorities = allRulesInfo.data.Results
-      .map((rule) => Number(rule?.Priority))
-      .filter((priority) => Number.isFinite(priority));
+    const priorities = allRulesInfo.data.Results.map((rule) => Number(rule?.Priority)).filter(
+      (priority) => Number.isFinite(priority)
+    )
 
     if (!priorities.length) {
-      return;
+      return
     }
 
-    const currentPriority = formControl.getValues("Priority");
-    if (currentPriority === "" || currentPriority === null || currentPriority === undefined) {
-      formControl.setValue("Priority", Math.max(...priorities) + 1, {
+    const currentPriority = formControl.getValues('Priority')
+    if (currentPriority === '' || currentPriority === null || currentPriority === undefined) {
+      formControl.setValue('Priority', Math.max(...priorities) + 1, {
         shouldDirty: false,
         shouldTouch: false,
-      });
+      })
     }
-  }, [drawerVisible, isEditMode, allRulesInfo.data, formControl]);
+  }, [drawerVisible, isEditMode, allRulesInfo.data, formControl])
 
   // Custom data formatter for API submission
   const customDataFormatter = useCallback(
     (values) => {
-      const rule = ruleInfo.data?.Results 
-        ? (Array.isArray(ruleInfo.data.Results) ? ruleInfo.data.Results[0] : ruleInfo.data.Results)
-        : (Array.isArray(ruleInfo.data) ? ruleInfo.data[0] : ruleInfo.data);
-      
+      const rule = ruleInfo.data?.Results
+        ? Array.isArray(ruleInfo.data.Results)
+          ? ruleInfo.data.Results[0]
+          : ruleInfo.data.Results
+        : Array.isArray(ruleInfo.data)
+          ? ruleInfo.data[0]
+          : ruleInfo.data
+
       const apiData = {
         tenantFilter: currentTenant,
         Name: values.Name,
         Priority: values.Priority,
         Comments: values.Comments,
-        State: values.Enabled ? "Enabled" : "Disabled",
+        State: values.Enabled ? 'Enabled' : 'Disabled',
         Mode: values.Mode?.value || values.Mode,
         SetAuditSeverity: values.SetAuditSeverity?.value || values.SetAuditSeverity,
         SenderAddressLocation: values.SenderAddressLocation?.value || values.SenderAddressLocation,
         StopRuleProcessing: values.StopRuleProcessing,
         ActivationDate: values.ActivationDate,
         ExpiryDate: values.ExpiryDate,
-      };
-
-      if (isEditMode && rule) {
-        apiData.ruleId = rule.Guid || rule.Identity || rule.Name;
       }
 
-      const conditionTypes = values.conditionType || [];
-      conditionTypes.forEach(condition => {
-        const conditionValue = condition.value || condition;
+      if (isEditMode && rule) {
+        apiData.ruleId = rule.Guid || rule.Identity || rule.Name
+      }
+
+      const conditionTypes = values.conditionType || []
+      conditionTypes.forEach((condition) => {
+        const conditionValue = condition.value || condition
         if (values[conditionValue] !== undefined) {
-          const fieldValue = values[conditionValue];
-          
+          const fieldValue = values[conditionValue]
+
           // Handle single object with value property
-          if (fieldValue && typeof fieldValue === 'object' && !Array.isArray(fieldValue) && fieldValue.value !== undefined) {
-            apiData[conditionValue] = fieldValue.value;
-          } 
+          if (
+            fieldValue &&
+            typeof fieldValue === 'object' &&
+            !Array.isArray(fieldValue) &&
+            fieldValue.value !== undefined
+          ) {
+            apiData[conditionValue] = fieldValue.value
+          }
           // Handle array of objects with value property (for creatable autocomplete fields)
           else if (Array.isArray(fieldValue)) {
-            apiData[conditionValue] = fieldValue.map(item => {
+            apiData[conditionValue] = fieldValue.map((item) => {
               if (item && typeof item === 'object' && item.value !== undefined) {
-                return item.value;
+                return item.value
               }
-              return item;
-            });
-          } 
+              return item
+            })
+          }
           // Handle plain values
           else {
-            apiData[conditionValue] = fieldValue;
+            apiData[conditionValue] = fieldValue
           }
         }
-        if (conditionValue === "HeaderContainsWords" && values.HeaderContainsWordsMessageHeader) {
-          apiData.HeaderContainsMessageHeader = values.HeaderContainsWordsMessageHeader;
-          apiData.HeaderContainsWords = values.HeaderContainsWords;
+        if (conditionValue === 'HeaderContainsWords' && values.HeaderContainsWordsMessageHeader) {
+          apiData.HeaderContainsMessageHeader = values.HeaderContainsWordsMessageHeader
+          apiData.HeaderContainsWords = values.HeaderContainsWords
         }
-        if (conditionValue === "HeaderMatchesPatterns" && values.HeaderMatchesPatternsMessageHeader) {
-          apiData.HeaderMatchesMessageHeader = values.HeaderMatchesPatternsMessageHeader;
-          apiData.HeaderMatchesPatterns = values.HeaderMatchesPatterns;
+        if (
+          conditionValue === 'HeaderMatchesPatterns' &&
+          values.HeaderMatchesPatternsMessageHeader
+        ) {
+          apiData.HeaderMatchesMessageHeader = values.HeaderMatchesPatternsMessageHeader
+          apiData.HeaderMatchesPatterns = values.HeaderMatchesPatterns
         }
-      });
+      })
 
-      const actionTypes = values.actionType || [];
-      actionTypes.forEach(action => {
-        const actionValue = action.value || action;
-        
-        if (actionValue === "RejectMessage") {
+      const actionTypes = values.actionType || []
+      actionTypes.forEach((action) => {
+        const actionValue = action.value || action
+
+        if (actionValue === 'RejectMessage') {
           if (values.RejectMessageReasonText) {
-            apiData.RejectMessageReasonText = values.RejectMessageReasonText;
+            apiData.RejectMessageReasonText = values.RejectMessageReasonText
           }
           if (values.RejectMessageEnhancedStatusCode) {
-            apiData.RejectMessageEnhancedStatusCode = values.RejectMessageEnhancedStatusCode;
+            apiData.RejectMessageEnhancedStatusCode = values.RejectMessageEnhancedStatusCode
           }
-        } else if (actionValue === "SetHeader") {
-          if (values.SetHeaderName) apiData.SetHeaderName = values.SetHeaderName;
-          if (values.SetHeaderValue) apiData.SetHeaderValue = values.SetHeaderValue;
-        } else if (actionValue === "ApplyHtmlDisclaimer") {
+        } else if (actionValue === 'SetHeader') {
+          if (values.SetHeaderName) apiData.SetHeaderName = values.SetHeaderName
+          if (values.SetHeaderValue) apiData.SetHeaderValue = values.SetHeaderValue
+        } else if (actionValue === 'ApplyHtmlDisclaimer') {
           if (values.ApplyHtmlDisclaimerText) {
-            apiData.ApplyHtmlDisclaimerText = values.ApplyHtmlDisclaimerText;
+            apiData.ApplyHtmlDisclaimerText = values.ApplyHtmlDisclaimerText
           }
           if (values.ApplyHtmlDisclaimerLocation) {
-            const location = values.ApplyHtmlDisclaimerLocation;
-            apiData.ApplyHtmlDisclaimerLocation = location?.value || location;
+            const location = values.ApplyHtmlDisclaimerLocation
+            apiData.ApplyHtmlDisclaimerLocation = location?.value || location
           }
           if (values.ApplyHtmlDisclaimerFallbackAction) {
-            const fallback = values.ApplyHtmlDisclaimerFallbackAction;
-            apiData.ApplyHtmlDisclaimerFallbackAction = fallback?.value || fallback;
+            const fallback = values.ApplyHtmlDisclaimerFallbackAction
+            apiData.ApplyHtmlDisclaimerFallbackAction = fallback?.value || fallback
           }
-        } else if (actionValue === "GenerateIncidentReport") {
+        } else if (actionValue === 'GenerateIncidentReport') {
           if (values.GenerateIncidentReport !== undefined) {
-            const fieldValue = values.GenerateIncidentReport;
+            const fieldValue = values.GenerateIncidentReport
             apiData.GenerateIncidentReport =
-              fieldValue && typeof fieldValue === "object" && fieldValue.value !== undefined
+              fieldValue && typeof fieldValue === 'object' && fieldValue.value !== undefined
                 ? fieldValue.value
-                : fieldValue;
+                : fieldValue
           }
           if (values.IncidentReportContent !== undefined) {
-            const fieldValue = values.IncidentReportContent;
+            const fieldValue = values.IncidentReportContent
             const incidentReportValues = Array.isArray(fieldValue)
               ? fieldValue.map((item) => {
-                if (item && typeof item === "object" && item.value !== undefined) {
-                  return item.value;
-                }
-                return item;
-              })
-              : [fieldValue];
-            apiData.IncidentReportContent = incidentReportValues.filter(Boolean).join(",");
+                  if (item && typeof item === 'object' && item.value !== undefined) {
+                    return item.value
+                  }
+                  return item
+                })
+              : [fieldValue]
+            apiData.IncidentReportContent = incidentReportValues.filter(Boolean).join(',')
           }
         } else if (values[actionValue] !== undefined) {
-          const fieldValue = values[actionValue];
-          
+          const fieldValue = values[actionValue]
+
           // Handle single object with value property
-          if (fieldValue && typeof fieldValue === 'object' && !Array.isArray(fieldValue) && fieldValue.value !== undefined) {
-            apiData[actionValue] = fieldValue.value;
-          } 
+          if (
+            fieldValue &&
+            typeof fieldValue === 'object' &&
+            !Array.isArray(fieldValue) &&
+            fieldValue.value !== undefined
+          ) {
+            apiData[actionValue] = fieldValue.value
+          }
           // Handle array of objects with value property (for creatable autocomplete fields)
           else if (Array.isArray(fieldValue)) {
-            apiData[actionValue] = fieldValue.map(item => {
+            apiData[actionValue] = fieldValue.map((item) => {
               if (item && typeof item === 'object' && item.value !== undefined) {
-                return item.value;
+                return item.value
               }
-              return item;
-            });
-          } 
+              return item
+            })
+          }
           // Handle plain values
           else {
-            apiData[actionValue] = fieldValue;
+            apiData[actionValue] = fieldValue
           }
         }
-      });
+      })
 
-      const exceptionTypes = values.exceptionType || [];
-      exceptionTypes.forEach(exception => {
-        const exceptionValue = exception.value || exception;
+      const exceptionTypes = values.exceptionType || []
+      exceptionTypes.forEach((exception) => {
+        const exceptionValue = exception.value || exception
         if (values[exceptionValue] !== undefined) {
-          const fieldValue = values[exceptionValue];
-          
+          const fieldValue = values[exceptionValue]
+
           // Handle single object with value property
-          if (fieldValue && typeof fieldValue === 'object' && !Array.isArray(fieldValue) && fieldValue.value !== undefined) {
-            apiData[exceptionValue] = fieldValue.value;
-          } 
+          if (
+            fieldValue &&
+            typeof fieldValue === 'object' &&
+            !Array.isArray(fieldValue) &&
+            fieldValue.value !== undefined
+          ) {
+            apiData[exceptionValue] = fieldValue.value
+          }
           // Handle array of objects with value property (for creatable autocomplete fields)
           else if (Array.isArray(fieldValue)) {
-            apiData[exceptionValue] = fieldValue.map(item => {
+            apiData[exceptionValue] = fieldValue.map((item) => {
               if (item && typeof item === 'object' && item.value !== undefined) {
-                return item.value;
+                return item.value
               }
-              return item;
-            });
-          } 
+              return item
+            })
+          }
           // Handle plain values
           else {
-            apiData[exceptionValue] = fieldValue;
+            apiData[exceptionValue] = fieldValue
           }
         }
-        if (exceptionValue === "ExceptIfHeaderContainsWords" && values.ExceptIfHeaderContainsWordsMessageHeader) {
-          apiData.ExceptIfHeaderContainsMessageHeader = values.ExceptIfHeaderContainsWordsMessageHeader;
-          apiData.ExceptIfHeaderContainsWords = values.ExceptIfHeaderContainsWords;
+        if (
+          exceptionValue === 'ExceptIfHeaderContainsWords' &&
+          values.ExceptIfHeaderContainsWordsMessageHeader
+        ) {
+          apiData.ExceptIfHeaderContainsMessageHeader =
+            values.ExceptIfHeaderContainsWordsMessageHeader
+          apiData.ExceptIfHeaderContainsWords = values.ExceptIfHeaderContainsWords
         }
-        if (exceptionValue === "ExceptIfHeaderMatchesPatterns" && values.ExceptIfHeaderMatchesPatternsMessageHeader) {
-          apiData.ExceptIfHeaderMatchesMessageHeader = values.ExceptIfHeaderMatchesPatternsMessageHeader;
-          apiData.ExceptIfHeaderMatchesPatterns = values.ExceptIfHeaderMatchesPatterns;
+        if (
+          exceptionValue === 'ExceptIfHeaderMatchesPatterns' &&
+          values.ExceptIfHeaderMatchesPatternsMessageHeader
+        ) {
+          apiData.ExceptIfHeaderMatchesMessageHeader =
+            values.ExceptIfHeaderMatchesPatternsMessageHeader
+          apiData.ExceptIfHeaderMatchesPatterns = values.ExceptIfHeaderMatchesPatterns
         }
-      });
+      })
 
-      return apiData;
+      return apiData
     },
     [currentTenant, ruleInfo.data, isEditMode]
-  );
+  )
 
   // Helper function to get field names for a condition
   const getConditionFieldNames = (conditionValue) => {
-    const fields = [conditionValue];
-    if (conditionValue === "HeaderContainsWords") {
-      fields.push("HeaderContainsWordsMessageHeader");
-    } else if (conditionValue === "HeaderMatchesPatterns") {
-      fields.push("HeaderMatchesPatternsMessageHeader");
+    const fields = [conditionValue]
+    if (conditionValue === 'HeaderContainsWords') {
+      fields.push('HeaderContainsWordsMessageHeader')
+    } else if (conditionValue === 'HeaderMatchesPatterns') {
+      fields.push('HeaderMatchesPatternsMessageHeader')
     }
-    return fields;
-  };
+    return fields
+  }
 
   // Helper function to get field names for an action
   const getActionFieldNames = (actionValue) => {
-    const fields = [];
+    const fields = []
     switch (actionValue) {
-      case "RejectMessage":
-        fields.push("RejectMessageReasonText", "RejectMessageEnhancedStatusCode");
-        break;
-      case "SetHeader":
-        fields.push("SetHeaderName", "SetHeaderValue");
-        break;
-      case "ApplyHtmlDisclaimer":
-        fields.push("ApplyHtmlDisclaimerText", "ApplyHtmlDisclaimerLocation", "ApplyHtmlDisclaimerFallbackAction");
-        break;
+      case 'RejectMessage':
+        fields.push('RejectMessageReasonText', 'RejectMessageEnhancedStatusCode')
+        break
+      case 'SetHeader':
+        fields.push('SetHeaderName', 'SetHeaderValue')
+        break
+      case 'ApplyHtmlDisclaimer':
+        fields.push(
+          'ApplyHtmlDisclaimerText',
+          'ApplyHtmlDisclaimerLocation',
+          'ApplyHtmlDisclaimerFallbackAction'
+        )
+        break
       default:
-        fields.push(actionValue);
+        fields.push(actionValue)
     }
-    return fields;
-  };
+    return fields
+  }
 
   // Update selected conditions and clean up removed ones
   useEffect(() => {
-    const newConditions = conditionTypeWatch || [];
-    const newConditionValues = newConditions.map(c => c.value || c);
-    const oldConditionValues = selectedConditions.map(c => c.value || c);
+    const newConditions = conditionTypeWatch || []
+    const newConditionValues = newConditions.map((c) => c.value || c)
+    const oldConditionValues = selectedConditions.map((c) => c.value || c)
 
     const removedConditions = oldConditionValues.filter(
-      oldVal => !newConditionValues.includes(oldVal)
-    );
+      (oldVal) => !newConditionValues.includes(oldVal)
+    )
 
-    removedConditions.forEach(conditionValue => {
-      const fieldNames = getConditionFieldNames(conditionValue);
-      fieldNames.forEach(fieldName => {
-        formControl.setValue(fieldName, undefined);
-      });
-    });
+    removedConditions.forEach((conditionValue) => {
+      const fieldNames = getConditionFieldNames(conditionValue)
+      fieldNames.forEach((fieldName) => {
+        formControl.setValue(fieldName, undefined)
+      })
+    })
 
-    setSelectedConditions(newConditions);
-  }, [conditionTypeWatch]);
+    setSelectedConditions(newConditions)
+  }, [conditionTypeWatch])
 
   // Update selected actions and clean up removed ones
   useEffect(() => {
-    const newActions = actionTypeWatch || [];
-    const newActionValues = newActions.map(a => a.value || a);
-    const oldActionValues = selectedActions.map(a => a.value || a);
+    const newActions = actionTypeWatch || []
+    const newActionValues = newActions.map((a) => a.value || a)
+    const oldActionValues = selectedActions.map((a) => a.value || a)
 
-    const removedActions = oldActionValues.filter(
-      oldVal => !newActionValues.includes(oldVal)
-    );
+    const removedActions = oldActionValues.filter((oldVal) => !newActionValues.includes(oldVal))
 
-    removedActions.forEach(actionValue => {
-      const fieldNames = getActionFieldNames(actionValue);
-      fieldNames.forEach(fieldName => {
-        formControl.setValue(fieldName, undefined);
-      });
-    });
+    removedActions.forEach((actionValue) => {
+      const fieldNames = getActionFieldNames(actionValue)
+      fieldNames.forEach((fieldName) => {
+        formControl.setValue(fieldName, undefined)
+      })
+    })
 
-    setSelectedActions(newActions);
-  }, [actionTypeWatch]);
+    setSelectedActions(newActions)
+  }, [actionTypeWatch])
 
   // Update selected exceptions and clean up removed ones
   useEffect(() => {
-    const newExceptions = exceptionTypeWatch || [];
-    const newExceptionValues = newExceptions.map(e => e.value || e);
-    const oldExceptionValues = selectedExceptions.map(e => e.value || e);
+    const newExceptions = exceptionTypeWatch || []
+    const newExceptionValues = newExceptions.map((e) => e.value || e)
+    const oldExceptionValues = selectedExceptions.map((e) => e.value || e)
 
     const removedExceptions = oldExceptionValues.filter(
-      oldVal => !newExceptionValues.includes(oldVal)
-    );
+      (oldVal) => !newExceptionValues.includes(oldVal)
+    )
 
-    removedExceptions.forEach(exceptionValue => {
-      const baseCondition = exceptionValue.replace("ExceptIf", "");
-      const fieldNames = getConditionFieldNames(baseCondition).map(
-        field => field.includes("MessageHeader") ? `ExceptIf${field}` : exceptionValue
-      );
-      fieldNames.forEach(fieldName => {
-        formControl.setValue(fieldName, undefined);
-      });
-    });
+    removedExceptions.forEach((exceptionValue) => {
+      const baseCondition = exceptionValue.replace('ExceptIf', '')
+      const fieldNames = getConditionFieldNames(baseCondition).map((field) =>
+        field.includes('MessageHeader') ? `ExceptIf${field}` : exceptionValue
+      )
+      fieldNames.forEach((fieldName) => {
+        formControl.setValue(fieldName, undefined)
+      })
+    })
 
-    setSelectedExceptions(newExceptions);
-  }, [exceptionTypeWatch]);
+    setSelectedExceptions(newExceptions)
+  }, [exceptionTypeWatch])
 
   // Handle "Apply to all messages" logic
   useEffect(() => {
     if (applyToAllMessagesWatch) {
-      formControl.setValue("conditionType", []);
-      setSelectedConditions([]);
+      formControl.setValue('conditionType', [])
+      setSelectedConditions([])
     }
-  }, [applyToAllMessagesWatch, formControl]);
+  }, [applyToAllMessagesWatch, formControl])
 
   // Disable "Apply to all messages" when conditions are selected
   useEffect(() => {
     if (conditionTypeWatch && conditionTypeWatch.length > 0) {
-      formControl.setValue("applyToAllMessages", false);
+      formControl.setValue('applyToAllMessages', false)
     }
-  }, [conditionTypeWatch, formControl]);
+  }, [conditionTypeWatch, formControl])
 
   // Condition options
   const conditionOptions = [
-    { value: "From", label: "The sender is..." },
-    { value: "FromScope", label: "The sender is located..." },
-    { value: "FromMemberOf", label: "The sender is a member of..." },
-    { value: "SentTo", label: "The recipient is..." },
-    { value: "SentToScope", label: "The recipient is located..." },
-    { value: "SentToMemberOf", label: "The recipient is a member of..." },
-    { value: "SubjectContainsWords", label: "Subject contains words..." },
-    { value: "SubjectMatchesPatterns", label: "Subject matches patterns..." },
-    { value: "SubjectOrBodyContainsWords", label: "Subject or body contains words..." },
-    { value: "SubjectOrBodyMatchesPatterns", label: "Subject or body matches patterns..." },
-    { value: "FromAddressContainsWords", label: "Sender address contains words..." },
-    { value: "FromAddressMatchesPatterns", label: "Sender address matches patterns..." },
-    { value: "AttachmentContainsWords", label: "Attachment content contains words..." },
-    { value: "AttachmentMatchesPatterns", label: "Attachment content matches patterns..." },
-    { value: "AttachmentNameMatchesPatterns", label: "Attachment name matches patterns..." },
-    { value: "AttachmentPropertyContainsWords", label: "Attachment properties contain words..." },
-    { value: "AttachmentExtensionMatchesWords", label: "Attachment extension is..." },
-    { value: "AttachmentHasExecutableContent", label: "Attachment has executable content" },
-    { value: "AttachmentIsPasswordProtected", label: "Attachment is password protected" },
-    { value: "AttachmentIsUnsupported", label: "Attachment type is unsupported" },
-    { value: "AttachmentProcessingLimitExceeded", label: "Attachment processing limit exceeded" },
-    { value: "AttachmentSizeOver", label: "Attachment size is greater than..." },
-    { value: "MessageSizeOver", label: "Message size is greater than..." },
-    { value: "SCLOver", label: "SCL is greater than or equal to..." },
-    { value: "WithImportance", label: "Message importance is..." },
-    { value: "MessageTypeMatches", label: "Message type is..." },
-    { value: "SenderDomainIs", label: "Sender domain is..." },
-    { value: "RecipientDomainIs", label: "Recipient domain is..." },
-    { value: "SenderIpRanges", label: "Sender IP address belongs to any of these ranges..." },
-    { value: "HeaderContainsWords", label: "Message header contains words..." },
-    { value: "HeaderMatchesPatterns", label: "Message header matches patterns..." },
-    { value: "AnyOfToHeader", label: "Any To header contains..." },
-    { value: "AnyOfToHeaderMemberOf", label: "Any To header is a member of..." },
-    { value: "AnyOfCcHeader", label: "Any Cc header contains..." },
-    { value: "AnyOfCcHeaderMemberOf", label: "Any Cc header is a member of..." },
-    { value: "AnyOfToCcHeader", label: "Any To or Cc header contains..." },
-    { value: "AnyOfToCcHeaderMemberOf", label: "Any To or Cc header is a member of..." },
-    { value: "RecipientAddressContainsWords", label: "Recipient address contains words..." },
-    { value: "RecipientAddressMatchesPatterns", label: "Recipient address matches patterns..." },
-    { value: "AnyOfRecipientAddressContainsWords", label: "Any recipient address contains words..." },
-    { value: "AnyOfRecipientAddressMatchesPatterns", label: "Any recipient address matches patterns..." },
-  ];
+    { value: 'From', label: 'The sender is...' },
+    { value: 'FromScope', label: 'The sender is located...' },
+    { value: 'FromMemberOf', label: 'The sender is a member of...' },
+    { value: 'SentTo', label: 'The recipient is...' },
+    { value: 'SentToScope', label: 'The recipient is located...' },
+    { value: 'SentToMemberOf', label: 'The recipient is a member of...' },
+    { value: 'SubjectContainsWords', label: 'Subject contains words...' },
+    { value: 'SubjectMatchesPatterns', label: 'Subject matches patterns...' },
+    { value: 'SubjectOrBodyContainsWords', label: 'Subject or body contains words...' },
+    { value: 'SubjectOrBodyMatchesPatterns', label: 'Subject or body matches patterns...' },
+    { value: 'FromAddressContainsWords', label: 'Sender address contains words...' },
+    { value: 'FromAddressMatchesPatterns', label: 'Sender address matches patterns...' },
+    { value: 'AttachmentContainsWords', label: 'Attachment content contains words...' },
+    { value: 'AttachmentMatchesPatterns', label: 'Attachment content matches patterns...' },
+    { value: 'AttachmentNameMatchesPatterns', label: 'Attachment name matches patterns...' },
+    { value: 'AttachmentPropertyContainsWords', label: 'Attachment properties contain words...' },
+    { value: 'AttachmentExtensionMatchesWords', label: 'Attachment extension is...' },
+    { value: 'AttachmentHasExecutableContent', label: 'Attachment has executable content' },
+    { value: 'AttachmentIsPasswordProtected', label: 'Attachment is password protected' },
+    { value: 'AttachmentIsUnsupported', label: 'Attachment type is unsupported' },
+    { value: 'AttachmentProcessingLimitExceeded', label: 'Attachment processing limit exceeded' },
+    { value: 'AttachmentSizeOver', label: 'Attachment size is greater than...' },
+    { value: 'MessageSizeOver', label: 'Message size is greater than...' },
+    { value: 'SCLOver', label: 'SCL is greater than or equal to...' },
+    { value: 'WithImportance', label: 'Message importance is...' },
+    { value: 'MessageTypeMatches', label: 'Message type is...' },
+    { value: 'SenderDomainIs', label: 'Sender domain is...' },
+    { value: 'RecipientDomainIs', label: 'Recipient domain is...' },
+    { value: 'SenderIpRanges', label: 'Sender IP address belongs to any of these ranges...' },
+    { value: 'HeaderContainsWords', label: 'Message header contains words...' },
+    { value: 'HeaderMatchesPatterns', label: 'Message header matches patterns...' },
+    { value: 'AnyOfToHeader', label: 'Any To header contains...' },
+    { value: 'AnyOfToHeaderMemberOf', label: 'Any To header is a member of...' },
+    { value: 'AnyOfCcHeader', label: 'Any Cc header contains...' },
+    { value: 'AnyOfCcHeaderMemberOf', label: 'Any Cc header is a member of...' },
+    { value: 'AnyOfToCcHeader', label: 'Any To or Cc header contains...' },
+    { value: 'AnyOfToCcHeaderMemberOf', label: 'Any To or Cc header is a member of...' },
+    { value: 'RecipientAddressContainsWords', label: 'Recipient address contains words...' },
+    { value: 'RecipientAddressMatchesPatterns', label: 'Recipient address matches patterns...' },
+    {
+      value: 'AnyOfRecipientAddressContainsWords',
+      label: 'Any recipient address contains words...',
+    },
+    {
+      value: 'AnyOfRecipientAddressMatchesPatterns',
+      label: 'Any recipient address matches patterns...',
+    },
+  ]
 
   // Action options
   const actionOptions = [
-    { value: "DeleteMessage", label: "Delete the message without notifying anyone" },
-    { value: "Quarantine", label: "Quarantine the message" },
-    { value: "RedirectMessageTo", label: "Redirect the message to..." },
-    { value: "RouteMessageOutboundConnector", label: "Route the message using the connector named..." },
-    { value: "BlindCopyTo", label: "Add recipients to the Bcc box..." },
-    { value: "CopyTo", label: "Add recipients to the Cc box..." },
-    { value: "ModerateMessageByUser", label: "Forward the message for approval to..." },
-    { value: "ModerateMessageByManager", label: "Forward the message for approval to the sender's manager" },
-    { value: "RejectMessage", label: "Reject the message with explanation..." },
-    { value: "PrependSubject", label: "Prepend the subject with..." },
-    { value: "SetSCL", label: "Set spam confidence level (SCL) to..." },
-    { value: "SetHeader", label: "Set message header..." },
-    { value: "RemoveHeader", label: "Remove message header..." },
-    { value: "ApplyClassification", label: "Apply message classification..." },
-    { value: "ApplyHtmlDisclaimer", label: "Apply HTML disclaimer..." },
-    { value: "GenerateIncidentReport", label: "Generate incident report and send to..." },
-    { value: "GenerateNotification", label: "Notify the sender with a message..." },
-    { value: "ApplyOME", label: "Apply Office 365 Message Encryption" },
-  ];
+    { value: 'DeleteMessage', label: 'Delete the message without notifying anyone' },
+    { value: 'Quarantine', label: 'Quarantine the message' },
+    { value: 'RedirectMessageTo', label: 'Redirect the message to...' },
+    {
+      value: 'RouteMessageOutboundConnector',
+      label: 'Route the message using the connector named...',
+    },
+    { value: 'BlindCopyTo', label: 'Add recipients to the Bcc box...' },
+    { value: 'CopyTo', label: 'Add recipients to the Cc box...' },
+    { value: 'ModerateMessageByUser', label: 'Forward the message for approval to...' },
+    {
+      value: 'ModerateMessageByManager',
+      label: "Forward the message for approval to the sender's manager",
+    },
+    { value: 'RejectMessage', label: 'Reject the message with explanation...' },
+    { value: 'PrependSubject', label: 'Prepend the subject with...' },
+    { value: 'SetSCL', label: 'Set spam confidence level (SCL) to...' },
+    { value: 'SetHeader', label: 'Set message header...' },
+    { value: 'RemoveHeader', label: 'Remove message header...' },
+    { value: 'ApplyClassification', label: 'Apply message classification...' },
+    { value: 'ApplyHtmlDisclaimer', label: 'Apply HTML disclaimer...' },
+    { value: 'GenerateIncidentReport', label: 'Generate incident report and send to...' },
+    { value: 'GenerateNotification', label: 'Notify the sender with a message...' },
+    { value: 'ApplyOME', label: 'Apply Office 365 Message Encryption' },
+  ]
   const incidentReportContentOptions = [
-    { value: "Sender", label: "Sender" },
-    { value: "Recipients", label: "Recipients" },
-    { value: "Subject", label: "Subject" },
-    { value: "CC", label: "CC" },
-    { value: "BCC", label: "BCC" },
-    { value: "Severity", label: "Severity" },
-    { value: "RuleDetections", label: "RuleDetections" },
-    { value: "FalsePositive", label: "FalsePositive" },
-    { value: "IdMatch", label: "IdMatch" },
-    { value: "AttachOriginalMail", label: "AttachOriginalMail" },
-  ];
+    { value: 'Sender', label: 'Sender' },
+    { value: 'Recipients', label: 'Recipients' },
+    { value: 'Subject', label: 'Subject' },
+    { value: 'CC', label: 'CC' },
+    { value: 'BCC', label: 'BCC' },
+    { value: 'Severity', label: 'Severity' },
+    { value: 'RuleDetections', label: 'RuleDetections' },
+    { value: 'FalsePositive', label: 'FalsePositive' },
+    { value: 'IdMatch', label: 'IdMatch' },
+    { value: 'AttachOriginalMail', label: 'AttachOriginalMail' },
+  ]
 
   const renderConditionField = (condition) => {
-    const conditionValue = condition.value || condition;
-    const conditionLabel = condition.label || condition;
+    const conditionValue = condition.value || condition
+    const conditionLabel = condition.label || condition
 
     switch (conditionValue) {
-      case "From":
-      case "SentTo":
-      case "AnyOfToHeader":
-      case "AnyOfCcHeader":
-      case "AnyOfToCcHeader":
+      case 'From':
+      case 'SentTo':
+      case 'AnyOfToHeader':
+      case 'AnyOfCcHeader':
+      case 'AnyOfToCcHeader':
         return (
           <Grid size={12} key={conditionValue}>
             <CippFormComponent
@@ -789,27 +891,27 @@ export const CippTransportRuleDrawer = ({
               multiple={true}
               creatable={true}
               api={{
-                url: "/api/ListGraphRequest",
+                url: '/api/ListGraphRequest',
                 queryKey: `Users-TransportRules-${currentTenant}`,
                 data: {
-                  Endpoint: "users",
+                  Endpoint: 'users',
                   tenantFilter: currentTenant,
-                  $select: "id,displayName,userPrincipalName",
+                  $select: 'id,displayName,userPrincipalName',
                   $top: 999,
                 },
                 labelField: (option) => `${option.displayName} (${option.userPrincipalName})`,
-                valueField: "userPrincipalName",
-                dataKey: "Results",
+                valueField: 'userPrincipalName',
+                dataKey: 'Results',
               }}
             />
           </Grid>
-        );
+        )
 
-      case "FromMemberOf":
-      case "SentToMemberOf":
-      case "AnyOfToHeaderMemberOf":
-      case "AnyOfCcHeaderMemberOf":
-      case "AnyOfToCcHeaderMemberOf":
+      case 'FromMemberOf':
+      case 'SentToMemberOf':
+      case 'AnyOfToHeaderMemberOf':
+      case 'AnyOfCcHeaderMemberOf':
+      case 'AnyOfToCcHeaderMemberOf':
         return (
           <Grid size={12} key={conditionValue}>
             <CippFormComponent
@@ -820,24 +922,25 @@ export const CippTransportRuleDrawer = ({
               multiple={true}
               creatable={true}
               api={{
-                url: "/api/ListGraphRequest",
+                url: '/api/ListGraphRequest',
                 queryKey: `Groups-TransportRules-${currentTenant}`,
                 data: {
-                  Endpoint: "groups",
+                  Endpoint: 'groups',
                   tenantFilter: currentTenant,
-                  $select: "id,displayName,mail",
+                  $select: 'id,displayName,mail',
                   $top: 999,
                 },
-                labelField: (option) => `${option.displayName}${option.mail ? ` (${option.mail})` : ''}`,
-                valueField: "mail",
-                dataKey: "Results",
+                labelField: (option) =>
+                  `${option.displayName}${option.mail ? ` (${option.mail})` : ''}`,
+                valueField: 'mail',
+                dataKey: 'Results',
               }}
             />
           </Grid>
-        );
+        )
 
-      case "FromScope":
-      case "SentToScope":
+      case 'FromScope':
+      case 'SentToScope':
         return (
           <Grid size={12} key={conditionValue}>
             <CippFormComponent
@@ -848,14 +951,14 @@ export const CippTransportRuleDrawer = ({
               creatable={false}
               multiple={false}
               options={[
-                { value: "InOrganization", label: "Inside the organization" },
-                { value: "NotInOrganization", label: "Outside the organization" },
+                { value: 'InOrganization', label: 'Inside the organization' },
+                { value: 'NotInOrganization', label: 'Outside the organization' },
               ]}
             />
           </Grid>
-        );
+        )
 
-      case "WithImportance":
+      case 'WithImportance':
         return (
           <Grid size={12} key={conditionValue}>
             <CippFormComponent
@@ -866,15 +969,15 @@ export const CippTransportRuleDrawer = ({
               multiple={false}
               formControl={formControl}
               options={[
-                { value: "Low", label: "Low" },
-                { value: "Normal", label: "Normal" },
-                { value: "High", label: "High" },
+                { value: 'Low', label: 'Low' },
+                { value: 'Normal', label: 'Normal' },
+                { value: 'High', label: 'High' },
               ]}
             />
           </Grid>
-        );
+        )
 
-      case "MessageTypeMatches":
+      case 'MessageTypeMatches':
         return (
           <Grid size={12} key={conditionValue}>
             <CippFormComponent
@@ -885,21 +988,21 @@ export const CippTransportRuleDrawer = ({
               multiple={false}
               formControl={formControl}
               options={[
-                { value: "OOF", label: "Automatic reply (OOF)" },
-                { value: "AutoForward", label: "Auto-forward" },
-                { value: "Encrypted", label: "Encrypted" },
-                { value: "Calendaring", label: "Calendaring" },
-                { value: "PermissionControlled", label: "Permission controlled" },
-                { value: "Voicemail", label: "Voicemail" },
-                { value: "Signed", label: "Signed" },
-                { value: "ApprovalRequest", label: "Approval request" },
-                { value: "ReadReceipt", label: "Read receipt" },
+                { value: 'OOF', label: 'Automatic reply (OOF)' },
+                { value: 'AutoForward', label: 'Auto-forward' },
+                { value: 'Encrypted', label: 'Encrypted' },
+                { value: 'Calendaring', label: 'Calendaring' },
+                { value: 'PermissionControlled', label: 'Permission controlled' },
+                { value: 'Voicemail', label: 'Voicemail' },
+                { value: 'Signed', label: 'Signed' },
+                { value: 'ApprovalRequest', label: 'Approval request' },
+                { value: 'ReadReceipt', label: 'Read receipt' },
               ]}
             />
           </Grid>
-        );
+        )
 
-      case "SCLOver":
+      case 'SCLOver':
         return (
           <Grid size={12} key={conditionValue}>
             <CippFormComponent
@@ -915,10 +1018,10 @@ export const CippTransportRuleDrawer = ({
               }))}
             />
           </Grid>
-        );
+        )
 
-      case "AttachmentSizeOver":
-      case "MessageSizeOver":
+      case 'AttachmentSizeOver':
+      case 'MessageSizeOver':
         return (
           <Grid size={12} key={conditionValue}>
             <CippFormComponent
@@ -930,12 +1033,12 @@ export const CippTransportRuleDrawer = ({
               placeholder="Enter size in bytes"
             />
           </Grid>
-        );
+        )
 
-      case "AttachmentHasExecutableContent":
-      case "AttachmentIsPasswordProtected":
-      case "AttachmentIsUnsupported":
-      case "AttachmentProcessingLimitExceeded":
+      case 'AttachmentHasExecutableContent':
+      case 'AttachmentIsPasswordProtected':
+      case 'AttachmentIsUnsupported':
+      case 'AttachmentProcessingLimitExceeded':
         return (
           <Grid size={12} key={conditionValue}>
             <CippFormComponent
@@ -945,10 +1048,10 @@ export const CippTransportRuleDrawer = ({
               formControl={formControl}
             />
           </Grid>
-        );
+        )
 
-      case "AttachmentNameMatchesPatterns":
-      case "AttachmentPropertyContainsWords":
+      case 'AttachmentNameMatchesPatterns':
+      case 'AttachmentPropertyContainsWords':
         return (
           <Grid size={12} key={conditionValue}>
             <CippFormComponent
@@ -959,10 +1062,10 @@ export const CippTransportRuleDrawer = ({
               placeholder="Enter comma-separated values"
             />
           </Grid>
-        );
+        )
 
-      case "SenderDomainIs":
-      case "RecipientDomainIs":
+      case 'SenderDomainIs':
+      case 'RecipientDomainIs':
         return (
           <Grid size={12} key={conditionValue}>
             <CippFormDomainSelector
@@ -972,9 +1075,9 @@ export const CippTransportRuleDrawer = ({
               formControl={formControl}
             />
           </Grid>
-        );
+        )
 
-      case "SenderIpRanges":
+      case 'SenderIpRanges':
         return (
           <Grid size={12} key={conditionValue}>
             <CippFormComponent
@@ -988,10 +1091,10 @@ export const CippTransportRuleDrawer = ({
               placeholder="Enter IP addresses or CIDR ranges (e.g., 192.168.1.1 or 10.0.0.0/24)"
             />
           </Grid>
-        );
+        )
 
-      case "HeaderContainsWords":
-      case "HeaderMatchesPatterns":
+      case 'HeaderContainsWords':
+      case 'HeaderMatchesPatterns':
         return (
           <Grid size={12} key={conditionValue}>
             <Grid container spacing={2}>
@@ -1015,7 +1118,7 @@ export const CippTransportRuleDrawer = ({
               </Grid>
             </Grid>
           </Grid>
-        );
+        )
 
       default:
         return (
@@ -1028,19 +1131,19 @@ export const CippTransportRuleDrawer = ({
               placeholder="Enter comma-separated values"
             />
           </Grid>
-        );
+        )
     }
-  };
+  }
 
   const renderActionField = (action) => {
-    const actionValue = action.value || action;
-    const actionLabel = action.label || action;
+    const actionValue = action.value || action
+    const actionLabel = action.label || action
 
     switch (actionValue) {
-      case "DeleteMessage":
-      case "Quarantine":
-      case "ModerateMessageByManager":
-      case "ApplyOME":
+      case 'DeleteMessage':
+      case 'Quarantine':
+      case 'ModerateMessageByManager':
+      case 'ApplyOME':
         return (
           <Grid size={12} key={actionValue}>
             <CippFormComponent
@@ -1050,12 +1153,12 @@ export const CippTransportRuleDrawer = ({
               formControl={formControl}
             />
           </Grid>
-        );
+        )
 
-      case "RedirectMessageTo":
-      case "BlindCopyTo":
-      case "CopyTo":
-      case "ModerateMessageByUser":
+      case 'RedirectMessageTo':
+      case 'BlindCopyTo':
+      case 'CopyTo':
+      case 'ModerateMessageByUser':
         return (
           <Grid size={12} key={actionValue}>
             <CippFormComponent
@@ -1065,23 +1168,23 @@ export const CippTransportRuleDrawer = ({
               formControl={formControl}
               multiple={true}
               api={{
-                url: "/api/ListGraphRequest",
+                url: '/api/ListGraphRequest',
                 queryKey: `Users-TransportRules-${currentTenant}`,
                 data: {
-                  Endpoint: "users",
+                  Endpoint: 'users',
                   tenantFilter: currentTenant,
-                  $select: "id,displayName,userPrincipalName",
+                  $select: 'id,displayName,userPrincipalName',
                   $top: 999,
                 },
                 labelField: (option) => `${option.displayName} (${option.userPrincipalName})`,
-                valueField: "userPrincipalName",
-                dataKey: "Results",
+                valueField: 'userPrincipalName',
+                dataKey: 'Results',
               }}
             />
           </Grid>
-        );
+        )
 
-      case "GenerateIncidentReport":
+      case 'GenerateIncidentReport':
         return (
           <Grid size={12} key={actionValue}>
             <Grid container spacing={2}>
@@ -1093,17 +1196,17 @@ export const CippTransportRuleDrawer = ({
                   formControl={formControl}
                   multiple={false}
                   api={{
-                    url: "/api/ListGraphRequest",
+                    url: '/api/ListGraphRequest',
                     queryKey: `Users-TransportRules-${currentTenant}`,
                     data: {
-                      Endpoint: "users",
+                      Endpoint: 'users',
                       tenantFilter: currentTenant,
-                      $select: "id,displayName,userPrincipalName",
+                      $select: 'id,displayName,userPrincipalName',
                       $top: 999,
                     },
                     labelField: (option) => `${option.displayName} (${option.userPrincipalName})`,
-                    valueField: "userPrincipalName",
-                    dataKey: "Results",
+                    valueField: 'userPrincipalName',
+                    dataKey: 'Results',
                   }}
                 />
               </Grid>
@@ -1120,9 +1223,9 @@ export const CippTransportRuleDrawer = ({
               </Grid>
             </Grid>
           </Grid>
-        );
+        )
 
-      case "RouteMessageOutboundConnector":
+      case 'RouteMessageOutboundConnector':
         return (
           <Grid size={12} key={actionValue}>
             <CippFormComponent
@@ -1133,18 +1236,19 @@ export const CippTransportRuleDrawer = ({
               multiple={false}
               creatable={false}
               api={{
-                url: "/api/ListExchangeConnectors",
+                url: '/api/ListExchangeConnectors',
+                dataKey: 'Results',
                 queryKey: `exchangeConnectors-${currentTenant}`,
                 labelField: (option) => `${option.Name}`,
-                valueField: "Name",
+                valueField: 'Name',
                 dataFilter: (options) =>
-                  options.filter((option) => option.rawData?.cippconnectortype === "outbound"),
+                  options.filter((option) => option.rawData?.cippconnectortype === 'outbound'),
               }}
             />
           </Grid>
-        );
+        )
 
-      case "SetSCL":
+      case 'SetSCL':
         return (
           <Grid size={12} key={actionValue}>
             <CippFormComponent
@@ -1153,7 +1257,7 @@ export const CippTransportRuleDrawer = ({
               name={actionValue}
               formControl={formControl}
               options={[
-                { value: "-1", label: "-1 (Bypass spam filtering)" },
+                { value: '-1', label: '-1 (Bypass spam filtering)' },
                 ...Array.from({ length: 10 }, (_, i) => ({
                   value: i.toString(),
                   label: i.toString(),
@@ -1161,9 +1265,9 @@ export const CippTransportRuleDrawer = ({
               ]}
             />
           </Grid>
-        );
+        )
 
-      case "RejectMessage":
+      case 'RejectMessage':
         return (
           <Grid size={12} key={actionValue}>
             <Grid container spacing={2}>
@@ -1189,9 +1293,9 @@ export const CippTransportRuleDrawer = ({
               </Grid>
             </Grid>
           </Grid>
-        );
+        )
 
-      case "SetHeader":
+      case 'SetHeader':
         return (
           <Grid size={12} key={actionValue}>
             <Grid container spacing={2}>
@@ -1215,9 +1319,9 @@ export const CippTransportRuleDrawer = ({
               </Grid>
             </Grid>
           </Grid>
-        );
+        )
 
-      case "RemoveHeader":
+      case 'RemoveHeader':
         return (
           <Grid size={12} key={actionValue}>
             <CippFormComponent
@@ -1228,9 +1332,9 @@ export const CippTransportRuleDrawer = ({
               placeholder="X-Header-To-Remove"
             />
           </Grid>
-        );
+        )
 
-      case "ApplyHtmlDisclaimer":
+      case 'ApplyHtmlDisclaimer':
         return (
           <Grid size={12} key={actionValue}>
             <Grid container spacing={2}>
@@ -1252,8 +1356,8 @@ export const CippTransportRuleDrawer = ({
                   name="ApplyHtmlDisclaimerLocation"
                   formControl={formControl}
                   options={[
-                    { value: "Append", label: "Append (bottom)" },
-                    { value: "Prepend", label: "Prepend (top)" },
+                    { value: 'Append', label: 'Append (bottom)' },
+                    { value: 'Prepend', label: 'Prepend (top)' },
                   ]}
                 />
               </Grid>
@@ -1264,19 +1368,19 @@ export const CippTransportRuleDrawer = ({
                   name="ApplyHtmlDisclaimerFallbackAction"
                   formControl={formControl}
                   options={[
-                    { value: "Wrap", label: "Wrap message" },
-                    { value: "Ignore", label: "Ignore and send" },
-                    { value: "Reject", label: "Reject message" },
+                    { value: 'Wrap', label: 'Wrap message' },
+                    { value: 'Ignore', label: 'Ignore and send' },
+                    { value: 'Reject', label: 'Reject message' },
                   ]}
                 />
               </Grid>
             </Grid>
           </Grid>
-        );
+        )
 
-      case "PrependSubject":
-      case "ApplyClassification":
-      case "GenerateNotification":
+      case 'PrependSubject':
+      case 'ApplyClassification':
+      case 'GenerateNotification':
         return (
           <Grid size={12} key={actionValue}>
             <CippFormComponent
@@ -1289,7 +1393,7 @@ export const CippTransportRuleDrawer = ({
               placeholder={`Enter ${actionLabel.toLowerCase()}`}
             />
           </Grid>
-        );
+        )
 
       default:
         return (
@@ -1301,17 +1405,17 @@ export const CippTransportRuleDrawer = ({
               formControl={formControl}
             />
           </Grid>
-        );
+        )
     }
-  };
+  }
 
   const renderExceptionField = (exception) => {
-    const exceptionValue = exception.value || exception;
-    const baseCondition = exceptionValue.replace("ExceptIf", "");
-    const exceptionLabel = exception.label || exception;
+    const exceptionValue = exception.value || exception
+    const baseCondition = exceptionValue.replace('ExceptIf', '')
+    const exceptionLabel = exception.label || exception
 
-    const mockCondition = { value: baseCondition, label: exceptionLabel };
-    const field = renderConditionField(mockCondition);
+    const mockCondition = { value: baseCondition, label: exceptionLabel }
+    const field = renderConditionField(mockCondition)
 
     if (field) {
       return cloneElement(field, {
@@ -1320,66 +1424,70 @@ export const CippTransportRuleDrawer = ({
           if (child?.type === CippFormComponent) {
             return cloneElement(child, {
               name: exceptionValue,
-            });
+            })
           }
           if (child?.type === Grid && child.props.container) {
             return cloneElement(child, {
               children: React.Children.map(child.props.children, (gridChild) => {
                 if (gridChild?.props?.children?.type === CippFormComponent) {
-                  const formComponent = gridChild.props.children;
-                  const originalName = formComponent.props.name;
-                  const newName = originalName.includes("MessageHeader")
+                  const formComponent = gridChild.props.children
+                  const originalName = formComponent.props.name
+                  const newName = originalName.includes('MessageHeader')
                     ? `ExceptIf${originalName}`
-                    : exceptionValue;
+                    : exceptionValue
                   return cloneElement(gridChild, {
                     children: cloneElement(formComponent, {
                       name: newName,
                     }),
-                  });
+                  })
                 }
-                return gridChild;
+                return gridChild
               }),
-            });
+            })
           }
-          return child;
+          return child
         }),
-      });
+      })
     }
-    return null;
-  };
+    return null
+  }
 
   const handleSubmit = () => {
-    formControl.trigger();
-    const formData = formControl.getValues();
-    const apiData = customDataFormatter(formData);
+    formControl.trigger()
+    const formData = formControl.getValues()
+    const apiData = customDataFormatter(formData)
 
     submitRule.mutate({
-      url: "/api/AddEditTransportRule",
+      url: '/api/AddEditTransportRule',
       data: apiData,
-    });
-  };
+    })
+  }
 
   const handleCloseDrawer = () => {
-    setDrawerVisible(false);
-    formControl.reset(defaultFormValues);
-    setSelectedConditions([]);
-    setSelectedActions([]);
-    setSelectedExceptions([]);
-  };
+    setDrawerVisible(false)
+    formControl.reset(defaultFormValues)
+    setSelectedConditions([])
+    setSelectedActions([])
+    setSelectedExceptions([])
+  }
 
-  const rule = ruleInfo.data?.Results 
-    ? (Array.isArray(ruleInfo.data.Results) ? ruleInfo.data.Results[0] : ruleInfo.data.Results)
-    : (Array.isArray(ruleInfo.data) ? ruleInfo.data[0] : ruleInfo.data);
+  const rule = ruleInfo.data?.Results
+    ? Array.isArray(ruleInfo.data.Results)
+      ? ruleInfo.data.Results[0]
+      : ruleInfo.data.Results
+    : Array.isArray(ruleInfo.data)
+      ? ruleInfo.data[0]
+      : ruleInfo.data
 
-  const queryClient = useQueryClient();
+  const queryClient = useQueryClient()
 
   useEffect(() => {
     if (submitRule.isSuccess) {
-      queryClient.invalidateQueries({ queryKey: [`ListTransportRules-${ruleId}`]});
-      queryClient.invalidateQueries({ queryKey: [`Transport Rules - ${currentTenant}`]});
-      onSuccess();
+      queryClient.invalidateQueries({ queryKey: [`ListTransportRules-${ruleId}`] })
+      queryClient.invalidateQueries({ queryKey: [`Transport Rules - ${currentTenant}`] })
+      onSuccess()
     }
-  }, [submitRule.isSuccess, queryClient, ruleId, currentTenant, onSuccess]);
+  }, [submitRule.isSuccess, queryClient, ruleId, currentTenant, onSuccess])
 
   return (
     <>
@@ -1393,20 +1501,20 @@ export const CippTransportRuleDrawer = ({
         </PermissionButton>
       )}
       <CippOffCanvas
-        title={isEditMode ? `Edit Rule: ${rule?.Name || ""}` : "New Transport Rule"}
+        title={isEditMode ? `Edit Rule: ${rule?.Name || ''}` : 'New Transport Rule'}
         visible={drawerVisible}
         onClose={handleCloseDrawer}
         size="xl"
         footer={
-          <div style={{ display: "flex", gap: "8px", justifyContent: "flex-start" }}>
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleSubmit}
-            >
+          <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-start' }}>
+            <Button variant="contained" color="primary" onClick={handleSubmit}>
               {submitRule.isLoading
-                ? isEditMode ? "Updating..." : "Creating..."
-                : isEditMode ? "Update Rule" : "Create Rule"}
+                ? isEditMode
+                  ? 'Updating...'
+                  : 'Creating...'
+                : isEditMode
+                  ? 'Update Rule'
+                  : 'Create Rule'}
             </Button>
             <Button variant="outlined" onClick={handleCloseDrawer}>
               Cancel
@@ -1414,255 +1522,255 @@ export const CippTransportRuleDrawer = ({
           </div>
         }
       >
-          <Grid container spacing={2}>
-            {/* Basic Information */}
+        <Grid container spacing={2}>
+          {/* Basic Information */}
+          <Grid size={12}>
+            <Typography variant="h6" sx={{ mb: 2 }}>
+              Basic Information
+            </Typography>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <CippFormComponent
+              type="textField"
+              label="Rule Name"
+              name="Name"
+              formControl={formControl}
+              required
+              validators={{
+                required: 'Rule name is required',
+              }}
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <CippFormComponent
+              type="number"
+              label="Priority"
+              name="Priority"
+              required
+              formControl={formControl}
+              placeholder="0 (lowest priority)"
+            />
+          </Grid>
+
+          <Grid size={12}>
+            <CippFormComponent
+              type="textField"
+              label="Comments"
+              name="Comments"
+              formControl={formControl}
+              multiline
+              rows={2}
+              placeholder="Optional description of this rule"
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 4 }}>
+            <CippFormComponent
+              type="autoComplete"
+              label="Rule Mode"
+              name="Mode"
+              multiple={false}
+              formControl={formControl}
+              required
+              creatable={false}
+              options={[
+                { value: 'Enforce', label: 'Enforce' },
+                { value: 'AuditAndNotify', label: 'Test with Policy Tips' },
+                { value: 'Audit', label: 'Test without Policy Tips' },
+              ]}
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 4 }}>
+            <CippFormComponent
+              type="autoComplete"
+              label="Severity"
+              name="SetAuditSeverity"
+              multiple={false}
+              formControl={formControl}
+              creatable={false}
+              options={[
+                { value: 'Low', label: 'Low' },
+                { value: 'Medium', label: 'Medium' },
+                { value: 'High', label: 'High' },
+                { value: 'DoNotAudit', label: 'Do not audit' },
+              ]}
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 4 }}>
+            <CippFormComponent
+              type="switch"
+              label="Enable this rule"
+              name="Enabled"
+              formControl={formControl}
+            />
+          </Grid>
+
+          <Divider sx={{ my: 2, width: '100%' }} />
+
+          {/* Conditions */}
+          <Grid size={12}>
+            <Typography variant="h6" sx={{ mb: 1 }}>
+              Apply this rule if...
+            </Typography>
+          </Grid>
+
+          <Grid size={12}>
+            <CippFormComponent
+              type="switch"
+              label="Apply to all messages (no conditions)"
+              name="applyToAllMessages"
+              formControl={formControl}
+            />
+          </Grid>
+
+          {applyToAllMessagesWatch && (
             <Grid size={12}>
-              <Typography variant="h6" sx={{ mb: 2 }}>
-                Basic Information
-              </Typography>
+              <Alert severity="info">
+                This rule will apply to ALL inbound and outbound messages for the entire
+                organization.
+              </Alert>
             </Grid>
+          )}
 
-            <Grid size={{ xs: 12, md: 6 }}>
-              <CippFormComponent
-                type="textField"
-                label="Rule Name"
-                name="Name"
-                formControl={formControl}
-                required
-                validators={{
-                  required: "Rule name is required",
-                }}
-              />
-            </Grid>
-
-            <Grid size={{ xs: 12, md: 6 }}>
-              <CippFormComponent
-                type="number"
-                label="Priority"
-                name="Priority"
-                required
-                formControl={formControl}
-                placeholder="0 (lowest priority)"
-              />
-            </Grid>
-
-            <Grid size={12}>
-              <CippFormComponent
-                type="textField"
-                label="Comments"
-                name="Comments"
-                formControl={formControl}
-                multiline
-                rows={2}
-                placeholder="Optional description of this rule"
-              />
-            </Grid>
-
-            <Grid size={{ xs: 12, md: 4 }}>
-              <CippFormComponent
-                type="autoComplete"
-                label="Rule Mode"
-                name="Mode"
-                multiple={false}
-                formControl={formControl}
-                required
-                creatable={false}
-                options={[
-                  { value: "Enforce", label: "Enforce" },
-                  { value: "AuditAndNotify", label: "Test with Policy Tips" },
-                  { value: "Audit", label: "Test without Policy Tips" },
-                ]}
-              />
-            </Grid>
-
-            <Grid size={{ xs: 12, md: 4 }}>
-              <CippFormComponent
-                type="autoComplete"
-                label="Severity"
-                name="SetAuditSeverity"
-                multiple={false}
-                formControl={formControl}
-                creatable={false}
-                options={[
-                  { value: "Low", label: "Low" },
-                  { value: "Medium", label: "Medium" },
-                  { value: "High", label: "High" },
-                  { value: "DoNotAudit", label: "Do not audit" },
-                ]}
-              />
-            </Grid>
-
-            <Grid size={{ xs: 12, md: 4 }}>
-              <CippFormComponent
-                type="switch"
-                label="Enable this rule"
-                name="Enabled"
-                formControl={formControl}
-              />
-            </Grid>
-
-            <Divider sx={{ my: 2, width: "100%" }} />
-
-            {/* Conditions */}
-            <Grid size={12}>
-              <Typography variant="h6" sx={{ mb: 1 }}>
-                Apply this rule if...
-              </Typography>
-            </Grid>
-
-            <Grid size={12}>
-              <CippFormComponent
-                type="switch"
-                label="Apply to all messages (no conditions)"
-                name="applyToAllMessages"
-                formControl={formControl}
-              />
-            </Grid>
-
-            {applyToAllMessagesWatch && (
+          {!applyToAllMessagesWatch && (
+            <>
               <Grid size={12}>
-                <Alert severity="info">
-                  This rule will apply to ALL inbound and outbound messages
-                  for the entire organization.
+                <Alert severity="info" sx={{ mb: 2 }}>
+                  Select one or more conditions to target specific messages. If you want this rule
+                  to apply to all messages, enable "Apply to all messages" above.
                 </Alert>
               </Grid>
-            )}
 
-            {!applyToAllMessagesWatch && (
-              <>
-                <Grid size={12}>
-                  <Alert severity="info" sx={{ mb: 2 }}>
-                    Select one or more conditions to target specific messages. If you want this rule to
-                    apply to all messages, enable "Apply to all messages" above.
-                  </Alert>
-                </Grid>
+              <Grid size={12}>
+                <CippFormComponent
+                  type="autoComplete"
+                  label="Select condition types"
+                  name="conditionType"
+                  formControl={formControl}
+                  multiple={true}
+                  options={conditionOptions}
+                  disabled={applyToAllMessagesWatch}
+                  creatable={false}
+                />
+              </Grid>
 
-                <Grid size={12}>
-                  <CippFormComponent
-                    type="autoComplete"
-                    label="Select condition types"
-                    name="conditionType"
-                    formControl={formControl}
-                    multiple={true}
-                    options={conditionOptions}
-                    disabled={applyToAllMessagesWatch}
-                    creatable={false}
-                  />
-                </Grid>
+              {selectedConditions.map((condition) => renderConditionField(condition))}
+            </>
+          )}
 
-                {selectedConditions.map((condition) => renderConditionField(condition))}
-              </>
-            )}
+          <Divider sx={{ my: 2, width: '100%' }} />
 
-            <Divider sx={{ my: 2, width: "100%" }} />
-
-            {/* Actions */}
-            <Grid size={12}>
-              <Typography variant="h6" sx={{ mb: 1 }}>
-                Do the following...
-              </Typography>
-            </Grid>
-
-            <Grid size={12}>
-              <CippFormComponent
-                type="autoComplete"
-                label="Select action types"
-                name="actionType"
-                formControl={formControl}
-                multiple={true}
-                options={actionOptions}
-                required
-                creatable={false}
-                validators={{
-                  required: "At least one action must be selected",
-                }}
-              />
-            </Grid>
-
-            {selectedActions.map((action) => renderActionField(action))}
-
-            <Divider sx={{ my: 2, width: "100%" }} />
-
-            {/* Exceptions */}
-            <Grid size={12}>
-              <Typography variant="h6" sx={{ mb: 1 }}>
-                Except if... (optional)
-              </Typography>
-            </Grid>
-
-            <Grid size={12}>
-              <CippFormComponent
-                type="autoComplete"
-                label="Select exception types"
-                name="exceptionType"
-                formControl={formControl}
-                multiple={true}
-                creatable={false}
-                options={conditionOptions.map((opt) => ({
-                  value: `ExceptIf${opt.value}`,
-                  label: opt.label,
-                }))}
-              />
-            </Grid>
-
-            {selectedExceptions.map((exception) => renderExceptionField(exception))}
-
-            <Divider sx={{ my: 2, width: "100%" }} />
-
-            {/* Advanced Settings */}
-            <Grid size={12}>
-              <Typography variant="h6" sx={{ mb: 2 }}>
-                Advanced Settings
-              </Typography>
-            </Grid>
-
-            <Grid size={{ xs: 12, md: 6 }}>
-              <CippFormComponent
-                type="autoComplete"
-                label="Match sender address in message"
-                name="SenderAddressLocation"
-                multiple={false}
-                formControl={formControl}
-                required
-                creatable={false}
-                options={[
-                  { value: "Header", label: "Header" },
-                  { value: "Envelope", label: "Envelope" },
-                  { value: "HeaderOrEnvelope", label: "Header or Envelope" },
-                ]}
-              />
-            </Grid>
-
-            <Grid size={{ xs: 12, md: 6 }}>
-              <CippFormComponent
-                type="switch"
-                label="Stop processing more rules"
-                name="StopRuleProcessing"
-                formControl={formControl}
-              />
-            </Grid>
-
-            <Grid size={{ xs: 12, md: 6 }}>
-              <CippFormComponent
-                type="datePicker"
-                label="Activate this rule on (optional)"
-                name="ActivationDate"
-                formControl={formControl}
-              />
-            </Grid>
-
-            <Grid size={{ xs: 12, md: 6 }}>
-              <CippFormComponent
-                type="datePicker"
-                label="Deactivate this rule on (optional)"
-                name="ExpiryDate"
-                formControl={formControl}
-              />
-            </Grid>
-
-            <CippApiResults apiObject={submitRule} />
+          {/* Actions */}
+          <Grid size={12}>
+            <Typography variant="h6" sx={{ mb: 1 }}>
+              Do the following...
+            </Typography>
           </Grid>
+
+          <Grid size={12}>
+            <CippFormComponent
+              type="autoComplete"
+              label="Select action types"
+              name="actionType"
+              formControl={formControl}
+              multiple={true}
+              options={actionOptions}
+              required
+              creatable={false}
+              validators={{
+                required: 'At least one action must be selected',
+              }}
+            />
+          </Grid>
+
+          {selectedActions.map((action) => renderActionField(action))}
+
+          <Divider sx={{ my: 2, width: '100%' }} />
+
+          {/* Exceptions */}
+          <Grid size={12}>
+            <Typography variant="h6" sx={{ mb: 1 }}>
+              Except if... (optional)
+            </Typography>
+          </Grid>
+
+          <Grid size={12}>
+            <CippFormComponent
+              type="autoComplete"
+              label="Select exception types"
+              name="exceptionType"
+              formControl={formControl}
+              multiple={true}
+              creatable={false}
+              options={conditionOptions.map((opt) => ({
+                value: `ExceptIf${opt.value}`,
+                label: opt.label,
+              }))}
+            />
+          </Grid>
+
+          {selectedExceptions.map((exception) => renderExceptionField(exception))}
+
+          <Divider sx={{ my: 2, width: '100%' }} />
+
+          {/* Advanced Settings */}
+          <Grid size={12}>
+            <Typography variant="h6" sx={{ mb: 2 }}>
+              Advanced Settings
+            </Typography>
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <CippFormComponent
+              type="autoComplete"
+              label="Match sender address in message"
+              name="SenderAddressLocation"
+              multiple={false}
+              formControl={formControl}
+              required
+              creatable={false}
+              options={[
+                { value: 'Header', label: 'Header' },
+                { value: 'Envelope', label: 'Envelope' },
+                { value: 'HeaderOrEnvelope', label: 'Header or Envelope' },
+              ]}
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <CippFormComponent
+              type="switch"
+              label="Stop processing more rules"
+              name="StopRuleProcessing"
+              formControl={formControl}
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <CippFormComponent
+              type="datePicker"
+              label="Activate this rule on (optional)"
+              name="ActivationDate"
+              formControl={formControl}
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 6 }}>
+            <CippFormComponent
+              type="datePicker"
+              label="Deactivate this rule on (optional)"
+              name="ExpiryDate"
+              formControl={formControl}
+            />
+          </Grid>
+
+          <CippApiResults apiObject={submitRule} />
+        </Grid>
       </CippOffCanvas>
     </>
-  );
-};
+  )
+}

--- a/src/components/CippComponents/CippUserActions.jsx
+++ b/src/components/CippComponents/CippUserActions.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import { EyeIcon, MagnifyingGlassIcon, TrashIcon } from "@heroicons/react/24/outline";
+import { useEffect } from 'react'
+import { EyeIcon, MagnifyingGlassIcon, TrashIcon } from '@heroicons/react/24/outline'
 import {
   Archive,
   Clear,
@@ -20,69 +20,69 @@ import {
   Shortcut,
   EditAttributes,
   CloudSync,
-} from "@mui/icons-material";
-import { getCippLicenseTranslation } from "../../utils/get-cipp-license-translation";
-import { useSettings } from "../../hooks/use-settings.js";
-import { usePermissions } from "../../hooks/use-permissions";
-import { Tooltip, Box, Divider, Typography } from "@mui/material";
-import CippFormComponent from "./CippFormComponent";
-import { CippFormCondition } from "./CippFormCondition";
-import { useWatch } from "react-hook-form";
+} from '@mui/icons-material'
+import { getCippLicenseTranslation } from '../../utils/get-cipp-license-translation'
+import { useSettings } from '../../hooks/use-settings.js'
+import { usePermissions } from '../../hooks/use-permissions'
+import { Tooltip, Box, Divider, Typography } from '@mui/material'
+import CippFormComponent from './CippFormComponent'
+import { CippFormCondition } from './CippFormCondition'
+import { useWatch } from 'react-hook-form'
 
 // Separate component for Manage Licenses form to avoid hook issues
 const ManageLicensesForm = ({ formControl, tenant }) => {
   const licenseOperation = useWatch({
     control: formControl.control,
-    name: "LicenseOperation",
-  });
+    name: 'LicenseOperation',
+  })
 
   const removeAllLicenses = useWatch({
     control: formControl.control,
-    name: "RemoveAllLicenses",
-  });
+    name: 'RemoveAllLicenses',
+  })
 
   const replaceAllLicenses = useWatch({
     control: formControl.control,
-    name: "ReplaceAllLicenses",
-  });
+    name: 'ReplaceAllLicenses',
+  })
 
   // Handle both string values and object values with .value property
-  const licenseOpValue = licenseOperation?.value || licenseOperation;
-  
-  const isRemoveOperation = licenseOpValue === "Remove";
-  const isReplaceOperation = licenseOpValue === "Replace";
-  const showLicensesToRemove = isRemoveOperation && !removeAllLicenses;
-  const showLicensesToReplace = isReplaceOperation && !replaceAllLicenses;
+  const licenseOpValue = licenseOperation?.value || licenseOperation
+
+  const isRemoveOperation = licenseOpValue === 'Remove'
+  const isReplaceOperation = licenseOpValue === 'Replace'
+  const showLicensesToRemove = isRemoveOperation && !removeAllLicenses
+  const showLicensesToReplace = isReplaceOperation && !replaceAllLicenses
 
   // Clear fields when operation changes to prevent stale data submission
   useEffect(() => {
     if (licenseOpValue) {
       // Clear all license-related fields when switching operations
-      if (licenseOpValue === "Add") {
+      if (licenseOpValue === 'Add') {
         // Clear Remove/Replace specific fields
-        formControl.setValue("RemoveAllLicenses", false);
-        formControl.setValue("ReplaceAllLicenses", false);
-        formControl.setValue("LicensesToRemove", []);
-        formControl.setValue("LicensesToReplace", []);
-      } else if (licenseOpValue === "Remove") {
+        formControl.setValue('RemoveAllLicenses', false)
+        formControl.setValue('ReplaceAllLicenses', false)
+        formControl.setValue('LicensesToRemove', [])
+        formControl.setValue('LicensesToReplace', [])
+      } else if (licenseOpValue === 'Remove') {
         // Clear Add/Replace specific fields
-        formControl.setValue("ReplaceAllLicenses", false);
-        formControl.setValue("LicensesToReplace", []);
-        formControl.setValue("Licenses", []);
-      } else if (licenseOpValue === "Replace") {
+        formControl.setValue('ReplaceAllLicenses', false)
+        formControl.setValue('LicensesToReplace', [])
+        formControl.setValue('Licenses', [])
+      } else if (licenseOpValue === 'Replace') {
         // Clear Remove specific fields
-        formControl.setValue("RemoveAllLicenses", false);
-        formControl.setValue("LicensesToRemove", []);
+        formControl.setValue('RemoveAllLicenses', false)
+        formControl.setValue('LicensesToRemove', [])
       }
     }
-  }, [licenseOpValue, formControl]);
+  }, [licenseOpValue, formControl])
 
   // Clear LicensesToReplace when ReplaceAllLicenses is toggled
   useEffect(() => {
     if (isReplaceOperation && replaceAllLicenses) {
-      formControl.setValue("LicensesToReplace", []);
+      formControl.setValue('LicensesToReplace', [])
     }
-  }, [replaceAllLicenses, isReplaceOperation, formControl]);
+  }, [replaceAllLicenses, isReplaceOperation, formControl])
 
   return (
     <>
@@ -92,11 +92,11 @@ const ManageLicensesForm = ({ formControl, tenant }) => {
         label="License Operation"
         formControl={formControl}
         options={[
-          { label: "Add Licenses", value: "Add" },
-          { label: "Remove Licenses", value: "Remove" },
-          { label: "Replace Licenses", value: "Replace" },
+          { label: 'Add Licenses', value: 'Add' },
+          { label: 'Remove Licenses', value: 'Remove' },
+          { label: 'Replace Licenses', value: 'Replace' },
         ]}
-        validators={{ required: "Please select a license operation" }}
+        validators={{ required: 'Please select a license operation' }}
       />
 
       {isRemoveOperation && (
@@ -125,11 +125,11 @@ const ManageLicensesForm = ({ formControl, tenant }) => {
           multiple={true}
           creatable={false}
           formControl={formControl}
-          validators={{ required: "Please select at least one license to remove" }}
+          validators={{ required: 'Please select at least one license to remove' }}
           api={{
-            url: "/api/ListLicenses",
+            url: '/api/ListLicenses',
             labelField: (option) => option.displayName || option.skuPartNumber,
-            valueField: "skuId",
+            valueField: 'skuId',
             queryKey: `ListLicenses-${tenant}`,
           }}
         />
@@ -143,50 +143,50 @@ const ManageLicensesForm = ({ formControl, tenant }) => {
           multiple={true}
           creatable={false}
           formControl={formControl}
-          validators={{ required: "Please select at least one license to replace" }}
+          validators={{ required: 'Please select at least one license to replace' }}
           api={{
-            url: "/api/ListLicenses",
+            url: '/api/ListLicenses',
             labelField: (option) => option.displayName || option.skuPartNumber,
-            valueField: "skuId",
+            valueField: 'skuId',
             queryKey: `ListLicenses-${tenant}`,
           }}
         />
       )}
 
-      {(licenseOpValue === "Add" || isReplaceOperation) && (
+      {(licenseOpValue === 'Add' || isReplaceOperation) && (
         <CippFormComponent
           type="autoComplete"
           name="Licenses"
-          label={isReplaceOperation ? "Select New Licenses" : "Select Licenses"}
+          label={isReplaceOperation ? 'Select New Licenses' : 'Select Licenses'}
           multiple={true}
           creatable={false}
           formControl={formControl}
-          validators={{ required: "Please select at least one license" }}
+          validators={{ required: 'Please select at least one license' }}
           api={{
-            url: "/api/ListLicenses",
+            url: '/api/ListLicenses',
             labelField: (option) =>
               `${option.displayName || option.skuPartNumber} (${
                 option.availableUnits || 0
               } available)`,
-            valueField: "skuId",
+            valueField: 'skuId',
             queryKey: `ListLicenses-Available-${tenant}`,
           }}
         />
       )}
     </>
-  );
-};
+  )
+}
 
 // Separate component for Out of Office form to avoid hook issues
 const OutOfOfficeForm = ({ formControl }) => {
   // Watch the Auto Reply State value
   const autoReplyState = useWatch({
     control: formControl.control,
-    name: "AutoReplyState",
-  });
+    name: 'AutoReplyState',
+  })
 
   // Calculate if date fields should be disabled
-  const areDateFieldsDisabled = autoReplyState?.value !== "Scheduled";
+  const areDateFieldsDisabled = autoReplyState?.value !== 'Scheduled'
 
   return (
     <>
@@ -198,17 +198,17 @@ const OutOfOfficeForm = ({ formControl }) => {
         formControl={formControl}
         creatable={false}
         options={[
-          { label: "Enabled", value: "Enabled" },
-          { label: "Disabled", value: "Disabled" },
-          { label: "Scheduled", value: "Scheduled" },
+          { label: 'Enabled', value: 'Enabled' },
+          { label: 'Disabled', value: 'Disabled' },
+          { label: 'Scheduled', value: 'Scheduled' },
         ]}
       />
 
       <Tooltip
         title={
           areDateFieldsDisabled
-            ? "Scheduling is only available when Auto Reply State is set to Scheduled"
-            : ""
+            ? 'Scheduling is only available when Auto Reply State is set to Scheduled'
+            : ''
         }
         placement="bottom"
       >
@@ -226,8 +226,8 @@ const OutOfOfficeForm = ({ formControl }) => {
       <Tooltip
         title={
           areDateFieldsDisabled
-            ? "Scheduling is only available when Auto Reply State is set to Scheduled"
-            : ""
+            ? 'Scheduling is only available when Auto Reply State is set to Scheduled'
+            : ''
         }
         placement="bottom"
       >
@@ -316,78 +316,78 @@ const OutOfOfficeForm = ({ formControl }) => {
         </>
       )}
     </>
-  );
-};
+  )
+}
 
 export const useCippUserActions = () => {
-  const tenant = useSettings().currentTenant;
+  const tenant = useSettings().currentTenant
 
-  const { checkPermissions } = usePermissions();
-  const canWriteUser = checkPermissions(["Identity.User.ReadWrite"]);
-  const canWriteMailbox = checkPermissions(["Exchange.Mailbox.ReadWrite"]);
-  const canWriteGroup = checkPermissions(["Identity.Group.ReadWrite"]);
+  const { checkPermissions } = usePermissions()
+  const canWriteUser = checkPermissions(['Identity.User.ReadWrite'])
+  const canWriteMailbox = checkPermissions(['Exchange.Mailbox.ReadWrite'])
+  const canWriteGroup = checkPermissions(['Identity.Group.ReadWrite'])
 
   return [
     {
       //tested
-      label: "View User",
-      link: "/identity/administration/users/user?userId=[id]",
+      label: 'View User',
+      link: '/identity/administration/users/user?userId=[id]',
       multiPost: false,
       icon: <EyeIcon />,
-      color: "success",
+      color: 'success',
     },
     {
       //tested
-      label: "Edit User",
-      link: "/identity/administration/users/user/edit?userId=[id]",
+      label: 'Edit User',
+      link: '/identity/administration/users/user/edit?userId=[id]',
       icon: <Edit />,
-      color: "success",
-      target: "_self",
+      color: 'success',
+      target: '_self',
       condition: () => canWriteUser,
     },
     {
-      label: "Create Template from User",
-      type: "POST",
+      label: 'Create Template from User',
+      type: 'POST',
       icon: <ContentCopy />,
-      url: "/api/AddUserDefaults",
+      url: '/api/AddUserDefaults',
       fields: [
         {
-          type: "textField",
-          name: "templateName",
-          label: "Template Name",
-          validators: { required: "Please enter a template name" },
+          type: 'textField',
+          name: 'templateName',
+          label: 'Template Name',
+          validators: { required: 'Please enter a template name' },
         },
         {
-          type: "switch",
-          name: "defaultForTenant",
-          label: "Default for Tenant",
+          type: 'switch',
+          name: 'defaultForTenant',
+          label: 'Default for Tenant',
         },
       ],
       customDataformatter: (row, action, formData) => {
-        const user = Array.isArray(row) ? row[0] : row;
+        const user = Array.isArray(row) ? row[0] : row
         const licenses =
           user.assignedLicenses?.map((l) => ({
             label: getCippLicenseTranslation([l])?.[0] || l.skuId,
             value: l.skuId,
-          })) || [];
+          })) || []
         return {
           tenantFilter: tenant,
           templateName: formData.templateName,
           defaultForTenant: formData.defaultForTenant || false,
           sourceUserId: user.id,
-          jobTitle: user.jobTitle || "",
-          department: user.department || "",
-          streetAddress: user.streetAddress || "",
-          city: user.city || "",
-          state: user.state || "",
-          postalCode: user.postalCode || "",
-          country: user.country || "",
-          companyName: user.companyName || "",
-          mobilePhone: user.mobilePhone || "",
-          "businessPhones[0]": user.businessPhones?.[0] || "",
-          usageLocation: user.usageLocation || "",
+          jobTitle: user.jobTitle || '',
+          department: user.department || '',
+          streetAddress: user.streetAddress || '',
+          city: user.city || '',
+          state: user.state || '',
+          postalCode: user.postalCode || '',
+          country: user.country || '',
+          companyName: user.companyName || '',
+          mobilePhone: user.mobilePhone || '',
+          'businessPhones[0]': user.businessPhones?.[0] || '',
+          usageLocation: user.usageLocation || '',
           licenses: licenses,
-        };
+        }
       },
       confirmText:
         "Create a new user default template based on [displayName]'s properties (job title, department, location, licenses, and group memberships).",
@@ -396,151 +396,151 @@ export const useCippUserActions = () => {
     },
     {
       //tested
-      label: "Research Compromised Account",
-      type: "GET",
+      label: 'Research Compromised Account',
+      type: 'GET',
       icon: <MagnifyingGlassIcon />,
-      link: "/identity/administration/users/user/bec?userId=[id]",
+      link: '/identity/administration/users/user/bec?userId=[id]',
       confirmText:
-        "Are you sure you want to research if [userPrincipalName] is a compromised account?",
+        'Are you sure you want to research if [userPrincipalName] is a compromised account?',
       multiPost: false,
     },
     {
       //tested
-      label: "Create Temporary Access Password",
-      type: "POST",
+      label: 'Create Temporary Access Password',
+      type: 'POST',
       icon: <Password />,
-      url: "/api/ExecCreateTAP",
-      data: { ID: "userPrincipalName" },
+      url: '/api/ExecCreateTAP',
+      data: { ID: 'userPrincipalName' },
       fields: [
         {
-          type: "number",
-          name: "lifetimeInMinutes",
-          label: "Lifetime (Minutes)",
-          placeholder: "Leave blank for default",
+          type: 'number',
+          name: 'lifetimeInMinutes',
+          label: 'Lifetime (Minutes)',
+          placeholder: 'Leave blank for default',
         },
         {
-          type: "switch",
-          name: "isUsableOnce",
-          label: "One-time use only",
+          type: 'switch',
+          name: 'isUsableOnce',
+          label: 'One-time use only',
         },
         {
-          type: "datePicker",
-          name: "startDateTime",
-          label: "Start Date/Time (leave blank for immediate)",
-          dateTimeType: "datetime",
+          type: 'datePicker',
+          name: 'startDateTime',
+          label: 'Start Date/Time (leave blank for immediate)',
+          dateTimeType: 'datetime',
         },
       ],
       confirmText:
-        "Are you sure you want to create a Temporary Access Password for [userPrincipalName]?",
+        'Are you sure you want to create a Temporary Access Password for [userPrincipalName]?',
       multiPost: false,
       condition: () => canWriteUser,
     },
     {
       //tested
-      label: "Re-require MFA registration",
-      type: "POST",
+      label: 'Re-require MFA registration',
+      type: 'POST',
       icon: <PhonelinkSetup />,
-      url: "/api/ExecResetMFA",
-      data: { ID: "userPrincipalName" },
-      confirmText: "Are you sure you want to reset MFA for [userPrincipalName]?",
+      url: '/api/ExecResetMFA',
+      data: { ID: 'userPrincipalName' },
+      confirmText: 'Are you sure you want to reset MFA for [userPrincipalName]?',
       multiPost: false,
       condition: () => canWriteUser,
     },
     {
       //tested
-      label: "Send MFA Push",
-      type: "POST",
+      label: 'Send MFA Push',
+      type: 'POST',
       icon: <PhonelinkLock />,
-      url: "/api/ExecSendPush",
-      data: { UserEmail: "userPrincipalName" },
-      confirmText: "Are you sure you want to send an MFA request to [userPrincipalName]?",
+      url: '/api/ExecSendPush',
+      data: { UserEmail: 'userPrincipalName' },
+      confirmText: 'Are you sure you want to send an MFA request to [userPrincipalName]?',
       multiPost: false,
     },
     {
       //tested
-      label: "Set Per-User MFA",
-      type: "POST",
+      label: 'Set Per-User MFA',
+      type: 'POST',
       icon: <LockPerson />,
-      url: "/api/ExecPerUserMFA",
-      data: { userId: "id", userPrincipalName: "userPrincipalName" },
+      url: '/api/ExecPerUserMFA',
+      data: { userId: 'id', userPrincipalName: 'userPrincipalName' },
       fields: [
         {
-          type: "autoComplete",
-          name: "State",
-          label: "State",
+          type: 'autoComplete',
+          name: 'State',
+          label: 'State',
           options: [
-            { label: "Enforced", value: "Enforced" },
-            { label: "Enabled", value: "Enabled" },
-            { label: "Disabled", value: "Disabled" },
+            { label: 'Enforced', value: 'Enforced' },
+            { label: 'Enabled', value: 'Enabled' },
+            { label: 'Disabled', value: 'Disabled' },
           ],
           multiple: false,
           creatable: false,
-          validators: { required: "Please select an MFA state" },
+          validators: { required: 'Please select an MFA state' },
         },
       ],
-      confirmText: "Are you sure you want to set per-user MFA for these users?",
+      confirmText: 'Are you sure you want to set per-user MFA for these users?',
       multiPost: false,
       condition: () => canWriteUser,
     },
     {
       //tested
-      label: "Convert Mailbox",
-      type: "POST",
+      label: 'Convert Mailbox',
+      type: 'POST',
       icon: <Email />,
-      url: "/api/ExecConvertMailbox",
-      data: { ID: "userPrincipalName" },
+      url: '/api/ExecConvertMailbox',
+      data: { ID: 'userPrincipalName' },
       fields: [
         {
-          type: "radio",
-          name: "MailboxType",
-          label: "Mailbox Type",
+          type: 'radio',
+          name: 'MailboxType',
+          label: 'Mailbox Type',
           options: [
-            { label: "User Mailbox", value: "Regular" },
-            { label: "Shared Mailbox", value: "Shared" },
-            { label: "Room Mailbox", value: "Room" },
-            { label: "Equipment Mailbox", value: "Equipment" },
+            { label: 'User Mailbox', value: 'Regular' },
+            { label: 'Shared Mailbox', value: 'Shared' },
+            { label: 'Room Mailbox', value: 'Room' },
+            { label: 'Equipment Mailbox', value: 'Equipment' },
           ],
-          validators: { required: "Please select a mailbox type" },
+          validators: { required: 'Please select a mailbox type' },
         },
       ],
-      confirmText: "Pick the type of mailbox you want to convert [userPrincipalName] to:",
+      confirmText: 'Pick the type of mailbox you want to convert [userPrincipalName] to:',
       multiPost: false,
       condition: () => canWriteMailbox,
     },
     {
       //tested
-      label: "Enable Online Archive",
-      type: "POST",
+      label: 'Enable Online Archive',
+      type: 'POST',
       icon: <Archive />,
-      url: "/api/ExecEnableArchive",
-      data: { ID: "userPrincipalName" },
-      confirmText: "Are you sure you want to enable the online archive for [userPrincipalName]?",
+      url: '/api/ExecEnableArchive',
+      data: { ID: 'userPrincipalName' },
+      confirmText: 'Are you sure you want to enable the online archive for [userPrincipalName]?',
       multiPost: false,
       condition: (row) => canWriteMailbox,
     },
     {
       //tested
-      label: "Set Out of Office",
-      type: "POST",
+      label: 'Set Out of Office',
+      type: 'POST',
       icon: <MeetingRoom />,
-      url: "/api/ExecSetOoO",
+      url: '/api/ExecSetOoO',
       data: {
-        userId: "userPrincipalName",
-        tenantFilter: "Tenant",
+        userId: 'userPrincipalName',
+        tenantFilter: 'Tenant',
       },
       children: ({ formHook: formControl }) => <OutOfOfficeForm formControl={formControl} />,
-      confirmText: "Are you sure you want to set the out of office?",
+      confirmText: 'Are you sure you want to set the out of office?',
       multiPost: false,
       condition: () => canWriteMailbox,
     },
     {
-      label: "Add to Group",
-      type: "POST",
+      label: 'Add to Group',
+      type: 'POST',
       icon: <GroupAdd />,
-      url: "/api/EditGroup",
+      url: '/api/EditGroup',
       customDataformatter: (row, action, formData) => {
         // Build the member list from selected users
-        let addMember = [];
+        let addMember = []
         if (Array.isArray(row)) {
           row
             .map((r) => ({
@@ -552,7 +552,7 @@ export const useCippUserActions = () => {
                 displayName: r.displayName,
               },
             }))
-            .forEach((r) => addMember.push(r));
+            .forEach((r) => addMember.push(r))
         } else {
           addMember.push({
             label: row.displayName,
@@ -562,283 +562,284 @@ export const useCippUserActions = () => {
               userPrincipalName: row.userPrincipalName,
               displayName: row.displayName,
             },
-          });
+          })
         }
 
         // Handle multiple groups - return an array of requests (one per group)
         const selectedGroups = Array.isArray(formData.groupId)
           ? formData.groupId
-          : [formData.groupId];
+          : [formData.groupId]
 
         return selectedGroups.map((group) => ({
           addMember: addMember,
           tenantFilter: tenant,
           groupId: group,
-        }));
+        }))
       },
       fields: [
         {
-          type: "autoComplete",
-          name: "groupId",
-          label: "Select groups to add the user to",
+          type: 'autoComplete',
+          name: 'groupId',
+          label: 'Select groups to add the user to',
           multiple: true,
           creatable: false,
-          validators: { required: "Please select at least one group" },
+          validators: { required: 'Please select at least one group' },
           api: {
-            url: "/api/ListGroups",
+            url: '/api/ListGroups',
             labelField: (option) =>
               option?.calculatedGroupType
                 ? `${option.displayName} (${option.calculatedGroupType})`
-                : (option?.displayName ?? ""),
-            valueField: "id",
+                : (option?.displayName ?? ''),
+            valueField: 'id',
             addedField: {
-              groupType: "groupType",
-              groupName: "displayName",
+              groupType: 'groupType',
+              groupName: 'displayName',
             },
             queryKey: `groups-${tenant}`,
             showRefresh: true,
           },
         },
       ],
-      confirmText: "Are you sure you want to add [userPrincipalName] to the selected groups?",
+      confirmText: 'Are you sure you want to add [userPrincipalName] to the selected groups?',
       multiPost: false,
       allowResubmit: true,
       condition: () => canWriteGroup,
     },
     {
-      label: "Manage Licenses",
-      type: "POST",
-      url: "/api/ExecBulkLicense",
+      label: 'Manage Licenses',
+      type: 'POST',
+      url: '/api/ExecBulkLicense',
       icon: <CloudDone />,
-      data: { userIds: "id" },
+      data: { userIds: 'id' },
       multiPost: true,
       allowResubmit: true,
       children: ({ formHook: formControl }) => (
         <ManageLicensesForm formControl={formControl} tenant={tenant} />
       ),
-      confirmText: "Are you sure you want to manage licenses for the selected users?",
+      confirmText: 'Are you sure you want to manage licenses for the selected users?',
       condition: () => canWriteUser,
     },
     {
-      label: "Disable Email Forwarding",
-      type: "POST",
-      url: "/api/ExecEmailForward",
+      label: 'Disable Email Forwarding',
+      type: 'POST',
+      url: '/api/ExecEmailForward',
       icon: <ForwardToInbox />,
       data: {
-        username: "userPrincipalName",
-        userid: "userPrincipalName",
-        ForwardOption: "!disabled",
+        username: 'userPrincipalName',
+        userid: 'userPrincipalName',
+        ForwardOption: '!disabled',
       },
       confirmText: "Are you sure you want to disable forwarding of [userPrincipalName]'s emails?",
       multiPost: false,
       condition: () => canWriteMailbox,
     },
     {
-      label: "Pre-provision OneDrive",
-      type: "POST",
+      label: 'Pre-provision OneDrive',
+      type: 'POST',
       icon: <CloudDone />,
-      url: "/api/ExecOneDriveProvision",
-      data: { UserPrincipalName: "userPrincipalName" },
-      confirmText: "Are you sure you want to pre-provision OneDrive for [userPrincipalName]?",
+      url: '/api/ExecOneDriveProvision',
+      data: { UserPrincipalName: 'userPrincipalName' },
+      confirmText: 'Are you sure you want to pre-provision OneDrive for [userPrincipalName]?',
       multiPost: false,
       condition: () => canWriteUser,
     },
     {
-      label: "Add OneDrive Shortcut",
-      type: "POST",
+      label: 'Add OneDrive Shortcut',
+      type: 'POST',
       icon: <Shortcut />,
-      url: "/api/ExecOneDriveShortCut",
+      url: '/api/ExecOneDriveShortCut',
       data: {
-        username: "userPrincipalName",
-        userid: "id",
+        username: 'userPrincipalName',
+        userid: 'id',
       },
       fields: [
         {
-          type: "autoComplete",
-          name: "siteUrl",
-          label: "Select a Site",
+          type: 'autoComplete',
+          name: 'siteUrl',
+          label: 'Select a Site',
           multiple: false,
           creatable: true,
-          validators: { required: "Please select or enter a SharePoint site URL" },
+          validators: { required: 'Please select or enter a SharePoint site URL' },
           api: {
-            url: "/api/ListSites",
-            data: { type: "SharePointSiteUsage", URLOnly: true },
-            labelField: "webUrl",
-            valueField: "webUrl",
+            url: '/api/ListSites',
+            data: { type: 'SharePointSiteUsage', URLOnly: true },
+            labelField: 'webUrl',
+            valueField: 'webUrl',
+            dataKey: 'Results',
             queryKey: `sharepointSites-${tenant}`,
           },
         },
       ],
-      confirmText: "Select a SharePoint site to create a shortcut for:",
+      confirmText: 'Select a SharePoint site to create a shortcut for:',
       multiPost: false,
       condition: () => canWriteUser,
     },
     {
-      label: "Set Sign In State",
-      type: "POST",
+      label: 'Set Sign In State',
+      type: 'POST',
       icon: <LockPerson />,
-      url: "/api/ExecDisableUser",
-      data: { ID: "id" },
+      url: '/api/ExecDisableUser',
+      data: { ID: 'id' },
       fields: [
         {
-          type: "radio",
-          name: "Enable",
-          label: "Sign In State",
+          type: 'radio',
+          name: 'Enable',
+          label: 'Sign In State',
           options: [
-            { label: "Enabled", value: true },
-            { label: "Disabled", value: false },
+            { label: 'Enabled', value: true },
+            { label: 'Disabled', value: false },
           ],
-          validators: { required: "Please select a sign-in state" },
+          validators: { required: 'Please select a sign-in state' },
         },
       ],
-      confirmText: "Are you sure you want to set the sign-in state for [userPrincipalName]?",
+      confirmText: 'Are you sure you want to set the sign-in state for [userPrincipalName]?',
       multiPost: false,
       condition: () => canWriteUser,
     },
     {
-      label: "Reset Password",
-      type: "POST",
+      label: 'Reset Password',
+      type: 'POST',
       icon: <LockReset />,
-      url: "/api/ExecResetPass",
+      url: '/api/ExecResetPass',
       data: {
-        ID: "userPrincipalName",
-        displayName: "displayName",
+        ID: 'userPrincipalName',
+        displayName: 'displayName',
       },
       fields: [
         {
-          type: "switch",
-          name: "MustChange",
-          label: "Must Change Password at Next Logon",
+          type: 'switch',
+          name: 'MustChange',
+          label: 'Must Change Password at Next Logon',
         },
       ],
-      confirmText: "Are you sure you want to reset the password for [userPrincipalName]?",
+      confirmText: 'Are you sure you want to reset the password for [userPrincipalName]?',
       multiPost: false,
       condition: () => canWriteUser,
     },
     {
-      label: "Set Password Expiration",
-      type: "POST",
+      label: 'Set Password Expiration',
+      type: 'POST',
       icon: <LockClock />,
-      url: "/api/ExecPasswordNeverExpires",
-      data: { userId: "id", userPrincipalName: "userPrincipalName" },
+      url: '/api/ExecPasswordNeverExpires',
+      data: { userId: 'id', userPrincipalName: 'userPrincipalName' },
       fields: [
         {
-          type: "radio",
-          name: "PasswordPolicy",
-          label: "Password Policy",
+          type: 'radio',
+          name: 'PasswordPolicy',
+          label: 'Password Policy',
           options: [
-            { label: "Disable Password Expiration", value: "DisablePasswordExpiration" },
-            { label: "Enable Password Expiration", value: "None" },
+            { label: 'Disable Password Expiration', value: 'DisablePasswordExpiration' },
+            { label: 'Enable Password Expiration', value: 'None' },
           ],
-          validators: { required: "Please select a password policy" },
+          validators: { required: 'Please select a password policy' },
         },
       ],
       confirmText:
-        "Set Password Never Expires state for [userPrincipalName]. If the password of the user is older than the set expiration date of the organization, the user will be prompted to change their password at their next login.",
+        'Set Password Never Expires state for [userPrincipalName]. If the password of the user is older than the set expiration date of the organization, the user will be prompted to change their password at their next login.',
       multiPost: false,
       condition: () => canWriteUser,
     },
     {
-      label: "Clear Immutable ID",
-      type: "POST",
+      label: 'Clear Immutable ID',
+      type: 'POST',
       icon: <Clear />,
-      url: "/api/ExecClrImmId",
+      url: '/api/ExecClrImmId',
       data: {
-        ID: "id",
+        ID: 'id',
       },
-      confirmText: "Are you sure you want to clear the Immutable ID for [userPrincipalName]?",
+      confirmText: 'Are you sure you want to clear the Immutable ID for [userPrincipalName]?',
       multiPost: false,
       condition: (row) => !row?.onPremisesSyncEnabled && row?.onPremisesImmutableId && canWriteUser,
     },
     {
-      label: "Set Source of Authority",
-      type: "POST",
-      url: "/api/ExecSetCloudManaged",
+      label: 'Set Source of Authority',
+      type: 'POST',
+      url: '/api/ExecSetCloudManaged',
       icon: <CloudSync />,
       data: {
-        ID: "id",
-        displayName: "displayName",
-        type: "!User",
+        ID: 'id',
+        displayName: 'displayName',
+        type: '!User',
       },
       fields: [
         {
-          type: "radio",
-          name: "isCloudManaged",
-          label: "Source of Authority",
+          type: 'radio',
+          name: 'isCloudManaged',
+          label: 'Source of Authority',
           options: [
-            { label: "Cloud Managed", value: true },
-            { label: "On-Premises Managed", value: false },
+            { label: 'Cloud Managed', value: true },
+            { label: 'On-Premises Managed', value: false },
           ],
-          validators: { required: "Please select a source of authority" },
+          validators: { required: 'Please select a source of authority' },
         },
       ],
       confirmText:
-        "Are you sure you want to change the source of authority for [userPrincipalName]? Setting it to On-Premises Managed will take until the next sync cycle to show the change.",
+        'Are you sure you want to change the source of authority for [userPrincipalName]? Setting it to On-Premises Managed will take until the next sync cycle to show the change.',
       multiPost: false,
     },
     {
-      label: "Reprocess License Assignments",
-      type: "POST",
+      label: 'Reprocess License Assignments',
+      type: 'POST',
       icon: <CloudDone />,
-      url: "/api/ExecReprocessUserLicenses",
-      data: { ID: "id", userPrincipalName: "userPrincipalName" },
+      url: '/api/ExecReprocessUserLicenses',
+      data: { ID: 'id', userPrincipalName: 'userPrincipalName' },
       confirmText:
-        "Are you sure you want to reprocess license assignments for [userPrincipalName]?",
+        'Are you sure you want to reprocess license assignments for [userPrincipalName]?',
       multiPost: false,
       condition: (row) => canWriteUser,
     },
     {
-      label: "Revoke all user sessions",
-      type: "POST",
+      label: 'Revoke all user sessions',
+      type: 'POST',
       icon: <PersonOff />,
-      url: "/api/ExecRevokeSessions",
-      data: { ID: "id", Username: "userPrincipalName" },
-      confirmText: "Are you sure you want to revoke all sessions for [userPrincipalName]?",
+      url: '/api/ExecRevokeSessions',
+      data: { ID: 'id', Username: 'userPrincipalName' },
+      confirmText: 'Are you sure you want to revoke all sessions for [userPrincipalName]?',
       multiPost: false,
       condition: () => canWriteUser,
     },
     {
-      label: "Delete User",
-      type: "POST",
+      label: 'Delete User',
+      type: 'POST',
       icon: <TrashIcon />,
-      url: "/api/RemoveUser",
-      data: { ID: "id", userPrincipalName: "userPrincipalName" },
-      confirmText: "Are you sure you want to delete [userPrincipalName]?",
+      url: '/api/RemoveUser',
+      data: { ID: 'id', userPrincipalName: 'userPrincipalName' },
+      confirmText: 'Are you sure you want to delete [userPrincipalName]?',
       multiPost: false,
       condition: () => canWriteUser,
     },
     {
-      label: "Edit Properties",
+      label: 'Edit Properties',
       icon: <EditAttributes />,
       multiPost: true,
       noConfirm: true,
       customFunction: (users, action, formData) => {
         // Handle both single user and multiple users
-        const userData = Array.isArray(users) ? users : [users];
+        const userData = Array.isArray(users) ? users : [users]
 
         // Store users in session storage to avoid URL length limits
-        sessionStorage.setItem("patchWizardUsers", JSON.stringify(userData));
+        sessionStorage.setItem('patchWizardUsers', JSON.stringify(userData))
 
         // Use Next.js router for internal navigation
-        import("next/router")
+        import('next/router')
           .then(({ default: router }) => {
-            router.push("/identity/administration/users/patch-wizard");
+            router.push('/identity/administration/users/patch-wizard')
           })
           .catch(() => {
             // Fallback to window.location if router is not available
-            window.location.href = "/identity/administration/users/patch-wizard";
-          });
+            window.location.href = '/identity/administration/users/patch-wizard'
+          })
       },
       condition: () => canWriteUser,
     },
-  ];
-};
+  ]
+}
 
 // Legacy wrapper function for backward compatibility - but this should not be used
 // Instead, components should use the useCippUserActions hook
 export const CippUserActions = () => {
-  console.warn("CippUserActions() function is deprecated. Use useCippUserActions() hook instead.");
-  return useCippUserActions();
-};
+  console.warn('CippUserActions() function is deprecated. Use useCippUserActions() hook instead.')
+  return useCippUserActions()
+}
 
-export default CippUserActions;
+export default CippUserActions

--- a/src/pages/email/reports/SharedMailboxEnabledAccount/index.js
+++ b/src/pages/email/reports/SharedMailboxEnabledAccount/index.js
@@ -1,49 +1,51 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { Block } from "@mui/icons-material";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { Block } from '@mui/icons-material'
 
 const Page = () => {
   return (
     <CippTablePage
       title="Shared Mailbox with Enabled Account"
       apiUrl="/api/ListSharedMailboxAccountEnabled"
+      apiDataKey="Results"
       actions={[
         {
-          label: "Block Sign In",
-          type: "POST",
+          label: 'Block Sign In',
+          type: 'POST',
           icon: <Block />,
-          url: "/api/ExecDisableUser",
-          data: { ID: "id" },
-          confirmText: "Are you sure you want to block the sign-in for this mailbox?",
-          condition: (row) => row.accountEnabled && !row.onPremisesSyncEnabled,
+          url: '/api/ExecDisableUser',
+          data: { ID: 'id' },
+          confirmText: 'Are you sure you want to block the sign-in for this mailbox?',
+          condition: (row) => row?.accountEnabled && !row?.onPremisesSyncEnabled,
         },
       ]}
       offCanvas={{
         extendedInfoFields: [
-          "UserPrincipalName",
-          "displayName",
-          "accountEnabled",
-          "assignedLicenses",
-          "onPremisesSyncEnabled",
+          'UserPrincipalName',
+          'displayName',
+          'accountEnabled',
+          'assignedLicenses',
+          'onPremisesSyncEnabled',
         ],
       }}
       simpleColumns={[
-        "UserPrincipalName",
-        "displayName",
-        "accountEnabled",
-        "assignedLicenses",
-        "onPremisesSyncEnabled",
+        'Tenant',
+        'UserPrincipalName',
+        'displayName',
+        'accountEnabled',
+        'assignedLicenses',
+        'onPremisesSyncEnabled',
       ]}
       filters={[
         {
-          id: "accountEnabled",
-          value: "Yes",
+          id: 'accountEnabled',
+          value: 'Yes',
         },
       ]}
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout allTenantsSupport={false}>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/email/reports/antiphishing-filters/index.js
+++ b/src/pages/email/reports/antiphishing-filters/index.js
@@ -1,35 +1,35 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { Block, Check } from "@mui/icons-material";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { Block, Check } from '@mui/icons-material'
 
 const Page = () => {
-  const pageTitle = "List of Anti-Phishing Filters";
+  const pageTitle = 'List of Anti-Phishing Filters'
 
   // Actions to perform (Enable/Disable/Delete Rules) - Delete Rule is commented for review
   const actions = [
     {
-      label: "Enable Rule",
-      type: "POST",
+      label: 'Enable Rule',
+      type: 'POST',
       icon: <Check />,
-      url: "/api/EditAntiPhishingFilter",
+      url: '/api/EditAntiPhishingFilter',
       data: {
-        State: "!Enable",
-        RuleName: "RuleName",
+        State: '!Enable',
+        RuleName: 'RuleName',
       },
-      confirmText: "Are you sure you want to enable this rule?",
-      condition: (row) => row.State === "Disabled",
+      confirmText: 'Are you sure you want to enable this rule?',
+      condition: (row) => row?.State === 'Disabled',
     },
     {
-      label: "Disable Rule",
-      type: "POST",
+      label: 'Disable Rule',
+      type: 'POST',
       icon: <Block />,
-      url: "/api/EditAntiPhishingFilter",
+      url: '/api/EditAntiPhishingFilter',
       data: {
-        State: "!Disable",
-        RuleName: "RuleName",
+        State: '!Disable',
+        RuleName: 'RuleName',
       },
-      confirmText: "Are you sure you want to disable this rule?",
-      condition: (row) => row.State === "Enabled",
+      confirmText: 'Are you sure you want to disable this rule?',
+      condition: (row) => row?.State === 'Enabled',
     },
     // Uncomment the following block if Delete Rule is to be re-enabled in the future
     /*
@@ -43,61 +43,63 @@ const Page = () => {
       confirmText: "Are you sure you want to delete this rule?",
     },
     */
-  ];
+  ]
 
   // Off-canvas structure: displays extended details and includes actions (Enable/Disable Rule)
   const offCanvas = {
     extendedInfoFields: [
-      "RuleName", // Rule Name
-      "Name", // Policy Name
-      "State", // Enabled/Disabled
-      "WhenCreated", // Creation Date
-      "WhenChanged", // Last Modified Date
+      'RuleName', // Rule Name
+      'Name', // Policy Name
+      'State', // Enabled/Disabled
+      'WhenCreated', // Creation Date
+      'WhenChanged', // Last Modified Date
     ],
     actions: actions,
-  };
+  }
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListAntiPhishingFilters"
+      apiDataKey="Results"
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={[
-        "RuleName",
-        "Name",
-        "State",
-        "Priority",
-        "RecipientDomainIs",
-        "ExcludedDomains",
-        "ExcludedSenders",
-        "PhishThresholdLevel",
-        "EnableMailboxIntelligence",
-        "EnableMailboxIntelligenceProtection",
-        "EnableSpoofIntelligence",
-        "EnableFirstContactSafetyTips",
-        "EnableSimilarUsersSafetyTips",
-        "EnableSimilarDomainsSafetyTips",
-        "EnableUnusualCharactersSafetyTips",
-        "EnableUnauthenticatedSender",
-        "EnableViaTag",
-        "EnableOrganizationDomainsProtection",
-        "AuthenticationFailAction",
-        "SpoofQuarantineTag",
-        "MailboxIntelligenceProtectionAction",
-        "MailboxIntelligenceQuarantineTag",
-        "TargetedUserProtectionAction",
-        "TargetedUserQuarantineTag",
-        "TargetedDomainProtectionAction",
-        "TargetedDomainQuarantineTag",
-        "WhenCreated",
-        "WhenChanged",
+        'Tenant',
+        'RuleName',
+        'Name',
+        'State',
+        'Priority',
+        'RecipientDomainIs',
+        'ExcludedDomains',
+        'ExcludedSenders',
+        'PhishThresholdLevel',
+        'EnableMailboxIntelligence',
+        'EnableMailboxIntelligenceProtection',
+        'EnableSpoofIntelligence',
+        'EnableFirstContactSafetyTips',
+        'EnableSimilarUsersSafetyTips',
+        'EnableSimilarDomainsSafetyTips',
+        'EnableUnusualCharactersSafetyTips',
+        'EnableUnauthenticatedSender',
+        'EnableViaTag',
+        'EnableOrganizationDomainsProtection',
+        'AuthenticationFailAction',
+        'SpoofQuarantineTag',
+        'MailboxIntelligenceProtectionAction',
+        'MailboxIntelligenceQuarantineTag',
+        'TargetedUserProtectionAction',
+        'TargetedUserQuarantineTag',
+        'TargetedDomainProtectionAction',
+        'TargetedDomainQuarantineTag',
+        'WhenCreated',
+        'WhenChanged',
       ]}
     />
-  );
-};
+  )
+}
 
 // Layout configuration: ensure page uses DashboardLayout
-Page.getLayout = (page) => <DashboardLayout allTenantsSupport={false}>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/email/reports/global-address-list/index.js
+++ b/src/pages/email/reports/global-address-list/index.js
@@ -1,86 +1,88 @@
-﻿import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { Visibility, VisibilityOff } from "@mui/icons-material";
+﻿import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { Visibility, VisibilityOff } from '@mui/icons-material'
 
 const Page = () => {
   const actions = [
     {
-      label: "Unhide from Global Address List",
-      type: "POST",
-      url: "/api/ExecHideFromGAL",
+      label: 'Unhide from Global Address List',
+      type: 'POST',
+      url: '/api/ExecHideFromGAL',
       icon: <Visibility />,
       data: {
         HideFromGAL: false,
-        ID: "PrimarySmtpAddress",
+        ID: 'PrimarySmtpAddress',
       },
-      confirmText: "Are you sure you want to show this mailbox in the Global Address List?",
-      condition: (row) => row.HiddenFromAddressListsEnabled == true,
+      confirmText: 'Are you sure you want to show this mailbox in the Global Address List?',
+      condition: (row) => row?.HiddenFromAddressListsEnabled == true,
     },
     {
-      label: "Hide from Global Address List",
-      type: "POST",
-      url: "/api/ExecHideFromGAL",
+      label: 'Hide from Global Address List',
+      type: 'POST',
+      url: '/api/ExecHideFromGAL',
       icon: <VisibilityOff />,
       data: {
         HideFromGAL: true,
-        ID: "PrimarySmtpAddress",
+        ID: 'PrimarySmtpAddress',
       },
-      confirmText: "Are you sure you want to hide this mailbox from the Global Address List?",
-      condition: (row) => row.HiddenFromAddressListsEnabled == false,
+      confirmText: 'Are you sure you want to hide this mailbox from the Global Address List?',
+      condition: (row) => row?.HiddenFromAddressListsEnabled == false,
     },
-  ];
+  ]
 
   const offCanvas = {
     extendedInfoFields: [
-      "HiddenFromAddressListsEnabled",
-      "ExternalDirectoryObjectId",
-      "DisplayName",
-      "PrimarySmtpAddress",
-      "RecipientType",
-      "RecipientTypeDetails",
-      "IsDirSynced",
-      "SKUAssigned",
-      "EmailAddresses",
+      'HiddenFromAddressListsEnabled',
+      'ExternalDirectoryObjectId',
+      'DisplayName',
+      'PrimarySmtpAddress',
+      'RecipientType',
+      'RecipientTypeDetails',
+      'IsDirSynced',
+      'SKUAssigned',
+      'EmailAddresses',
     ],
     actions: actions,
-  };
+  }
 
   const filters = [
     {
-      filterName: "Hidden from GAL",
-      value: [{ id: "HiddenFromAddressListsEnabled", value: "Yes" }],
-      type: "column",
+      filterName: 'Hidden from GAL',
+      value: [{ id: 'HiddenFromAddressListsEnabled', value: 'Yes' }],
+      type: 'column',
     },
     {
-      filterName: "Shown in GAL",
-      value: [{ id: "HiddenFromAddressListsEnabled", value: "No" }],
-      type: "column",
+      filterName: 'Shown in GAL',
+      value: [{ id: 'HiddenFromAddressListsEnabled', value: 'No' }],
+      type: 'column',
     },
     {
-      filterName: "Cloud only mailboxes",
-      value: [{ id: "IsDirSynced", value: "No" }],
-      type: "column",
+      filterName: 'Cloud only mailboxes',
+      value: [{ id: 'IsDirSynced', value: 'No' }],
+      type: 'column',
     },
-  ];
+  ]
 
   return (
     <CippTablePage
       title="Global Address List"
       apiUrl="/api/ListGlobalAddressList"
+      apiDataKey="Results"
       actions={actions}
       offCanvas={offCanvas}
       filters={filters}
       simpleColumns={[
-        "HiddenFromAddressListsEnabled",
-        "DisplayName",
-        "PrimarySmtpAddress",
-        "RecipientTypeDetails",
-        "IsDirSynced",
+        'Tenant',
+        'HiddenFromAddressListsEnabled',
+        'DisplayName',
+        'PrimarySmtpAddress',
+        'RecipientTypeDetails',
+        'IsDirSynced',
       ]}
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout allTenantsSupport={false}>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/email/reports/mailbox-activity/index.js
+++ b/src/pages/email/reports/mailbox-activity/index.js
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
+import { useState } from 'react'
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
 import {
   Button,
   Accordion,
@@ -9,50 +9,50 @@ import {
   Typography,
   SvgIcon,
   Stack,
-} from "@mui/material";
-import { Grid } from "@mui/system";
-import { ExpandMore, Sort } from "@mui/icons-material";
-import { FunnelIcon, XMarkIcon } from "@heroicons/react/24/outline";
-import { useForm } from "react-hook-form";
-import CippFormComponent from "../../../../components/CippComponents/CippFormComponent";
+} from '@mui/material'
+import { Grid } from '@mui/system'
+import { ExpandMore, Sort } from '@mui/icons-material'
+import { FunnelIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { useForm } from 'react-hook-form'
+import CippFormComponent from '../../../../components/CippComponents/CippFormComponent'
 
 const Page = () => {
   const formControl = useForm({
     defaultValues: {
-      period: { value: "D30", label: "30 days" },
+      period: { value: 'D30', label: '30 days' },
     },
-  });
+  })
 
-  const [expanded, setExpanded] = useState(false);
-  const [selectedPeriod, setSelectedPeriod] = useState("D30");
-  const [selectedPeriodLabel, setSelectedPeriodLabel] = useState("30 days");
+  const [expanded, setExpanded] = useState(false)
+  const [selectedPeriod, setSelectedPeriod] = useState('D30')
+  const [selectedPeriodLabel, setSelectedPeriodLabel] = useState('30 days')
 
   const periodOptions = [
-    { value: "D7", label: "7 days" },
-    { value: "D30", label: "30 days" },
-    { value: "D90", label: "90 days" },
-    { value: "D180", label: "180 days" },
-  ];
+    { value: 'D7', label: '7 days' },
+    { value: 'D30', label: '30 days' },
+    { value: 'D90', label: '90 days' },
+    { value: 'D180', label: '180 days' },
+  ]
 
   const onSubmit = (data) => {
     const periodValue =
-      typeof data.period === "object" && data.period?.value ? data.period.value : data.period;
+      typeof data.period === 'object' && data.period?.value ? data.period.value : data.period
     const periodLabel =
-      typeof data.period === "object" && data.period?.label ? data.period.label : data.period;
+      typeof data.period === 'object' && data.period?.label ? data.period.label : data.period
 
-    setSelectedPeriod(periodValue);
-    setSelectedPeriodLabel(periodLabel);
-    setExpanded(false);
-  };
+    setSelectedPeriod(periodValue)
+    setSelectedPeriodLabel(periodLabel)
+    setExpanded(false)
+  }
 
   const clearFilters = () => {
     formControl.reset({
-      period: { value: "D30", label: "30 days" },
-    });
-    setSelectedPeriod("D30");
-    setSelectedPeriodLabel("30 days");
-    setExpanded(false);
-  };
+      period: { value: 'D30', label: '30 days' },
+    })
+    setSelectedPeriod('D30')
+    setSelectedPeriodLabel('30 days')
+    setExpanded(false)
+  }
 
   const tableFilter = (
     <Accordion expanded={expanded} onChange={() => setExpanded(!expanded)}>
@@ -63,7 +63,7 @@ const Page = () => {
           </SvgIcon>
           <Typography variant="h6">
             Report Period
-            <span style={{ fontSize: "0.8em", marginLeft: "10px", fontWeight: "normal" }}>
+            <span style={{ fontSize: '0.8em', marginLeft: '10px', fontWeight: 'normal' }}>
               (Period: {selectedPeriodLabel})
             </span>
           </Typography>
@@ -116,7 +116,7 @@ const Page = () => {
         </form>
       </AccordionDetails>
     </Accordion>
-  );
+  )
 
   return (
     <CippTablePage
@@ -125,28 +125,29 @@ const Page = () => {
       apiUrl="/api/ListGraphRequest"
       apiData={{
         Endpoint: `reports/getEmailActivityUserDetail(period='${selectedPeriod}')`,
-        $format: "application/json",
-        Sort: "userPrincipalName",
+        $format: 'application/json',
+        Sort: 'userPrincipalName',
       }}
       apiDataKey="Results"
       queryKey={`MailboxActivity-${selectedPeriod}`}
       simpleColumns={[
-        "userPrincipalName",
-        "displayName",
-        "sendCount",
-        "receiveCount",
-        "readCount",
-        "meetingCreatedCount",
-        "meetingInteractedCount",
-        "lastActivityDate",
-        "reportRefreshDate",
-        "reportPeriod",
+        'Tenant',
+        'userPrincipalName',
+        'displayName',
+        'sendCount',
+        'receiveCount',
+        'readCount',
+        'meetingCreatedCount',
+        'meetingInteractedCount',
+        'lastActivityDate',
+        'reportRefreshDate',
+        'reportPeriod',
       ]}
       offCanvas={null}
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/email/reports/mailbox-statistics/index.js
+++ b/src/pages/email/reports/mailbox-statistics/index.js
@@ -1,5 +1,5 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
 
 const Page = () => {
   return (
@@ -8,29 +8,30 @@ const Page = () => {
       apiUrl="/api/ListGraphRequest"
       apiData={{
         Endpoint: "reports/getMailboxUsageDetail(period='D7')",
-        $format: "application/json",
+        $format: 'application/json',
       }}
       apiDataKey="Results"
       simpleColumns={[
         /* Columns from the original component translated to simpleColumns */
-        "tenant", // Original conditional column, included directly here as per simplified requirements
-        "CippStatus", // Maps to "Retrieval Status" in original
-        "userPrincipalName", // Maps to "User Principal Name"
-        "displayName", // Maps to "Display Name"
-        "recipientType", // Maps to "Mailbox Type"
-        "lastActivityDate", // Maps to "Last Active"
-        "storageUsedInBytes", // Maps to "Used Space (GB)"
-        "prohibitSendReceiveQuotaInBytes", // Maps to "Quota (GB)"
-        "quotaUsedPercentage", // Calculated quota usage percentage, mapped here for backend processing if needed
-        "itemCount", // Maps to "Item Count (Total)"
-        "hasArchive", // Maps to "Archiving Enabled"
+        'Tenant',
+        'tenant', // Original conditional column, included directly here as per simplified requirements
+        'CippStatus', // Maps to "Retrieval Status" in original
+        'userPrincipalName', // Maps to "User Principal Name"
+        'displayName', // Maps to "Display Name"
+        'recipientType', // Maps to "Mailbox Type"
+        'lastActivityDate', // Maps to "Last Active"
+        'storageUsedInBytes', // Maps to "Used Space (GB)"
+        'prohibitSendReceiveQuotaInBytes', // Maps to "Quota (GB)"
+        'quotaUsedPercentage', // Calculated quota usage percentage, mapped here for backend processing if needed
+        'itemCount', // Maps to "Item Count (Total)"
+        'hasArchive', // Maps to "Archiving Enabled"
       ]}
       /* No actions specified in the original file */
       offCanvas={null} // No off-canvas data specified, so set to null
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/email/reports/malware-filters/index.js
+++ b/src/pages/email/reports/malware-filters/index.js
@@ -1,36 +1,37 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { Block, Check } from "@mui/icons-material";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { Block, Check } from '@mui/icons-material'
 
 const Page = () => {
   return (
     <CippTablePage
       title="List of Malware Filters"
       apiUrl="/api/ListMalwareFilters"
+      apiDataKey="Results"
       actions={[
         {
-          label: "Enable Rule",
-          type: "POST",
+          label: 'Enable Rule',
+          type: 'POST',
           icon: <Check />,
-          url: "/api/EditMalwareFilter",
+          url: '/api/EditMalwareFilter',
           data: {
-            State: "!Enable",
-            RuleName: "RuleName",
+            State: '!Enable',
+            RuleName: 'RuleName',
           },
-          confirmText: "Are you sure you want to enable this rule?",
-          condition: (row) => row.State === "Disabled",
+          confirmText: 'Are you sure you want to enable this rule?',
+          condition: (row) => row?.State === 'Disabled',
         },
         {
-          label: "Disable Rule",
-          type: "POST",
+          label: 'Disable Rule',
+          type: 'POST',
           icon: <Block />,
-          url: "/api/EditMalwareFilter",
+          url: '/api/EditMalwareFilter',
           data: {
-            State: "!Disable",
-            RuleName: "RuleName",
+            State: '!Disable',
+            RuleName: 'RuleName',
           },
-          confirmText: "Are you sure you want to disable this rule?",
-          condition: (row) => row.State === "Enabled",
+          confirmText: 'Are you sure you want to disable this rule?',
+          condition: (row) => row?.State === 'Enabled',
         },
         /* Uncomment and add additional actions if required by future specs
         {
@@ -45,39 +46,40 @@ const Page = () => {
         */
       ]}
       offCanvas={{
-        extendedInfoFields: ["RuleName", "Name", "State", "WhenCreated", "WhenChanged"],
+        extendedInfoFields: ['RuleName', 'Name', 'State', 'WhenCreated', 'WhenChanged'],
         actions: [
           {
-            label: "Enable Rule",
-            color: "info",
+            label: 'Enable Rule',
+            color: 'info',
           },
           {
-            label: "Disable Rule",
-            color: "info",
+            label: 'Disable Rule',
+            color: 'info',
           },
         ],
       }}
       simpleColumns={[
-        "RuleName",
-        "Name",
-        "State",
-        "Priority",
-        "RecipientDomainIs",
-        "EnableFileFilter",
-        "FileTypes",
-        "FileTypeAction",
-        "ZapEnabled",
-        "QuarantineTag",
-        "EnableInternalSenderAdminNotifications",
-        "InternalSenderAdminAddress",
-        "EnableExternalSenderAdminNotifications",
-        "ExternalSenderAdminAddress",
-        "WhenCreated",
-        "WhenChanged",
+        'Tenant',
+        'RuleName',
+        'Name',
+        'State',
+        'Priority',
+        'RecipientDomainIs',
+        'EnableFileFilter',
+        'FileTypes',
+        'FileTypeAction',
+        'ZapEnabled',
+        'QuarantineTag',
+        'EnableInternalSenderAdminNotifications',
+        'InternalSenderAdminAddress',
+        'EnableExternalSenderAdminNotifications',
+        'ExternalSenderAdminAddress',
+        'WhenCreated',
+        'WhenChanged',
       ]}
     />
-  );
-};
+  )
+}
 
 /* Developer Notes:
   - The tenant data reference "tenant.defaultDomainName" is dynamically handled by the component, per instruction.
@@ -89,6 +91,6 @@ const Page = () => {
   - Additional action for "Delete Rule" is commented for developer convenience, pending further instruction.
 */
 
-Page.getLayout = (page) => <DashboardLayout allTenantsSupport={false}>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/email/reports/safeattachments-filters/index.js
+++ b/src/pages/email/reports/safeattachments-filters/index.js
@@ -1,38 +1,38 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { Block, Check } from "@mui/icons-material";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { Block, Check } from '@mui/icons-material'
 
 const Page = () => {
-  const pageTitle = "List of Safe Attachment Filters";
-  const apiUrl = "/api/ListSafeAttachmentsFilters";
+  const pageTitle = 'List of Safe Attachment Filters'
+  const apiUrl = '/api/ListSafeAttachmentsFilters'
 
   // Actions converted from legacy code:
   const actions = [
     {
-      label: "Enable Rule",
-      type: "POST",
+      label: 'Enable Rule',
+      type: 'POST',
       icon: <Check />,
-      url: "/api/EditSafeAttachmentsFilter",
+      url: '/api/EditSafeAttachmentsFilter',
       data: {
-        State: "!enable",
-        RuleName: "RuleName",
+        State: '!enable',
+        RuleName: 'RuleName',
       },
-      confirmText: "Are you sure you want to enable this rule?",
-      color: "info",
-      condition: (row) => row.State === "Disabled",
+      confirmText: 'Are you sure you want to enable this rule?',
+      color: 'info',
+      condition: (row) => row?.State === 'Disabled',
     },
     {
-      label: "Disable Rule",
-      type: "POST",
+      label: 'Disable Rule',
+      type: 'POST',
       icon: <Block />,
-      url: "/api/EditSafeAttachmentsFilter",
+      url: '/api/EditSafeAttachmentsFilter',
       data: {
-        State: "Disable",
-        RuleName: "RuleName",
+        State: 'Disable',
+        RuleName: 'RuleName',
       },
-      confirmText: "Are you sure you want to disable this rule?",
-      color: "info",
-      condition: (row) => row.State === "Enabled",
+      confirmText: 'Are you sure you want to disable this rule?',
+      color: 'info',
+      condition: (row) => row?.State === 'Enabled',
     },
     // Commented out "Delete Rule" action from the original file as it was also commented in legacy code
     /*
@@ -47,30 +47,31 @@ const Page = () => {
       color: "danger",
     },
     */
-  ];
+  ]
 
   // Off-canvas setting including extended info fields for detailed rule information display:
   const offCanvas = {
-    extendedInfoFields: ["RuleName", "Name", "State", "WhenCreated", "WhenChanged"],
+    extendedInfoFields: ['RuleName', 'Name', 'State', 'WhenCreated', 'WhenChanged'],
     actions: actions, // Attaching actions to offCanvas per original design
-  };
+  }
 
   // Columns simplified from legacy configuration:
   const simpleColumns = [
-    "RuleName",
-    "Name",
-    "State",
-    "Priority",
-    "RecipientDomainIs",
-    "Action",
-    "QuarantineTag",
-    "Redirect",
-    "RedirectAddress",
-    "WhenCreated",
-    "WhenChanged",
-  ];
+    'Tenant',
+    'RuleName',
+    'Name',
+    'State',
+    'Priority',
+    'RecipientDomainIs',
+    'Action',
+    'QuarantineTag',
+    'Redirect',
+    'RedirectAddress',
+    'WhenCreated',
+    'WhenChanged',
+  ]
 
-  /* 
+  /*
     Notes:
     - The original file includes tenant data fetch through Redux (`useSelector`). This is no longer necessary, as tenant handling is managed within the `CippTablePage`.
     - Offcanvas visibility states (`ocVisible`) are removed since `CippTablePage` now manages them directly.
@@ -81,13 +82,14 @@ const Page = () => {
     <CippTablePage
       title={pageTitle}
       apiUrl={apiUrl}
+      apiDataKey="Results"
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={simpleColumns}
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout allTenantsSupport={false}>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/email/resources/management/equipment/edit.jsx
+++ b/src/pages/email/resources/management/equipment/edit.jsx
@@ -1,55 +1,55 @@
-import React, { useEffect } from "react";
-import { Divider, Typography } from "@mui/material";
-import { Grid } from "@mui/system";
-import { useForm } from "react-hook-form";
-import { Layout as DashboardLayout } from "../../../../../layouts/index.js";
-import CippFormPage from "../../../../../components/CippFormPages/CippFormPage";
-import CippFormComponent from "../../../../../components/CippComponents/CippFormComponent";
-import CippFormSkeleton from "../../../../../components/CippFormPages/CippFormSkeleton";
-import { useSettings } from "../../../../../hooks/use-settings";
-import { useRouter } from "next/router";
-import { ApiGetCall } from "../../../../../api/ApiCall";
-import countryList from "../../../../../data/countryList.json";
-import timezoneList from "../../../../../data/timezoneList.json";
+import React, { useEffect } from 'react'
+import { Divider, Typography } from '@mui/material'
+import { Grid } from '@mui/system'
+import { useForm } from 'react-hook-form'
+import { Layout as DashboardLayout } from '../../../../../layouts/index.js'
+import CippFormPage from '../../../../../components/CippFormPages/CippFormPage'
+import CippFormComponent from '../../../../../components/CippComponents/CippFormComponent'
+import CippFormSkeleton from '../../../../../components/CippFormPages/CippFormSkeleton'
+import { useSettings } from '../../../../../hooks/use-settings'
+import { useRouter } from 'next/router'
+import { ApiGetCall } from '../../../../../api/ApiCall'
+import countryList from '../../../../../data/countryList.json'
+import timezoneList from '../../../../../data/timezoneList.json'
 
 // Work days options
 const workDaysOptions = [
-  { value: "Sunday", label: "Sunday" },
-  { value: "Monday", label: "Monday" },
-  { value: "Tuesday", label: "Tuesday" },
-  { value: "Wednesday", label: "Wednesday" },
-  { value: "Thursday", label: "Thursday" },
-  { value: "Friday", label: "Friday" },
-  { value: "Saturday", label: "Saturday" },
-  { value: "WeekDay", label: "Weekdays (Monday-Friday)" },
-  { value: "WeekendDay", label: "Weekend (Saturday-Sunday)" },
-  { value: "AllDays", label: "All Days" },
-];
+  { value: 'Sunday', label: 'Sunday' },
+  { value: 'Monday', label: 'Monday' },
+  { value: 'Tuesday', label: 'Tuesday' },
+  { value: 'Wednesday', label: 'Wednesday' },
+  { value: 'Thursday', label: 'Thursday' },
+  { value: 'Friday', label: 'Friday' },
+  { value: 'Saturday', label: 'Saturday' },
+  { value: 'WeekDay', label: 'Weekdays (Monday-Friday)' },
+  { value: 'WeekendDay', label: 'Weekend (Saturday-Sunday)' },
+  { value: 'AllDays', label: 'All Days' },
+]
 
 // Automation Processing Options
 const automateProcessingOptions = [
-  { value: "None", label: "None - No processing" },
-  { value: "AutoUpdate", label: "AutoUpdate - Accept/Decline but not delete" },
-  { value: "AutoAccept", label: "AutoAccept - Accept and delete" },
-];
+  { value: 'None', label: 'None - No processing' },
+  { value: 'AutoUpdate', label: 'AutoUpdate - Accept/Decline but not delete' },
+  { value: 'AutoAccept', label: 'AutoAccept - Accept and delete' },
+]
 
 const EditEquipmentMailbox = () => {
-  const router = useRouter();
-  const { equipmentId } = router.query;
-  const tenantDomain = useSettings().currentTenant;
+  const router = useRouter()
+  const { equipmentId } = router.query
+  const tenantDomain = useSettings().currentTenant
   const formControl = useForm({
-    mode: "onChange",
-  });
+    mode: 'onChange',
+  })
 
   const equipmentInfo = ApiGetCall({
     url: `/api/ListEquipment?EquipmentId=${equipmentId}&tenantFilter=${tenantDomain}`,
     queryKey: `Equipment-${equipmentId}`,
     waiting: false,
-  });
+  })
 
   useEffect(() => {
-    if (equipmentInfo.isSuccess && equipmentInfo.data?.[0]) {
-      const equipment = equipmentInfo.data[0];
+    if (equipmentInfo.isSuccess && equipmentInfo.data?.Results?.[0]) {
+      const equipment = equipmentInfo.data.Results[0]
       formControl.reset({
         // Core Properties
         displayName: equipment.displayName,
@@ -65,8 +65,8 @@ const EditEquipmentMailbox = () => {
         stateOrProvince: equipment.stateOrProvince,
         postalCode: equipment.postalCode,
         countryOrRegion: equipment.countryOrRegion
-          ? countryList.find((c) => c.Name === equipment.countryOrRegion)?.Code || ""
-          : "",
+          ? countryList.find((c) => c.Name === equipment.countryOrRegion)?.Code || ''
+          : '',
         phone: equipment.phone,
         tags: equipment.tags?.map((tag) => ({ label: tag, value: tag })) || [],
 
@@ -82,7 +82,7 @@ const EditEquipmentMailbox = () => {
 
         // Calendar Configuration
         workDays:
-          equipment.workDays?.split(",")?.map((day) => ({
+          equipment.workDays?.split(',')?.map((day) => ({
             label: day.trim(),
             value: day.trim(),
           })) || [],
@@ -99,15 +99,15 @@ const EditEquipmentMailbox = () => {
                 : equipment.workingHoursTimeZone,
             }
           : null,
-      });
+      })
     }
-  }, [equipmentInfo.isSuccess, equipmentInfo.data]);
+  }, [equipmentInfo.isSuccess, equipmentInfo.data])
 
   useEffect(() => {
     if (equipmentId) {
-      equipmentInfo.refetch();
+      equipmentInfo.refetch()
     }
-  }, [router.query, equipmentId, tenantDomain]);
+  }, [router.query, equipmentId, tenantDomain])
 
   return (
     <CippFormPage
@@ -146,7 +146,7 @@ const EditEquipmentMailbox = () => {
         automateProcessing: values.automateProcessing?.value || values.automateProcessing,
 
         // Calendar Configuration
-        workDays: values.workDays?.map((day) => day.value).join(","),
+        workDays: values.workDays?.map((day) => day.value).join(','),
         workHoursStartTime: values.workHoursStartTime,
         workHoursEndTime: values.workHoursEndTime,
         workingHoursTimeZone: values.workingHoursTimeZone?.value || values.workingHoursTimeZone,
@@ -170,7 +170,7 @@ const EditEquipmentMailbox = () => {
               label="Display Name"
               name="displayName"
               formControl={formControl}
-              validators={{ required: "Display Name is required" }}
+              validators={{ required: 'Display Name is required' }}
             />
           </Grid>
 
@@ -183,7 +183,7 @@ const EditEquipmentMailbox = () => {
             />
           </Grid>
 
-          <Divider sx={{ my: 2, width: "100%" }} />
+          <Divider sx={{ my: 2, width: '100%' }} />
 
           {/* Booking Information */}
           <Grid size={{ xs: 12 }}>
@@ -200,10 +200,10 @@ const EditEquipmentMailbox = () => {
               name="maximumDurationInMinutes"
               formControl={formControl}
               validators={{
-                min: { value: 0, message: "Minimum is 0 (0 = Unlimited)" },
+                min: { value: 0, message: 'Minimum is 0 (0 = Unlimited)' },
                 max: {
                   value: 2147483647,
-                  message: "Maximum is 2,147,483,647 minutes",
+                  message: 'Maximum is 2,147,483,647 minutes',
                 },
               }}
               InputProps={{
@@ -221,8 +221,8 @@ const EditEquipmentMailbox = () => {
               name="bookingWindowInDays"
               formControl={formControl}
               validators={{
-                min: { value: 0, message: "Minimum is 0 days" },
-                max: { value: 1080, message: "Maximum is 1080 days (3 years)" },
+                min: { value: 0, message: 'Minimum is 0 days' },
+                max: { value: 1080, message: 'Maximum is 1080 days (3 years)' },
               }}
               InputProps={{
                 inputProps: { min: 0, max: 1080 },
@@ -279,7 +279,7 @@ const EditEquipmentMailbox = () => {
             />
           </Grid>
 
-          <Divider sx={{ my: 2, width: "100%" }} />
+          <Divider sx={{ my: 2, width: '100%' }} />
 
           {/* Working Hours */}
           <Grid size={{ xs: 12 }}>
@@ -342,7 +342,7 @@ const EditEquipmentMailbox = () => {
             />
           </Grid>
 
-          <Divider sx={{ my: 2, width: "100%" }} />
+          <Divider sx={{ my: 2, width: '100%' }} />
 
           {/* Equipment & Location Details */}
           <Grid size={{ xs: 12 }}>
@@ -440,13 +440,13 @@ const EditEquipmentMailbox = () => {
             />
           </Grid>
 
-          <Divider sx={{ my: 2, width: "100%" }} />
+          <Divider sx={{ my: 2, width: '100%' }} />
         </Grid>
       )}
     </CippFormPage>
-  );
-};
+  )
+}
 
-EditEquipmentMailbox.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+EditEquipmentMailbox.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>
 
-export default EditEquipmentMailbox;
+export default EditEquipmentMailbox

--- a/src/pages/email/resources/management/equipment/index.js
+++ b/src/pages/email/resources/management/equipment/index.js
@@ -1,77 +1,79 @@
-import { Layout as DashboardLayout } from "../../../../../layouts/index.js";
-import { CippTablePage } from "../../../../../components/CippComponents/CippTablePage.jsx";
-import { Edit, Block, LockOpen, Key } from "@mui/icons-material";
-import { TrashIcon } from "@heroicons/react/24/outline";
-import { CippAddEquipmentDrawer } from "../../../../../components/CippComponents/CippAddEquipmentDrawer";
+import { Layout as DashboardLayout } from '../../../../../layouts/index.js'
+import { CippTablePage } from '../../../../../components/CippComponents/CippTablePage.jsx'
+import { Edit, Block, LockOpen, Key } from '@mui/icons-material'
+import { TrashIcon } from '@heroicons/react/24/outline'
+import { CippAddEquipmentDrawer } from '../../../../../components/CippComponents/CippAddEquipmentDrawer'
 
 const Page = () => {
-  const pageTitle = "Equipment";
-  const cardButtonPermissions = ["Exchange.Equipment.ReadWrite"];
+  const pageTitle = 'Equipment'
+  const cardButtonPermissions = ['Exchange.Equipment.ReadWrite']
 
   const actions = [
     {
-      label: "Edit Equipment",
+      label: 'Edit Equipment',
       link: `/email/resources/management/equipment/edit?equipmentId=[ExternalDirectoryObjectId]`,
       icon: <Edit />,
-      color: "info",
+      color: 'info',
       condition: (row) => !row.isDirSynced,
     },
     {
-      label: "Edit permissions",
-      link: "/identity/administration/users/user/exchange?userId=[ExternalDirectoryObjectId]",
-      color: "info",
+      label: 'Edit permissions',
+      link: '/identity/administration/users/user/exchange?userId=[ExternalDirectoryObjectId]',
+      color: 'info',
       icon: <Key />,
     },
     {
-      label: "Block Sign In",
-      type: "POST",
+      label: 'Block Sign In',
+      type: 'POST',
       icon: <Block />,
-      url: "/api/ExecDisableUser",
-      data: { ID: "ExternalDirectoryObjectId" },
-      confirmText: "Are you sure you want to block the sign-in for this equipment mailbox?",
+      url: '/api/ExecDisableUser',
+      data: { ID: 'ExternalDirectoryObjectId' },
+      confirmText: 'Are you sure you want to block the sign-in for this equipment mailbox?',
       multiPost: false,
       condition: (row) => !row.isDirSynced,
     },
     {
-      label: "Unblock Sign In",
-      type: "POST",
+      label: 'Unblock Sign In',
+      type: 'POST',
       icon: <LockOpen />,
-      url: "/api/ExecDisableUser",
-      data: { ID: "ExternalDirectoryObjectId", Enable: true },
-      confirmText: "Are you sure you want to unblock sign-in for this equipment mailbox?",
+      url: '/api/ExecDisableUser',
+      data: { ID: 'ExternalDirectoryObjectId', Enable: true },
+      confirmText: 'Are you sure you want to unblock sign-in for this equipment mailbox?',
       multiPost: false,
       condition: (row) => !row.isDirSynced,
     },
     {
-      label: "Delete Equipment",
-      type: "POST",
+      label: 'Delete Equipment',
+      type: 'POST',
       icon: <TrashIcon />,
-      url: "/api/RemoveUser",
-      data: { ID: "ExternalDirectoryObjectId" },
-      confirmText: "Are you sure you want to delete this equipment mailbox?",
+      url: '/api/RemoveUser',
+      data: { ID: 'ExternalDirectoryObjectId' },
+      confirmText: 'Are you sure you want to delete this equipment mailbox?',
       multiPost: false,
       condition: (row) => !row.isDirSynced,
     },
-  ];
+  ]
 
   const simpleColumns = [
-    "DisplayName",
-    "UserPrincipalName",
-    "HiddenFromAddressListsEnabled",
-    "PrimarySmtpAddress",
-  ];
+    'Tenant',
+    'DisplayName',
+    'UserPrincipalName',
+    'HiddenFromAddressListsEnabled',
+    'PrimarySmtpAddress',
+  ]
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListEquipment"
+      apiDataKey="Results"
       actions={actions}
       simpleColumns={simpleColumns}
       cardButton={<CippAddEquipmentDrawer requiredPermissions={cardButtonPermissions} />}
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout allTenantsSupport={false}>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/email/resources/management/list-rooms/edit.jsx
+++ b/src/pages/email/resources/management/list-rooms/edit.jsx
@@ -1,56 +1,56 @@
-import { useEffect } from "react";
-import { Box, Divider, IconButton, Tooltip, Typography } from "@mui/material";
-import { Sync } from "@mui/icons-material";
-import { Grid } from "@mui/system";
-import { useForm } from "react-hook-form";
-import { Layout as DashboardLayout } from "../../../../../layouts/index.js";
-import CippFormPage from "../../../../../components/CippFormPages/CippFormPage";
-import CippFormComponent from "../../../../../components/CippComponents/CippFormComponent";
-import CippFormSkeleton from "../../../../../components/CippFormPages/CippFormSkeleton";
-import { useSettings } from "../../../../../hooks/use-settings";
-import { useRouter } from "next/router";
-import { ApiGetCall } from "../../../../../api/ApiCall";
-import countryList from "../../../../../data/countryList.json";
-import timezoneList from "../../../../../data/timezoneList.json";
+import { useEffect } from 'react'
+import { Box, Divider, IconButton, Tooltip, Typography } from '@mui/material'
+import { Sync } from '@mui/icons-material'
+import { Grid } from '@mui/system'
+import { useForm } from 'react-hook-form'
+import { Layout as DashboardLayout } from '../../../../../layouts/index.js'
+import CippFormPage from '../../../../../components/CippFormPages/CippFormPage'
+import CippFormComponent from '../../../../../components/CippComponents/CippFormComponent'
+import CippFormSkeleton from '../../../../../components/CippFormPages/CippFormSkeleton'
+import { useSettings } from '../../../../../hooks/use-settings'
+import { useRouter } from 'next/router'
+import { ApiGetCall } from '../../../../../api/ApiCall'
+import countryList from '../../../../../data/countryList.json'
+import timezoneList from '../../../../../data/timezoneList.json'
 
 // Work days options
 const workDaysOptions = [
-  { value: "Sunday", label: "Sunday" },
-  { value: "Monday", label: "Monday" },
-  { value: "Tuesday", label: "Tuesday" },
-  { value: "Wednesday", label: "Wednesday" },
-  { value: "Thursday", label: "Thursday" },
-  { value: "Friday", label: "Friday" },
-  { value: "Saturday", label: "Saturday" },
-  { value: "WeekDay", label: "Weekdays (Monday-Friday)" },
-  { value: "WeekendDay", label: "Weekend (Saturday-Sunday)" },
-  { value: "AllDays", label: "All Days" },
-];
+  { value: 'Sunday', label: 'Sunday' },
+  { value: 'Monday', label: 'Monday' },
+  { value: 'Tuesday', label: 'Tuesday' },
+  { value: 'Wednesday', label: 'Wednesday' },
+  { value: 'Thursday', label: 'Thursday' },
+  { value: 'Friday', label: 'Friday' },
+  { value: 'Saturday', label: 'Saturday' },
+  { value: 'WeekDay', label: 'Weekdays (Monday-Friday)' },
+  { value: 'WeekendDay', label: 'Weekend (Saturday-Sunday)' },
+  { value: 'AllDays', label: 'All Days' },
+]
 
 // Automation Processing Options
 const automateProcessingOptions = [
-  { value: "None", label: "None - No processing" },
-  { value: "AutoUpdate", label: "AutoUpdate - Accept/Decline but not delete" },
-  { value: "AutoAccept", label: "AutoAccept - Accept and delete" },
-];
+  { value: 'None', label: 'None - No processing' },
+  { value: 'AutoUpdate', label: 'AutoUpdate - Accept/Decline but not delete' },
+  { value: 'AutoAccept', label: 'AutoAccept - Accept and delete' },
+]
 
 const EditRoomMailbox = () => {
-  const router = useRouter();
-  const { roomId } = router.query;
-  const tenantDomain = useSettings().currentTenant;
+  const router = useRouter()
+  const { roomId } = router.query
+  const tenantDomain = useSettings().currentTenant
   const formControl = useForm({
-    mode: "onChange",
-  });
+    mode: 'onChange',
+  })
 
   const roomInfo = ApiGetCall({
     url: `/api/ListRooms?roomId=${roomId}&tenantFilter=${tenantDomain}`,
     queryKey: `Room-${roomId}`,
     waiting: false,
-  });
+  })
 
   useEffect(() => {
-    if (roomInfo.isSuccess && roomInfo.data?.[0]) {
-      const room = roomInfo.data[0];
+    if (roomInfo.isSuccess && roomInfo.data?.Results?.[0]) {
+      const room = roomInfo.data.Results[0]
       formControl.reset({
         // Core Properties
         displayName: room.displayName,
@@ -68,8 +68,8 @@ const EditRoomMailbox = () => {
         state: room.state,
         postalCode: room.postalCode,
         countryOrRegion: room.countryOrRegion
-          ? countryList.find((c) => c.Name === room.countryOrRegion)?.Code || ""
-          : "",
+          ? countryList.find((c) => c.Name === room.countryOrRegion)?.Code || ''
+          : '',
 
         // Room Equipment
         audioDeviceName: room.audioDeviceName,
@@ -97,7 +97,7 @@ const EditRoomMailbox = () => {
 
         // Calendar Configuration
         WorkDays:
-          room.WorkDays?.split(",")?.map((day) => ({
+          room.WorkDays?.split(',')?.map((day) => ({
             label: day.trim(),
             value: day.trim(),
           })) || [],
@@ -114,16 +114,16 @@ const EditRoomMailbox = () => {
                 : room.WorkingHoursTimeZone,
             }
           : null,
-      });
-      void formControl.trigger();
+      })
+      void formControl.trigger()
     }
-  }, [roomInfo.isSuccess, roomInfo.data]);
+  }, [roomInfo.isSuccess, roomInfo.data])
 
   useEffect(() => {
     if (roomId) {
-      roomInfo.refetch();
+      roomInfo.refetch()
     }
-  }, [router.query, roomId, tenantDomain]);
+  }, [router.query, roomId, tenantDomain])
 
   return (
     <CippFormPage
@@ -176,7 +176,7 @@ const EditRoomMailbox = () => {
         RemoveCanceledMeetings: values.RemoveCanceledMeetings,
 
         // Calendar Configuration
-        WorkDays: values.WorkDays?.map((day) => day.value).join(","),
+        WorkDays: values.WorkDays?.map((day) => day.value).join(','),
         WorkHoursStartTime: values.WorkHoursStartTime,
         WorkHoursEndTime: values.WorkHoursEndTime,
         WorkingHoursTimeZone: values.WorkingHoursTimeZone?.value || values.WorkingHoursTimeZone,
@@ -189,7 +189,9 @@ const EditRoomMailbox = () => {
         <Grid container spacing={2}>
           {/* Basic Information */}
           <Grid size={{ xs: 12 }}>
-            <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
+            <Box
+              sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}
+            >
               <Typography variant="subtitle1">Basic Information</Typography>
               <Tooltip title="Refresh">
                 <IconButton size="small" onClick={() => roomInfo.refetch()}>
@@ -205,7 +207,7 @@ const EditRoomMailbox = () => {
               label="Display Name"
               name="displayName"
               formControl={formControl}
-              validators={{ required: "Display Name is required" }}
+              validators={{ required: 'Display Name is required' }}
             />
           </Grid>
           <Grid size={{ md: 6, xs: 12 }}>
@@ -216,7 +218,7 @@ const EditRoomMailbox = () => {
               formControl={formControl}
             />
           </Grid>
-          <Divider sx={{ my: 2, width: "100%" }} />
+          <Divider sx={{ my: 2, width: '100%' }} />
           {/* Booking Settings */}
           <Grid size={{ xs: 12 }}>
             <Typography variant="subtitle1" sx={{ mb: 2 }}>
@@ -242,8 +244,8 @@ const EditRoomMailbox = () => {
               name="MaximumDurationInMinutes"
               formControl={formControl}
               validators={{
-                min: { value: 1, message: "Minimum duration is 1 minute" },
-                max: { value: 1440, message: "Maximum duration is 1440 minutes (24 hours)" },
+                min: { value: 1, message: 'Minimum duration is 1 minute' },
+                max: { value: 1440, message: 'Maximum duration is 1440 minutes (24 hours)' },
               }}
               InputProps={{
                 inputProps: { min: 1, max: 1440 },
@@ -258,8 +260,8 @@ const EditRoomMailbox = () => {
               name="BookingWindowInDays"
               formControl={formControl}
               validators={{
-                min: { value: 0, message: "Minimum is 0 days" },
-                max: { value: 1080, message: "Maximum is 1080 days (3 years)" },
+                min: { value: 0, message: 'Minimum is 0 days' },
+                max: { value: 1080, message: 'Maximum is 1080 days (3 years)' },
               }}
               InputProps={{
                 inputProps: { min: 0, max: 1080 },
@@ -342,7 +344,7 @@ const EditRoomMailbox = () => {
               formControl={formControl}
             />
           </Grid>
-          <Divider sx={{ my: 2, width: "100%" }} />
+          <Divider sx={{ my: 2, width: '100%' }} />
           {/* Working Hours */}
           <Grid size={{ xs: 12 }}>
             <Typography variant="subtitle1" sx={{ mb: 2 }}>
@@ -400,7 +402,7 @@ const EditRoomMailbox = () => {
               formControl={formControl}
             />
           </Grid>
-          <Divider sx={{ my: 2, width: "100%" }} />
+          <Divider sx={{ my: 2, width: '100%' }} />
           {/* Room Facilities */}
           <Grid size={{ xs: 12 }}>
             <Typography variant="subtitle1" sx={{ mb: 2 }}>
@@ -458,7 +460,7 @@ const EditRoomMailbox = () => {
               creatable={true}
             />
           </Grid>
-          <Divider sx={{ my: 2, width: "100%" }} />
+          <Divider sx={{ my: 2, width: '100%' }} />
           {/* Location Information */}
           <Grid size={{ xs: 12 }}>
             <Typography variant="subtitle1" sx={{ mb: 2 }}>
@@ -538,9 +540,9 @@ const EditRoomMailbox = () => {
         </Grid>
       )}
     </CippFormPage>
-  );
-};
+  )
+}
 
-EditRoomMailbox.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+EditRoomMailbox.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>
 
-export default EditRoomMailbox;
+export default EditRoomMailbox

--- a/src/pages/email/resources/management/list-rooms/index.js
+++ b/src/pages/email/resources/management/list-rooms/index.js
@@ -1,80 +1,82 @@
-import { Layout as DashboardLayout } from "../../../../../layouts/index.js";
-import { CippTablePage } from "../../../../../components/CippComponents/CippTablePage.jsx";
-import { Edit, Block, LockOpen, Key } from "@mui/icons-material";
-import { TrashIcon } from "@heroicons/react/24/outline";
-import { CippAddRoomDrawer } from "../../../../../components/CippComponents/CippAddRoomDrawer";
+import { Layout as DashboardLayout } from '../../../../../layouts/index.js'
+import { CippTablePage } from '../../../../../components/CippComponents/CippTablePage.jsx'
+import { Edit, Block, LockOpen, Key } from '@mui/icons-material'
+import { TrashIcon } from '@heroicons/react/24/outline'
+import { CippAddRoomDrawer } from '../../../../../components/CippComponents/CippAddRoomDrawer'
 
 const Page = () => {
-  const pageTitle = "Rooms";
-  const cardButtonPermissions = ["Exchange.Room.ReadWrite"];
+  const pageTitle = 'Rooms'
+  const cardButtonPermissions = ['Exchange.Room.ReadWrite']
 
   const actions = [
     {
-      label: "Edit Room",
+      label: 'Edit Room',
       link: `/email/resources/management/list-rooms/edit?roomId=[id]`,
       icon: <Edit />,
-      color: "info",
+      color: 'info',
       condition: (row) => !row.isDirSynced,
     },
     {
-      label: "Edit permissions",
-      link: "/identity/administration/users/user/exchange?userId=[id]",
-      color: "info",
+      label: 'Edit permissions',
+      link: '/identity/administration/users/user/exchange?userId=[id]',
+      color: 'info',
       icon: <Key />,
     },
     {
-      label: "Block Sign In",
-      type: "POST",
+      label: 'Block Sign In',
+      type: 'POST',
       icon: <Block />,
-      url: "/api/ExecDisableUser",
-      data: { ID: "id" },
-      confirmText: "Are you sure you want to block the sign-in for this room mailbox?",
+      url: '/api/ExecDisableUser',
+      data: { ID: 'id' },
+      confirmText: 'Are you sure you want to block the sign-in for this room mailbox?',
       multiPost: false,
       condition: (row) => !row.accountDisabled && !row.isDirSynced,
     },
     {
-      label: "Unblock Sign In",
-      type: "POST",
+      label: 'Unblock Sign In',
+      type: 'POST',
       icon: <LockOpen />,
-      url: "/api/ExecDisableUser",
-      data: { ID: "id", Enable: true },
-      confirmText: "Are you sure you want to unblock sign-in for this room mailbox?",
+      url: '/api/ExecDisableUser',
+      data: { ID: 'id', Enable: true },
+      confirmText: 'Are you sure you want to unblock sign-in for this room mailbox?',
       multiPost: false,
-      condition: (row) => row.accountDisabled && !row.isDirSynced,
+      condition: (row) => row?.accountDisabled && !row?.isDirSynced,
     },
     {
-      label: "Delete Room",
-      type: "POST",
+      label: 'Delete Room',
+      type: 'POST',
       icon: <TrashIcon />,
-      url: "/api/RemoveUser",
-      data: { ID: "id" },
-      confirmText: "Are you sure you want to delete this room mailbox?",
+      url: '/api/RemoveUser',
+      data: { ID: 'id' },
+      confirmText: 'Are you sure you want to delete this room mailbox?',
       multiPost: false,
       condition: (row) => !row.isDirSynced,
     },
-  ];
+  ]
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListRooms"
+      apiDataKey="Results"
       actions={actions}
       simpleColumns={[
-        "displayName",
-        "mail",
-        "building",
-        "floor",
-        "capacity",
-        "city",
-        "state",
-        "countryOrRegion",
-        "hiddenFromAddressListsEnabled",
+        'Tenant',
+        'displayName',
+        'mail',
+        'building',
+        'floor',
+        'capacity',
+        'city',
+        'state',
+        'countryOrRegion',
+        'hiddenFromAddressListsEnabled',
       ]}
       cardButton={<CippAddRoomDrawer requiredPermissions={cardButtonPermissions} />}
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout allTenantsSupport={false}>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/email/resources/management/room-lists/edit.jsx
+++ b/src/pages/email/resources/management/room-lists/edit.jsx
@@ -1,40 +1,40 @@
-import { useEffect, useState } from "react";
-import { Box, Button, Divider, Typography } from "@mui/material";
-import { Grid } from "@mui/system";
-import { useForm } from "react-hook-form";
-import { Layout as DashboardLayout } from "../../../../../layouts/index.js";
-import CippFormPage from "../../../../../components/CippFormPages/CippFormPage";
-import CippFormComponent from "../../../../../components/CippComponents/CippFormComponent";
-import { CippFormUserSelector } from "../../../../../components/CippComponents/CippFormUserSelector";
-import { useRouter } from "next/router";
-import { ApiGetCall } from "../../../../../api/ApiCall";
-import { useSettings } from "../../../../../hooks/use-settings";
-import { CippDataTable } from "../../../../../components/CippTable/CippDataTable";
+import { useEffect, useState } from 'react'
+import { Box, Button, Divider, Typography } from '@mui/material'
+import { Grid } from '@mui/system'
+import { useForm } from 'react-hook-form'
+import { Layout as DashboardLayout } from '../../../../../layouts/index.js'
+import CippFormPage from '../../../../../components/CippFormPages/CippFormPage'
+import CippFormComponent from '../../../../../components/CippComponents/CippFormComponent'
+import { CippFormUserSelector } from '../../../../../components/CippComponents/CippFormUserSelector'
+import { useRouter } from 'next/router'
+import { ApiGetCall } from '../../../../../api/ApiCall'
+import { useSettings } from '../../../../../hooks/use-settings'
+import { CippDataTable } from '../../../../../components/CippTable/CippDataTable'
 
 const EditRoomList = () => {
-  const router = useRouter();
-  const { groupId } = router.query;
-  const [groupIdReady, setGroupIdReady] = useState(false);
-  const [showMembershipTable, setShowMembershipTable] = useState(false);
-  const [combinedData, setCombinedData] = useState([]);
-  const [originalAllowExternal, setOriginalAllowExternal] = useState(null);
-  const tenantFilter = useSettings().currentTenant;
+  const router = useRouter()
+  const { groupId } = router.query
+  const [groupIdReady, setGroupIdReady] = useState(false)
+  const [showMembershipTable, setShowMembershipTable] = useState(false)
+  const [combinedData, setCombinedData] = useState([])
+  const [originalAllowExternal, setOriginalAllowExternal] = useState(null)
+  const tenantFilter = useSettings().currentTenant
 
   const groupInfo = ApiGetCall({
     url: `/api/ListRoomLists?groupID=${groupId}&tenantFilter=${tenantFilter}&members=true&owners=true`,
     queryKey: `ListRoomLists-${groupId}`,
     waiting: groupIdReady,
-  });
+  })
 
   useEffect(() => {
     if (groupId) {
-      setGroupIdReady(true);
-      groupInfo.refetch();
+      setGroupIdReady(true)
+      groupInfo.refetch()
     }
-  }, [router.query, groupId, tenantFilter]);
+  }, [router.query, groupId, tenantFilter])
 
   const formControl = useForm({
-    mode: "onChange",
+    mode: 'onChange',
     defaultValues: {
       tenantFilter: tenantFilter,
       AddMember: [],
@@ -42,53 +42,53 @@ const EditRoomList = () => {
       AddOwner: [],
       RemoveOwner: [],
     },
-  });
+  })
 
   useEffect(() => {
     if (groupInfo.isSuccess) {
-      const group = groupInfo.data?.groupInfo;
+      const group = groupInfo.data?.groupInfo
       if (group) {
         // Create combined data for the table
-        const owners = Array.isArray(groupInfo.data?.owners) ? groupInfo.data.owners : [];
-        const members = Array.isArray(groupInfo.data?.members) ? groupInfo.data.members : [];
+        const owners = Array.isArray(groupInfo.data?.owners) ? groupInfo.data.owners : []
+        const members = Array.isArray(groupInfo.data?.members) ? groupInfo.data.members : []
 
         const combinedData = [
           ...owners.map((o) => ({
-            type: "Owner",
+            type: 'Owner',
             userPrincipalName: o.userPrincipalName,
             displayName: o.displayName,
           })),
           ...members.map((m) => ({
-            type: "Room",
+            type: 'Room',
             userPrincipalName: m.PrimarySmtpAddress || m.userPrincipalName || m.mail,
             displayName: m.DisplayName || m.displayName,
           })),
-        ];
-        setCombinedData(combinedData);
+        ]
+        setCombinedData(combinedData)
 
         // Store original allowExternal value for comparison
-        const allowExternalValue = groupInfo?.data?.allowExternal;
-        setOriginalAllowExternal(allowExternalValue);
+        const allowExternalValue = groupInfo?.data?.allowExternal
+        setOriginalAllowExternal(allowExternalValue)
 
         // Reset the form with all values
         formControl.reset({
           tenantFilter: tenantFilter,
           mail: group.PrimarySmtpAddress || group.mail,
-          mailNickname: group.Alias || group.mailNickname || "",
+          mailNickname: group.Alias || group.mailNickname || '',
           allowExternal: allowExternalValue,
           displayName: group.DisplayName || group.displayName,
-          description: group.Description || group.description || "",
+          description: group.Description || group.description || '',
           groupId: group.Guid || group.id,
-          groupType: "Room List",
+          groupType: 'Room List',
           // Initialize empty arrays for add/remove actions
           AddMember: [],
           RemoveMember: [],
           AddOwner: [],
           RemoveOwner: [],
-        });
+        })
       }
     }
-  }, [groupInfo.isSuccess, router.query, groupInfo.isFetching]);
+  }, [groupInfo.isSuccess, router.query, groupInfo.isFetching])
 
   return (
     <>
@@ -96,18 +96,18 @@ const EditRoomList = () => {
         formControl={formControl}
         queryKey={[`ListRoomLists-${groupId}`]}
         title={`Room List: ${
-          groupInfo.data?.groupInfo?.DisplayName || groupInfo.data?.groupInfo?.displayName || ""
+          groupInfo.data?.groupInfo?.DisplayName || groupInfo.data?.groupInfo?.displayName || ''
         }`}
         formPageType="Edit"
         backButtonTitle="Room Lists"
         postUrl="/api/EditRoomList"
         customDataformatter={(values) => {
           // Only include allowExternal if it has changed from the original value
-          const modifiedValues = { ...values };
+          const modifiedValues = { ...values }
           if (originalAllowExternal !== null && values.allowExternal === originalAllowExternal) {
-            delete modifiedValues.allowExternal;
+            delete modifiedValues.allowExternal
           }
-          return modifiedValues;
+          return modifiedValues
         }}
         titleButton={
           <>
@@ -117,7 +117,7 @@ const EditRoomList = () => {
               onClick={() => setShowMembershipTable(!showMembershipTable)}
               sx={{ mb: 2 }}
             >
-              {showMembershipTable ? "Edit Membership" : "View members"}
+              {showMembershipTable ? 'Edit Membership' : 'View members'}
             </Button>
           </>
         }
@@ -127,7 +127,7 @@ const EditRoomList = () => {
             <CippDataTable
               data={combinedData}
               isFetching={groupInfo.isFetching}
-              simpleColumns={["type", "userPrincipalName", "displayName"]}
+              simpleColumns={['type', 'userPrincipalName', 'displayName']}
               refreshFunction={groupInfo.refetch}
             />
           </Box>
@@ -187,16 +187,17 @@ const EditRoomList = () => {
                   isFetching={groupInfo.isFetching}
                   disabled={groupInfo.isFetching}
                   api={{
-                    url: "/api/ListRooms",
+                    url: '/api/ListRooms',
+                    dataKey: 'Results',
                     labelField: (room) =>
-                      `${room.displayName || "Unknown"} (${
-                        room.mail || room.userPrincipalName || "No email"
+                      `${room.displayName || 'Unknown'} (${
+                        room.mail || room.userPrincipalName || 'No email'
                       })`,
-                    valueField: "mail",
+                    valueField: 'mail',
                     addedField: {
-                      roomType: "bookingType",
-                      capacity: "capacity",
-                      id: "id",
+                      roomType: 'bookingType',
+                      capacity: 'capacity',
+                      id: 'id',
                     },
                     queryKey: `rooms-${tenantFilter}`,
                     showRefresh: true,
@@ -204,20 +205,20 @@ const EditRoomList = () => {
                       // Get current member emails to filter out
                       const members = Array.isArray(groupInfo.data?.members)
                         ? groupInfo.data.members
-                        : [];
+                        : []
                       const currentMemberEmails = members
                         .map((m) => m.mail || m.userPrincipalName)
-                        .filter(Boolean);
+                        .filter(Boolean)
 
                       // Filter out rooms that are already members
                       // rooms here have been transformed to {label, value, addedFields} format
                       const filteredRooms = rooms.filter((room) => {
-                        const roomEmail = room.value; // email is in the value field
-                        const isAlreadyMember = currentMemberEmails.includes(roomEmail);
-                        return !isAlreadyMember;
-                      });
+                        const roomEmail = room.value // email is in the value field
+                        const isAlreadyMember = currentMemberEmails.includes(roomEmail)
+                        return !isAlreadyMember
+                      })
 
-                      return filteredRooms;
+                      return filteredRooms
                     },
                   }}
                 />
@@ -234,14 +235,14 @@ const EditRoomList = () => {
                   isFetching={groupInfo.isFetching}
                   disabled={groupInfo.isFetching}
                   api={{
-                    url: "/api/ListUsers",
+                    url: '/api/ListUsers',
                     labelField: (user) =>
-                      `${user.displayName || "Unknown"} (${
-                        user.userPrincipalName || user.mail || "No email"
+                      `${user.displayName || 'Unknown'} (${
+                        user.userPrincipalName || user.mail || 'No email'
                       })`,
-                    valueField: "userPrincipalName",
+                    valueField: 'userPrincipalName',
                     addedField: {
-                      id: "id",
+                      id: 'id',
                     },
                     queryKey: `users-${tenantFilter}`,
                     showRefresh: true,
@@ -249,20 +250,20 @@ const EditRoomList = () => {
                       // Get current owner userPrincipalNames to filter out
                       const owners = Array.isArray(groupInfo.data?.owners)
                         ? groupInfo.data.owners
-                        : [];
+                        : []
                       const currentOwnerEmails = owners
                         .map((o) => o.userPrincipalName)
-                        .filter(Boolean);
+                        .filter(Boolean)
 
                       // Filter out users that are already owners
                       // users here have been transformed to {label, value, addedFields} format
                       const filteredUsers = users.filter((user) => {
-                        const userEmail = user.value; // userPrincipalName is in the value field
-                        const isAlreadyOwner = currentOwnerEmails.includes(userEmail);
-                        return !isAlreadyOwner;
-                      });
+                        const userEmail = user.value // userPrincipalName is in the value field
+                        const isAlreadyOwner = currentOwnerEmails.includes(userEmail)
+                        return !isAlreadyOwner
+                      })
 
-                      return filteredUsers;
+                      return filteredUsers
                     },
                   }}
                 />
@@ -285,7 +286,7 @@ const EditRoomList = () => {
                   options={
                     Array.isArray(groupInfo.data?.members)
                       ? groupInfo.data.members.map((m) => ({
-                          label: `${m.DisplayName || m.displayName || "Unknown"} (${
+                          label: `${m.DisplayName || m.displayName || 'Unknown'} (${
                             m.PrimarySmtpAddress || m.userPrincipalName || m.mail
                           })`,
                           value: m.PrimarySmtpAddress || m.userPrincipalName || m.mail,
@@ -337,9 +338,9 @@ const EditRoomList = () => {
         )}
       </CippFormPage>
     </>
-  );
-};
+  )
+}
 
-EditRoomList.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+EditRoomList.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>
 
-export default EditRoomList;
+export default EditRoomList

--- a/src/pages/email/resources/management/room-lists/index.js
+++ b/src/pages/email/resources/management/room-lists/index.js
@@ -1,51 +1,58 @@
-import { Layout as DashboardLayout } from "../../../../../layouts/index.js";
-import { CippTablePage } from "../../../../../components/CippComponents/CippTablePage.jsx";
-import { Edit } from "@mui/icons-material";
-import { TrashIcon } from "@heroicons/react/24/outline";
-import { CippAddRoomListDrawer } from "../../../../../components/CippComponents/CippAddRoomListDrawer";
+import { Layout as DashboardLayout } from '../../../../../layouts/index.js'
+import { CippTablePage } from '../../../../../components/CippComponents/CippTablePage.jsx'
+import { Edit } from '@mui/icons-material'
+import { TrashIcon } from '@heroicons/react/24/outline'
+import { CippAddRoomListDrawer } from '../../../../../components/CippComponents/CippAddRoomListDrawer'
 
 const Page = () => {
-  const pageTitle = "Room Lists";
-  const apiUrl = "/api/ListRoomLists";
-  const cardButtonPermissions = ["Exchange.Room.ReadWrite"];
+  const pageTitle = 'Room Lists'
+  const apiUrl = '/api/ListRoomLists'
+  const cardButtonPermissions = ['Exchange.Room.ReadWrite']
 
   const actions = [
     {
-      label: "Edit Room List",
-      link: "/email/resources/management/room-lists/edit?groupId=[PrimarySmtpAddress]",
+      label: 'Edit Room List',
+      link: '/email/resources/management/room-lists/edit?groupId=[PrimarySmtpAddress]',
       multiPost: false,
       icon: <Edit />,
-      color: "success",
+      color: 'success',
     },
     {
-      label: "Delete Room List",
-      type: "POST",
-      url: "/api/ExecGroupsDelete",
+      label: 'Delete Room List',
+      type: 'POST',
+      url: '/api/ExecGroupsDelete',
       icon: <TrashIcon />,
       data: {
-        id: "Guid",
-        displayName: "DisplayName",
-        GroupType: "!Distribution List",
+        id: 'Guid',
+        displayName: 'DisplayName',
+        GroupType: '!Distribution List',
       },
-      confirmText: "Are you sure you want to delete this room list?",
+      confirmText: 'Are you sure you want to delete this room list?',
       multiPost: false,
     },
-  ];
+  ]
 
   const offCanvas = {
     extendedInfoFields: [
-      "Guid",
-      "PrimarySmtpAddress",
-      "DisplayName",
-      "Phone",
-      "Identity",
-      "Notes",
-      "MailNickname",
+      'Guid',
+      'PrimarySmtpAddress',
+      'DisplayName',
+      'Phone',
+      'Identity',
+      'Notes',
+      'MailNickname',
     ],
     actions: actions,
-  };
+  }
 
-  const simpleColumns = ["DisplayName", "PrimarySmtpAddress", "Identity", "Phone", "Notes"];
+  const simpleColumns = [
+    'Tenant',
+    'DisplayName',
+    'PrimarySmtpAddress',
+    'Identity',
+    'Phone',
+    'Notes',
+  ]
 
   return (
     <CippTablePage
@@ -61,9 +68,9 @@ const Page = () => {
         </>
       }
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout allTenantsSupport={false}>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/email/spamfilter/list-connectionfilter/index.js
+++ b/src/pages/email/spamfilter/list-connectionfilter/index.js
@@ -1,45 +1,53 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { Button } from "@mui/material";
-import { Book, AddModerator } from "@mui/icons-material";
-import Link from "next/link";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { Button } from '@mui/material'
+import { Book, AddModerator } from '@mui/icons-material'
+import Link from 'next/link'
 
 const Page = () => {
-  const pageTitle = "Connection Filters";
+  const pageTitle = 'Connection Filters'
 
   const actions = [
     {
-      label: "Create template based on filter",
-      type: "POST",
-      url: "/api/AddConnectionfilterTemplate",
+      label: 'Create template based on filter',
+      type: 'POST',
+      url: '/api/AddConnectionfilterTemplate',
       dataFunction: (data) => {
-        return { ...data };
+        return { ...data }
       },
       icon: <Book />,
-      confirmText: "Are you sure you want to create a template based on this filter?",
+      confirmText: 'Are you sure you want to create a template based on this filter?',
     },
-  ];
+  ]
 
   const offCanvas = {
     extendedInfoFields: [
-      "DistinguishedName",
-      "DirectoryBasedEdgeBlockMode",
-      "ExchangeVersion",
-      "ExchangeObjectId",
-      "OrganizationalUnitRoot",
-      "WhenCreated",
-      "WhenChanged",
-      "Guid",
+      'DistinguishedName',
+      'DirectoryBasedEdgeBlockMode',
+      'ExchangeVersion',
+      'ExchangeObjectId',
+      'OrganizationalUnitRoot',
+      'WhenCreated',
+      'WhenChanged',
+      'Guid',
     ],
     actions: actions,
-  };
+  }
 
-  const simpleColumns = ["Name", "IsDefault", "IPAllowList", "IPBlockList", "EnableSafeList"];
+  const simpleColumns = [
+    'Tenant',
+    'Name',
+    'IsDefault',
+    'IPAllowList',
+    'IPBlockList',
+    'EnableSafeList',
+  ]
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListConnectionFilter"
+      apiDataKey="Results"
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={simpleColumns}
@@ -55,8 +63,8 @@ const Page = () => {
         </>
       }
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout allTenantsSupport={false}>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
+export default Page

--- a/src/pages/email/spamfilter/list-spamfilter/index.js
+++ b/src/pages/email/spamfilter/list-spamfilter/index.js
@@ -1,101 +1,103 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { Button } from "@mui/material";
-import { Book, Block, Check } from "@mui/icons-material";
-import { TrashIcon } from "@heroicons/react/24/outline";
-import Link from "next/link";
-import { RocketLaunch } from "@mui/icons-material";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { Button } from '@mui/material'
+import { Book, Block, Check } from '@mui/icons-material'
+import { TrashIcon } from '@heroicons/react/24/outline'
+import Link from 'next/link'
+import { RocketLaunch } from '@mui/icons-material'
 
 const Page = () => {
-  const pageTitle = "Spam Filters";
-  const apiUrl = "/api/ListSpamfilter";
+  const pageTitle = 'Spam Filters'
+  const apiUrl = '/api/ListSpamfilter'
 
   const actions = [
     {
-      label: "Create template based on rule",
-      type: "POST",
+      label: 'Create template based on rule',
+      type: 'POST',
       icon: <Book />,
-      url: "/api/AddSpamfilterTemplate",
+      url: '/api/AddSpamfilterTemplate',
       dataFunction: (data) => {
-        return { ...data };
+        return { ...data }
       },
-      confirmText: "Are you sure you want to create a template based on this rule?",
+      confirmText: 'Are you sure you want to create a template based on this rule?',
     },
     {
-      label: "Enable Rule",
-      type: "POST",
+      label: 'Enable Rule',
+      type: 'POST',
       icon: <Check />,
-      url: "/api/EditSpamfilter",
+      url: '/api/EditSpamfilter',
       data: {
-        State: "!enable",
-        name: "Name",
+        State: '!enable',
+        name: 'Name',
       },
-      confirmText: "Are you sure you want to enable this rule?",
-      condition: (row) => row.ruleState === "Disabled",
+      confirmText: 'Are you sure you want to enable this rule?',
+      condition: (row) => row?.ruleState === 'Disabled',
     },
     {
-      label: "Disable Rule",
-      type: "POST",
+      label: 'Disable Rule',
+      type: 'POST',
       icon: <Block />,
-      url: "/api/EditSpamfilter",
+      url: '/api/EditSpamfilter',
       data: {
-        State: "!disable",
-        name: "Name",
+        State: '!disable',
+        name: 'Name',
       },
-      confirmText: "Are you sure you want to disable this rule?",
-      condition: (row) => row.ruleState === "Enabled",
+      confirmText: 'Are you sure you want to disable this rule?',
+      condition: (row) => row?.ruleState === 'Enabled',
     },
     {
-      label: "Delete Rule",
-      type: "POST",
+      label: 'Delete Rule',
+      type: 'POST',
       icon: <TrashIcon />,
-      url: "/api/RemoveSpamFilter",
+      url: '/api/RemoveSpamFilter',
       data: {
-        name: "Name",
+        name: 'Name',
       },
-      confirmText: "Are you sure you want to delete this rule?",
-      color: "danger",
+      confirmText: 'Are you sure you want to delete this rule?',
+      color: 'danger',
     },
-  ];
+  ]
 
   const offCanvas = {
     extendedInfoFields: [
-      "IncreaseScoreWithImageLinks",
-      "IncreaseScoreWithNumericIps",
-      "IncreaseScoreWithRedirectToOtherPort",
-      "IncreaseScoreWithBizOrInfoUrls",
-      "MarkAsSpamEmptyMessages",
-      "MarkAsSpamJavaScriptInHtml",
-      "MarkAsSpamFramesInHtml",
-      "MarkAsSpamObjectTagsInHtml",
-      "MarkAsSpamEmbedTagsInHtml",
-      "MarkAsSpamFormTagsInHtml",
-      "MarkAsSpamWebBugsInHtml",
-      "MarkAsSpamSensitiveWordList",
-      "MarkAsSpamSpfRecordHardFail",
-      "MarkAsSpamFromAddressAuthFail",
-      "MarkAsSpamBulkMail",
-      "MarkAsSpamNdrBackscatter",
+      'IncreaseScoreWithImageLinks',
+      'IncreaseScoreWithNumericIps',
+      'IncreaseScoreWithRedirectToOtherPort',
+      'IncreaseScoreWithBizOrInfoUrls',
+      'MarkAsSpamEmptyMessages',
+      'MarkAsSpamJavaScriptInHtml',
+      'MarkAsSpamFramesInHtml',
+      'MarkAsSpamObjectTagsInHtml',
+      'MarkAsSpamEmbedTagsInHtml',
+      'MarkAsSpamFormTagsInHtml',
+      'MarkAsSpamWebBugsInHtml',
+      'MarkAsSpamSensitiveWordList',
+      'MarkAsSpamSpfRecordHardFail',
+      'MarkAsSpamFromAddressAuthFail',
+      'MarkAsSpamBulkMail',
+      'MarkAsSpamNdrBackscatter',
     ],
     actions: actions,
-  };
+  }
 
   const simpleColumns = [
-    "Name",
-    "IsDefault",
-    "ruleState",
-    "rulePrio",
-    "HighConfidenceSpamAction",
-    "BulkSpamAction",
-    "PhishSpamAction",
-    "WhenCreated",
-    "WhenChanged",
-  ];
+    'Tenant',
+    'Name',
+    'IsDefault',
+    'ruleState',
+    'rulePrio',
+    'HighConfidenceSpamAction',
+    'BulkSpamAction',
+    'PhishSpamAction',
+    'WhenCreated',
+    'WhenChanged',
+  ]
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl={apiUrl}
+      apiDataKey="Results"
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={simpleColumns}
@@ -111,8 +113,8 @@ const Page = () => {
         </>
       }
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout allTenantsSupport={false}>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
+export default Page

--- a/src/pages/email/transport/list-connectors/index.js
+++ b/src/pages/email/transport/list-connectors/index.js
@@ -1,107 +1,109 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { Book, Check, Block, Delete } from "@mui/icons-material";
-import { CippAddConnectorDrawer } from "../../../../components/CippComponents/CippAddConnectorDrawer";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { Book, Check, Block, Delete } from '@mui/icons-material'
+import { CippAddConnectorDrawer } from '../../../../components/CippComponents/CippAddConnectorDrawer'
 
 const Page = () => {
-  const pageTitle = "Connector List";
-  const cardButtonPermissions = ["Exchange.Connector.ReadWrite"];
+  const pageTitle = 'Connector List'
+  const cardButtonPermissions = ['Exchange.Connector.ReadWrite']
 
   const actions = [
     {
-      label: "Create template based on connector",
-      type: "POST",
-      url: "/api/AddExConnectorTemplate",
+      label: 'Create template based on connector',
+      type: 'POST',
+      url: '/api/AddExConnectorTemplate',
       icon: <Book />,
       postEntireRow: true,
-      confirmText: "Are you sure you want to create a template based on this connector?",
-      color: "info",
+      confirmText: 'Are you sure you want to create a template based on this connector?',
+      color: 'info',
     },
     {
-      label: "Enable Connector",
-      type: "POST",
-      url: "/api/EditExConnector",
+      label: 'Enable Connector',
+      type: 'POST',
+      url: '/api/EditExConnector',
       icon: <Check />,
-      condition: (row) => !row.Enabled,
+      condition: (row) => !row?.Enabled,
       data: {
-        State: "!Enable",
-        GUID: "Guid",
-        Type: "cippconnectortype",
+        State: '!Enable',
+        GUID: 'Guid',
+        Type: 'cippconnectortype',
       },
-      confirmText: "Are you sure you want to enable this connector?",
-      color: "info",
+      confirmText: 'Are you sure you want to enable this connector?',
+      color: 'info',
     },
     {
-      label: "Disable Connector",
-      type: "POST",
-      url: "/api/EditExConnector",
+      label: 'Disable Connector',
+      type: 'POST',
+      url: '/api/EditExConnector',
       icon: <Block />,
-      condition: (row) => row.Enabled,
+      condition: (row) => row?.Enabled,
       data: {
-        State: "!Disable",
-        GUID: "Guid",
-        Type: "cippconnectortype",
+        State: '!Disable',
+        GUID: 'Guid',
+        Type: 'cippconnectortype',
       },
-      confirmText: "Are you sure you want to disable this connector?",
-      color: "info",
+      confirmText: 'Are you sure you want to disable this connector?',
+      color: 'info',
     },
     {
-      label: "Delete Connector",
-      type: "POST",
-      url: "/api/RemoveExConnector",
+      label: 'Delete Connector',
+      type: 'POST',
+      url: '/api/RemoveExConnector',
       icon: <Delete />,
       data: {
-        GUID: "Guid",
-        Type: "cippconnectortype",
+        GUID: 'Guid',
+        Type: 'cippconnectortype',
       },
-      confirmText: "Are you sure you want to delete this connector?",
-      color: "danger",
+      confirmText: 'Are you sure you want to delete this connector?',
+      color: 'danger',
     },
-  ];
+  ]
 
   const simpleColumns = [
-    "Name",
-    "Enabled",
-    "Comment",
-    "cippconnectortype",
-    "TlsSenderCertificateName",
-    "SenderIPAddresses",
-    "IsTransportRuleScoped",
-    "SmartHosts",
-    "TlsSettings",
-    "TlsDomain",
-  ];
+    'Tenant',
+    'Name',
+    'Enabled',
+    'Comment',
+    'cippconnectortype',
+    'TlsSenderCertificateName',
+    'SenderIPAddresses',
+    'IsTransportRuleScoped',
+    'SmartHosts',
+    'TlsSettings',
+    'TlsDomain',
+  ]
 
   const filters = [
     {
-      filterName: "Inbound Connectors",
-      value: [{ id: "cippconnectortype", value: "Inbound" }],
-      type: "column",
+      filterName: 'Inbound Connectors',
+      value: [{ id: 'cippconnectortype', value: 'Inbound' }],
+      type: 'column',
     },
     {
-      filterName: "Outbound Connectors",
-      value: [{ id: "cippconnectortype", value: "Outbound" }],
-      type: "column",
+      filterName: 'Outbound Connectors',
+      value: [{ id: 'cippconnectortype', value: 'Outbound' }],
+      type: 'column',
     },
-  ];
+  ]
 
   const offCanvas = {
     extendedInfoFields: simpleColumns,
     actions: actions,
-  };
+  }
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListExchangeConnectors"
+      apiDataKey="Results"
       actions={actions}
       offCanvas={offCanvas}
       filters={filters}
       simpleColumns={simpleColumns}
       cardButton={<CippAddConnectorDrawer requiredPermissions={cardButtonPermissions} />}
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout allTenantsSupport={false}>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
+export default Page

--- a/src/pages/endpoint/MEM/assignment-filters/index.js
+++ b/src/pages/endpoint/MEM/assignment-filters/index.js
@@ -1,66 +1,66 @@
-import { Button } from "@mui/material";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import Link from "next/link";
-import { TrashIcon } from "@heroicons/react/24/outline";
-import { Edit, Add, Book } from "@mui/icons-material";
-import { Stack } from "@mui/system";
-import { useSettings } from "../../../../hooks/use-settings";
+import { Button } from '@mui/material'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import Link from 'next/link'
+import { TrashIcon } from '@heroicons/react/24/outline'
+import { Edit, Add, Book } from '@mui/icons-material'
+import { Stack } from '@mui/system'
+import { useSettings } from '../../../../hooks/use-settings'
 
 const Page = () => {
-  const pageTitle = "Assignment Filters";
-  const { currentTenant } = useSettings();
+  const pageTitle = 'Assignment Filters'
+  const { currentTenant } = useSettings()
 
   const actions = [
     {
-      label: "Create template based on filter",
-      type: "POST",
-      url: "/api/AddAssignmentFilterTemplate",
+      label: 'Create template based on filter',
+      type: 'POST',
+      url: '/api/AddAssignmentFilterTemplate',
       icon: <Book />,
       data: {
-        displayName: "displayName",
-        description: "description",
-        platform: "platform",
-        rule: "rule",
-        assignmentFilterManagementType: "assignmentFilterManagementType",
+        displayName: 'displayName',
+        description: 'description',
+        platform: 'platform',
+        rule: 'rule',
+        assignmentFilterManagementType: 'assignmentFilterManagementType',
       },
-      confirmText: "Are you sure you want to create a template based on this filter?",
+      confirmText: 'Are you sure you want to create a template based on this filter?',
       multiPost: false,
     },
     {
-      label: "Edit Filter",
-      link: "/endpoint/MEM/assignment-filters/edit?filterId=[id]",
+      label: 'Edit Filter',
+      link: '/endpoint/MEM/assignment-filters/edit?filterId=[id]',
       multiPost: false,
       icon: <Edit />,
-      color: "success",
+      color: 'success',
     },
     {
-      label: "Delete Filter",
-      type: "POST",
-      url: "/api/ExecAssignmentFilter",
+      label: 'Delete Filter',
+      type: 'POST',
+      url: '/api/ExecAssignmentFilter',
       icon: <TrashIcon />,
       data: {
-        ID: "id",
-        Action: "Delete",
+        ID: 'id',
+        Action: 'Delete',
       },
-      confirmText: "Are you sure you want to delete this assignment filter?",
+      confirmText: 'Are you sure you want to delete this assignment filter?',
       multiPost: false,
     },
-  ];
+  ]
 
   const offCanvas = {
     extendedInfoFields: [
-      "displayName",
-      "description",
-      "id",
-      "platform",
-      "rule",
-      "assignmentFilterManagementType",
-      "createdDateTime",
-      "lastModifiedDateTime",
+      'displayName',
+      'description',
+      'id',
+      'platform',
+      'rule',
+      'assignmentFilterManagementType',
+      'createdDateTime',
+      'lastModifiedDateTime',
     ],
     actions: actions,
-  };
+  }
 
   return (
     <CippTablePage
@@ -73,20 +73,22 @@ const Page = () => {
         </Stack>
       }
       apiUrl="/api/ListAssignmentFilters"
+      apiDataKey="Results"
       queryKey={`assignment-filters-${currentTenant}`}
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={[
-        "displayName",
-        "description",
-        "platform",
-        "assignmentFilterManagementType",
-        "rule",
+        'Tenant',
+        'displayName',
+        'description',
+        'platform',
+        'assignmentFilterManagementType',
+        'rule',
       ]}
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/endpoint/MEM/compare-policies/index.js
+++ b/src/pages/endpoint/MEM/compare-policies/index.js
@@ -1,10 +1,10 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { useForm, useWatch } from "react-hook-form";
-import { ApiPostCall } from "../../../../api/ApiCall";
-import { CippFormComponent } from "../../../../components/CippComponents/CippFormComponent";
-import { CippFormCondition } from "../../../../components/CippComponents/CippFormCondition";
-import { CippFormTenantSelector } from "../../../../components/CippComponents/CippFormTenantSelector";
-import { CippCodeBlock } from "../../../../components/CippComponents/CippCodeBlock";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { useForm, useWatch } from 'react-hook-form'
+import { ApiPostCall } from '../../../../api/ApiCall'
+import { CippFormComponent } from '../../../../components/CippComponents/CippFormComponent'
+import { CippFormCondition } from '../../../../components/CippComponents/CippFormCondition'
+import { CippFormTenantSelector } from '../../../../components/CippComponents/CippFormTenantSelector'
+import { CippCodeBlock } from '../../../../components/CippComponents/CippCodeBlock'
 import {
   Box,
   Button,
@@ -26,47 +26,47 @@ import {
   Stack,
   Chip,
   Skeleton,
-} from "@mui/material";
+} from '@mui/material'
 import {
   ExpandMore as ExpandMoreIcon,
   CompareArrows as CompareArrowsIcon,
   CheckCircle as CheckCircleIcon,
   Error as ErrorIcon,
-} from "@mui/icons-material";
-import { useEffect, useMemo } from "react";
-import { Grid } from "@mui/system";
-import CippPageCard from "../../../../components/CippCards/CippPageCard";
+} from '@mui/icons-material'
+import { useEffect, useMemo } from 'react'
+import { Grid } from '@mui/system'
+import CippPageCard from '../../../../components/CippCards/CippPageCard'
 
 const sourceTypeOptions = [
-  { label: "CIPP Template", value: "template" },
-  { label: "Tenant Policy", value: "tenantPolicy" },
-  { label: "Community Repository", value: "communityRepo" },
-];
+  { label: 'CIPP Template', value: 'template' },
+  { label: 'Tenant Policy', value: 'tenantPolicy' },
+  { label: 'Community Repository', value: 'communityRepo' },
+]
 
 const SourceSelector = ({ prefix, formControl, label }) => {
-  const tenantValue = useWatch({ control: formControl.control, name: `${prefix}.tenantFilter` });
-  const repoValue = useWatch({ control: formControl.control, name: `${prefix}.repo` });
-  const branchValue = useWatch({ control: formControl.control, name: `${prefix}.branch` });
+  const tenantValue = useWatch({ control: formControl.control, name: `${prefix}.tenantFilter` })
+  const repoValue = useWatch({ control: formControl.control, name: `${prefix}.repo` })
+  const branchValue = useWatch({ control: formControl.control, name: `${prefix}.branch` })
 
   useEffect(() => {
     if (repoValue?.addedFields?.defaultBranch) {
       formControl.setValue(`${prefix}.branch`, {
         label: repoValue.addedFields.defaultBranch,
         value: repoValue.addedFields.defaultBranch,
-      });
+      })
     } else {
-      formControl.setValue(`${prefix}.branch`, null);
+      formControl.setValue(`${prefix}.branch`, null)
     }
-    formControl.setValue(`${prefix}.repoFile`, null);
-  }, [repoValue?.value]);
+    formControl.setValue(`${prefix}.repoFile`, null)
+  }, [repoValue?.value])
 
   useEffect(() => {
-    formControl.setValue(`${prefix}.repoFile`, null);
-  }, [branchValue?.value]);
+    formControl.setValue(`${prefix}.repoFile`, null)
+  }, [branchValue?.value])
 
   return (
-    <Card variant="outlined" sx={{ height: "100%" }}>
-      <CardHeader title={label} titleTypographyProps={{ variant: "h6" }} />
+    <Card variant="outlined" sx={{ height: '100%' }}>
+      <CardHeader title={label} titleTypographyProps={{ variant: 'h6' }} />
       <CardContent>
         <Stack spacing={2}>
           <CippFormComponent
@@ -92,14 +92,14 @@ const SourceSelector = ({ prefix, formControl, label }) => {
               multiple={false}
               creatable={false}
               api={{
-                url: "/api/ListIntuneTemplates",
+                url: '/api/ListIntuneTemplates',
                 queryKey: `ListIntuneTemplates-${prefix}`,
                 labelField: (item) =>
-                  `${item.Displayname || item.displayName}${item.Type ? ` (${item.Type})` : ""}`,
-                valueField: "GUID",
-                addedField: { type: "Type" },
+                  `${item.Displayname || item.displayName}${item.Type ? ` (${item.Type})` : ''}`,
+                valueField: 'GUID',
+                addedField: { type: 'Type' },
               }}
-              validators={{ required: { value: true, message: "Template is required" } }}
+              validators={{ required: { value: true, message: 'Template is required' } }}
             />
           </CippFormCondition>
 
@@ -130,20 +130,21 @@ const SourceSelector = ({ prefix, formControl, label }) => {
                 api={
                   tenantValue
                     ? {
-                        url: "/api/ListIntunePolicy",
+                        url: '/api/ListIntunePolicy',
+                        dataKey: 'Results',
                         queryKey: `ListIntunePolicy-${prefix}-${tenantValue?.value}`,
                         tenantFilter: tenantValue?.value,
                         labelField: (item) => {
-                          const name = item.displayName || item.name || "Unnamed Policy";
-                          const type = item.PolicyTypeName || item.URLName || "";
-                          return type ? `${name} (${type})` : name;
+                          const name = item.displayName || item.name || 'Unnamed Policy'
+                          const type = item.PolicyTypeName || item.URLName || ''
+                          return type ? `${name} (${type})` : name
                         },
-                        valueField: "id",
-                        addedField: { urlName: "URLName" },
+                        valueField: 'id',
+                        addedField: { urlName: 'URLName' },
                       }
                     : undefined
                 }
-                validators={{ required: { value: true, message: "Policy is required" } }}
+                validators={{ required: { value: true, message: 'Policy is required' } }}
               />
             </Stack>
           </CippFormCondition>
@@ -163,14 +164,14 @@ const SourceSelector = ({ prefix, formControl, label }) => {
                 multiple={false}
                 creatable={false}
                 api={{
-                  url: "/api/ListCommunityRepos",
+                  url: '/api/ListCommunityRepos',
                   queryKey: `ListCommunityRepos-${prefix}`,
-                  dataKey: "Results",
-                  labelField: "FullName",
-                  valueField: "FullName",
-                  addedField: { defaultBranch: "DefaultBranch" },
+                  dataKey: 'Results',
+                  labelField: 'FullName',
+                  valueField: 'FullName',
+                  addedField: { defaultBranch: 'DefaultBranch' },
                 }}
-                validators={{ required: { value: true, message: "Repository is required" } }}
+                validators={{ required: { value: true, message: 'Repository is required' } }}
               />
 
               <CippFormComponent
@@ -184,16 +185,16 @@ const SourceSelector = ({ prefix, formControl, label }) => {
                 api={
                   repoValue?.value
                     ? {
-                        url: "/api/ExecGitHubAction",
+                        url: '/api/ExecGitHubAction',
                         queryKey: `GetBranches-${prefix}-${repoValue.value}`,
-                        dataKey: "Results",
-                        data: { Action: "GetBranches", FullName: repoValue.value },
-                        labelField: "name",
-                        valueField: "name",
+                        dataKey: 'Results',
+                        data: { Action: 'GetBranches', FullName: repoValue.value },
+                        labelField: 'name',
+                        valueField: 'name',
                       }
                     : undefined
                 }
-                validators={{ required: { value: true, message: "Branch is required" } }}
+                validators={{ required: { value: true, message: 'Branch is required' } }}
               />
 
               <CippFormComponent
@@ -207,166 +208,166 @@ const SourceSelector = ({ prefix, formControl, label }) => {
                 api={
                   repoValue?.value && branchValue?.value
                     ? {
-                        url: "/api/ExecGitHubAction",
+                        url: '/api/ExecGitHubAction',
                         queryKey: `GetFileTree-${prefix}-${repoValue.value}-${branchValue.value}`,
-                        dataKey: "Results",
+                        dataKey: 'Results',
                         data: {
-                          Action: "GetFileTree",
+                          Action: 'GetFileTree',
                           FullName: repoValue.value,
                           Branch: branchValue.value,
                         },
-                        labelField: "path",
-                        valueField: "path",
+                        labelField: 'path',
+                        valueField: 'path',
                       }
                     : undefined
                 }
-                validators={{ required: { value: true, message: "Template file is required" } }}
+                validators={{ required: { value: true, message: 'Template file is required' } }}
               />
             </Stack>
           </CippFormCondition>
         </Stack>
       </CardContent>
     </Card>
-  );
-};
+  )
+}
 
-const hasValue = (val) => val !== null && val !== undefined && val !== "";
+const hasValue = (val) => val !== null && val !== undefined && val !== ''
 
 const getDiffStatus = (row) => {
-  const a = hasValue(row.ExpectedValue);
-  const b = hasValue(row.ReceivedValue);
-  if (a && b) return "different";
-  if (a) return "onlyA";
-  if (b) return "onlyB";
-  return "equal";
-};
+  const a = hasValue(row.ExpectedValue)
+  const b = hasValue(row.ReceivedValue)
+  if (a && b) return 'different'
+  if (a) return 'onlyA'
+  if (b) return 'onlyB'
+  return 'equal'
+}
 
 const diffChipProps = {
-  different: { label: "Different", color: "error" },
-  onlyA: { label: "Only in A", color: "warning" },
-  onlyB: { label: "Only in B", color: "info" },
-  equal: { label: "Equal", color: "success" },
-};
+  different: { label: 'Different', color: 'error' },
+  onlyA: { label: 'Only in A', color: 'warning' },
+  onlyB: { label: 'Only in B', color: 'info' },
+  equal: { label: 'Equal', color: 'success' },
+}
 
 const DiffStatusChip = ({ row }) => {
-  const props = diffChipProps[getDiffStatus(row)];
-  return <Chip label={props.label} size="small" color={props.color} variant="outlined" />;
-};
+  const props = diffChipProps[getDiffStatus(row)]
+  return <Chip label={props.label} size="small" color={props.color} variant="outlined" />
+}
 
 const diffRowColors = {
-  different: { dark: "rgba(244, 67, 54, 0.08)", light: "rgba(244, 67, 54, 0.04)" },
-  onlyA: { dark: "rgba(255, 152, 0, 0.08)", light: "rgba(255, 152, 0, 0.04)" },
-  onlyB: { dark: "rgba(33, 150, 243, 0.08)", light: "rgba(33, 150, 243, 0.04)" },
-  equal: { dark: "transparent", light: "transparent" },
-};
+  different: { dark: 'rgba(244, 67, 54, 0.08)', light: 'rgba(244, 67, 54, 0.04)' },
+  onlyA: { dark: 'rgba(255, 152, 0, 0.08)', light: 'rgba(255, 152, 0, 0.04)' },
+  onlyB: { dark: 'rgba(33, 150, 243, 0.08)', light: 'rgba(33, 150, 243, 0.04)' },
+  equal: { dark: 'transparent', light: 'transparent' },
+}
 
 const getRowColor = (row, theme) => {
-  const colors = diffRowColors[getDiffStatus(row)];
-  return theme.palette.mode === "dark" ? colors.dark : colors.light;
-};
+  const colors = diffRowColors[getDiffStatus(row)]
+  return theme.palette.mode === 'dark' ? colors.dark : colors.light
+}
 
 const formatValue = (val) => {
-  if (val === null || val === undefined) return <Typography color="text.disabled">N/A</Typography>;
-  if (typeof val === "object") {
+  if (val === null || val === undefined) return <Typography color="text.disabled">N/A</Typography>
+  if (typeof val === 'object') {
     return (
       <Box
         component="pre"
-        sx={{ m: 0, fontSize: "0.8rem", whiteSpace: "pre-wrap", wordBreak: "break-word" }}
+        sx={{ m: 0, fontSize: '0.8rem', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
       >
         {JSON.stringify(val, null, 2)}
       </Box>
-    );
+    )
   }
-  return String(val);
-};
+  return String(val)
+}
 
 const Page = () => {
   const formControl = useForm({
-    mode: "onChange",
+    mode: 'onChange',
     defaultValues: {
-      sourceA: { type: "template" },
-      sourceB: { type: "template" },
+      sourceA: { type: 'template' },
+      sourceB: { type: 'template' },
     },
-  });
+  })
 
-  const compareApi = ApiPostCall({ relatedQueryKeys: [] });
+  const compareApi = ApiPostCall({ relatedQueryKeys: [] })
 
-  const sourceAType = useWatch({ control: formControl.control, name: "sourceA.type" });
-  const sourceBType = useWatch({ control: formControl.control, name: "sourceB.type" });
-  const sourceATemplate = useWatch({ control: formControl.control, name: "sourceA.template" });
-  const sourceBTemplate = useWatch({ control: formControl.control, name: "sourceB.template" });
-  const sourceAPolicy = useWatch({ control: formControl.control, name: "sourceA.policy" });
-  const sourceBPolicy = useWatch({ control: formControl.control, name: "sourceB.policy" });
-  const sourceARepoFile = useWatch({ control: formControl.control, name: "sourceA.repoFile" });
-  const sourceBRepoFile = useWatch({ control: formControl.control, name: "sourceB.repoFile" });
+  const sourceAType = useWatch({ control: formControl.control, name: 'sourceA.type' })
+  const sourceBType = useWatch({ control: formControl.control, name: 'sourceB.type' })
+  const sourceATemplate = useWatch({ control: formControl.control, name: 'sourceA.template' })
+  const sourceBTemplate = useWatch({ control: formControl.control, name: 'sourceB.template' })
+  const sourceAPolicy = useWatch({ control: formControl.control, name: 'sourceA.policy' })
+  const sourceBPolicy = useWatch({ control: formControl.control, name: 'sourceB.policy' })
+  const sourceARepoFile = useWatch({ control: formControl.control, name: 'sourceA.repoFile' })
+  const sourceBRepoFile = useWatch({ control: formControl.control, name: 'sourceB.repoFile' })
 
   const isSourceReady = (type, template, policy, repoFile) =>
-    type === "template"
+    type === 'template'
       ? !!template?.value
-      : type === "tenantPolicy"
+      : type === 'tenantPolicy'
         ? !!policy?.value
-        : type === "communityRepo"
+        : type === 'communityRepo'
           ? !!repoFile?.value
-          : false;
+          : false
 
   const canCompare =
     isSourceReady(sourceAType, sourceATemplate, sourceAPolicy, sourceARepoFile) &&
-    isSourceReady(sourceBType, sourceBTemplate, sourceBPolicy, sourceBRepoFile);
+    isSourceReady(sourceBType, sourceBTemplate, sourceBPolicy, sourceBRepoFile)
 
   const handleCompare = () => {
-    const values = formControl.getValues();
+    const values = formControl.getValues()
 
     const buildPayload = (source) => {
-      if (source.type === "template") {
+      if (source.type === 'template') {
         return {
-          type: "template",
+          type: 'template',
           templateGuid: source.template?.value,
-        };
+        }
       }
-      if (source.type === "communityRepo") {
+      if (source.type === 'communityRepo') {
         return {
-          type: "communityRepo",
+          type: 'communityRepo',
           fullName: source.repo?.value,
           branch: source.branch?.value,
           path: source.repoFile?.value,
-        };
+        }
       }
       return {
-        type: "tenantPolicy",
+        type: 'tenantPolicy',
         tenantFilter: source.tenantFilter?.value,
         policyId: source.policy?.value,
         urlName: source.policy?.addedFields?.urlName,
-      };
-    };
+      }
+    }
 
     compareApi.mutate({
-      url: "/api/ExecCompareIntunePolicy",
+      url: '/api/ExecCompareIntunePolicy',
       data: {
         sourceA: buildPayload(values.sourceA),
         sourceB: buildPayload(values.sourceB),
       },
-    });
-  };
+    })
+  }
 
   const results = useMemo(() => {
-    if (!compareApi.isSuccess) return null;
-    return compareApi.data?.data || compareApi.data;
-  }, [compareApi.isSuccess, compareApi.data]);
+    if (!compareApi.isSuccess) return null
+    return compareApi.data?.data || compareApi.data
+  }, [compareApi.isSuccess, compareApi.data])
 
   const errorMessage = useMemo(() => {
-    if (!compareApi.isError) return null;
-    const errData = compareApi.error?.response?.data;
-    return errData?.Results || compareApi.error?.message || "An error occurred";
-  }, [compareApi.isError, compareApi.error]);
+    if (!compareApi.isError) return null
+    const errData = compareApi.error?.response?.data
+    return errData?.Results || compareApi.error?.message || 'An error occurred'
+  }, [compareApi.isError, compareApi.error])
 
   const sourceAJson = useMemo(
-    () => (results?.sourceAData ? JSON.stringify(results.sourceAData, null, 2) : ""),
-    [results?.sourceAData],
-  );
+    () => (results?.sourceAData ? JSON.stringify(results.sourceAData, null, 2) : ''),
+    [results?.sourceAData]
+  )
   const sourceBJson = useMemo(
-    () => (results?.sourceBData ? JSON.stringify(results.sourceBData, null, 2) : ""),
-    [results?.sourceBData],
-  );
+    () => (results?.sourceBData ? JSON.stringify(results.sourceBData, null, 2) : ''),
+    [results?.sourceBData]
+  )
 
   return (
     <CippPageCard title="Compare Intune Policies" backButtonTitle="Back to Policies">
@@ -381,7 +382,7 @@ const Page = () => {
             </Grid>
           </Grid>
 
-          <Box sx={{ display: "flex", justifyContent: "center" }}>
+          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
             <Button
               variant="contained"
               size="large"
@@ -389,7 +390,7 @@ const Page = () => {
               onClick={handleCompare}
               disabled={!canCompare || compareApi.isPending}
             >
-              {compareApi.isPending ? "Comparing..." : "Compare"}
+              {compareApi.isPending ? 'Comparing...' : 'Compare'}
             </Button>
           </Box>
 
@@ -413,14 +414,14 @@ const Page = () => {
           {results && (
             <Stack spacing={3}>
               <Alert
-                severity={results.identical ? "success" : "warning"}
+                severity={results.identical ? 'success' : 'warning'}
                 icon={results.identical ? <CheckCircleIcon /> : <CompareArrowsIcon />}
               >
                 {results.identical
-                  ? "Policies are identical - no differences found."
-                  : `${results.Results?.length || 0} difference${results.Results?.length === 1 ? "" : "s"} found between policies.`}
-                <Box component="span" sx={{ display: "block", mt: 0.5 }}>
-                  <strong>A:</strong> {results.sourceALabel} &mdash; <strong>B:</strong>{" "}
+                  ? 'Policies are identical - no differences found.'
+                  : `${results.Results?.length || 0} difference${results.Results?.length === 1 ? '' : 's'} found between policies.`}
+                <Box component="span" sx={{ display: 'block', mt: 0.5 }}>
+                  <strong>A:</strong> {results.sourceALabel} &mdash; <strong>B:</strong>{' '}
                   {results.sourceBLabel}
                 </Box>
               </Alert>
@@ -430,10 +431,10 @@ const Page = () => {
                   <Table size="small">
                     <TableHead>
                       <TableRow>
-                        <TableCell sx={{ fontWeight: "bold" }}>Property</TableCell>
-                        <TableCell sx={{ fontWeight: "bold" }}>Source A</TableCell>
-                        <TableCell sx={{ fontWeight: "bold" }}>Source B</TableCell>
-                        <TableCell sx={{ fontWeight: "bold", width: 120 }}>Status</TableCell>
+                        <TableCell sx={{ fontWeight: 'bold' }}>Property</TableCell>
+                        <TableCell sx={{ fontWeight: 'bold' }}>Source A</TableCell>
+                        <TableCell sx={{ fontWeight: 'bold' }}>Source B</TableCell>
+                        <TableCell sx={{ fontWeight: 'bold', width: 120 }}>Status</TableCell>
                       </TableRow>
                     </TableHead>
                     <TableBody>
@@ -479,9 +480,9 @@ const Page = () => {
         </Stack>
       </CardContent>
     </CippPageCard>
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/endpoint/MEM/devices/index.js
+++ b/src/pages/endpoint/MEM/devices/index.js
@@ -1,10 +1,10 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { CippApiDialog } from "../../../../components/CippComponents/CippApiDialog.jsx";
-import { useSettings } from "../../../../hooks/use-settings";
-import { useDialog } from "../../../../hooks/use-dialog.js";
-import { EyeIcon } from "@heroicons/react/24/outline";
-import { Box, Button } from "@mui/material";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { CippApiDialog } from '../../../../components/CippComponents/CippApiDialog.jsx'
+import { useSettings } from '../../../../hooks/use-settings'
+import { useDialog } from '../../../../hooks/use-dialog.js'
+import { EyeIcon } from '@heroicons/react/24/outline'
+import { Box, Button } from '@mui/material'
 import {
   Sync,
   RestartAlt,
@@ -20,383 +20,383 @@ import {
   AutoMode,
   Recycling,
   ManageAccounts,
-} from "@mui/icons-material";
+} from '@mui/icons-material'
 
 const Page = () => {
-  const pageTitle = "Devices";
-  const tenantFilter = useSettings().currentTenant;
-  const depSyncDialog = useDialog();
+  const pageTitle = 'Devices'
+  const tenantFilter = useSettings().currentTenant
+  const depSyncDialog = useDialog()
 
   const actions = [
     {
-      label: "View Device",
+      label: 'View Device',
       link: `/endpoint/MEM/devices/device?deviceId=[id]`,
-      color: "info",
+      color: 'info',
       icon: <EyeIcon />,
       multiPost: false,
     },
     {
-      label: "View in Intune",
+      label: 'View in Intune',
       link: `https://intune.microsoft.com/${tenantFilter}/#view/Microsoft_Intune_Devices/DeviceSettingsMenuBlade/~/overview/mdmDeviceId/[id]`,
-      color: "info",
+      color: 'info',
       icon: <EyeIcon />,
-      target: "_blank",
+      target: '_blank',
       multiPost: false,
       external: true,
     },
     {
-      label: "Change Primary User",
-      type: "POST",
+      label: 'Change Primary User',
+      type: 'POST',
       icon: <ManageAccounts />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "!users",
+        GUID: 'id',
+        Action: '!users',
       },
       fields: [
         {
-          type: "autoComplete",
-          name: "user",
-          label: "Select User",
+          type: 'autoComplete',
+          name: 'user',
+          label: 'Select User',
           multiple: false,
           creatable: false,
           api: {
-            url: "/api/ListGraphRequest",
+            url: '/api/ListGraphRequest',
             data: {
-              Endpoint: "users",
-              $select: "id,displayName,userPrincipalName",
+              Endpoint: 'users',
+              $select: 'id,displayName,userPrincipalName',
               $top: 999,
               $count: true,
             },
-            queryKey: "ListUsersAutoComplete",
-            dataKey: "Results",
+            queryKey: 'ListUsersAutoComplete',
+            dataKey: 'Results',
             labelField: (user) => `${user.displayName} (${user.userPrincipalName})`,
-            valueField: "id",
+            valueField: 'id',
             addedField: {
-              userPrincipalName: "userPrincipalName",
+              userPrincipalName: 'userPrincipalName',
             },
             showRefresh: true,
           },
         },
       ],
-      confirmText: "Select the User to set as the primary user for [deviceName]",
+      confirmText: 'Select the User to set as the primary user for [deviceName]',
     },
     {
-      label: "Rename Device",
-      type: "POST",
+      label: 'Rename Device',
+      type: 'POST',
       icon: <Edit />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "setDeviceName",
+        GUID: 'id',
+        Action: 'setDeviceName',
       },
-      confirmText: "Enter the new name for the device",
+      confirmText: 'Enter the new name for the device',
       fields: [
         {
-          type: "textField",
-          name: "input",
-          label: "New Device Name",
+          type: 'textField',
+          name: 'input',
+          label: 'New Device Name',
           required: true,
         },
       ],
     },
     {
-      label: "Sync Device",
-      type: "POST",
+      label: 'Sync Device',
+      type: 'POST',
       icon: <Sync />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "syncDevice",
+        GUID: 'id',
+        Action: 'syncDevice',
       },
-      confirmText: "Are you sure you want to sync [deviceName]?",
+      confirmText: 'Are you sure you want to sync [deviceName]?',
     },
     {
-      label: "Reboot Device",
-      type: "POST",
+      label: 'Reboot Device',
+      type: 'POST',
       icon: <RestartAlt />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "rebootNow",
+        GUID: 'id',
+        Action: 'rebootNow',
       },
-      confirmText: "Are you sure you want to reboot [deviceName]?",
+      confirmText: 'Are you sure you want to reboot [deviceName]?',
     },
     {
-      label: "Locate Device",
-      type: "POST",
+      label: 'Locate Device',
+      type: 'POST',
       icon: <LocationOn />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "locateDevice",
+        GUID: 'id',
+        Action: 'locateDevice',
       },
-      confirmText: "Are you sure you want to locate [deviceName]?",
+      confirmText: 'Are you sure you want to locate [deviceName]?',
     },
     {
-      label: "Retrieve LAPS password",
-      type: "POST",
+      label: 'Retrieve LAPS password',
+      type: 'POST',
       icon: <Password />,
-      url: "/api/ExecGetLocalAdminPassword",
+      url: '/api/ExecGetLocalAdminPassword',
       data: {
-        GUID: "azureADDeviceId",
+        GUID: 'azureADDeviceId',
       },
-      condition: (row) => row.operatingSystem === "Windows",
-      confirmText: "Are you sure you want to retrieve the local admin password for [deviceName]?",
+      condition: (row) => row.operatingSystem === 'Windows',
+      confirmText: 'Are you sure you want to retrieve the local admin password for [deviceName]?',
     },
     {
-      label: "Rotate Local Admin Password",
-      type: "POST",
+      label: 'Rotate Local Admin Password',
+      type: 'POST',
       icon: <PasswordOutlined />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "RotateLocalAdminPassword",
+        GUID: 'id',
+        Action: 'RotateLocalAdminPassword',
       },
-      condition: (row) => row.operatingSystem === "Windows",
-      confirmText: "Are you sure you want to rotate the password for [deviceName]?",
+      condition: (row) => row.operatingSystem === 'Windows',
+      confirmText: 'Are you sure you want to rotate the password for [deviceName]?',
     },
     {
-      label: "Retrieve BitLocker Keys",
-      type: "POST",
+      label: 'Retrieve BitLocker Keys',
+      type: 'POST',
       icon: <Key />,
-      url: "/api/ExecGetRecoveryKey",
+      url: '/api/ExecGetRecoveryKey',
       data: {
-        GUID: "azureADDeviceId",
-        RecoveryKeyType: "!BitLocker",
+        GUID: 'azureADDeviceId',
+        RecoveryKeyType: '!BitLocker',
       },
-      condition: (row) => row.operatingSystem === "Windows",
-      confirmText: "Are you sure you want to retrieve the BitLocker keys for [deviceName]?",
+      condition: (row) => row.operatingSystem === 'Windows',
+      confirmText: 'Are you sure you want to retrieve the BitLocker keys for [deviceName]?',
     },
     {
-      label: "Retrieve FileVault Key",
-      type: "POST",
+      label: 'Retrieve FileVault Key',
+      type: 'POST',
       icon: <Security />,
-      url: "/api/ExecGetRecoveryKey",
+      url: '/api/ExecGetRecoveryKey',
       data: {
-        GUID: "id",
-        RecoveryKeyType: "!FileVault",
+        GUID: 'id',
+        RecoveryKeyType: '!FileVault',
       },
-      condition: (row) => row.operatingSystem === "macOS",
-      confirmText: "Are you sure you want to retrieve the FileVault key for [deviceName]?",
+      condition: (row) => row.operatingSystem === 'macOS',
+      confirmText: 'Are you sure you want to retrieve the FileVault key for [deviceName]?',
     },
     {
-      label: "Reset Passcode",
-      type: "POST",
+      label: 'Reset Passcode',
+      type: 'POST',
       icon: <PasswordOutlined />,
-      url: "/api/ExecDevicePasscodeAction",
+      url: '/api/ExecDevicePasscodeAction',
       data: {
-        GUID: "id",
-        Action: "resetPasscode",
+        GUID: 'id',
+        Action: 'resetPasscode',
       },
-      condition: (row) => row.operatingSystem === "Android",
+      condition: (row) => row.operatingSystem === 'Android',
       confirmText:
-        "Are you sure you want to reset the passcode for [deviceName]? A new passcode will be generated and displayed.",
+        'Are you sure you want to reset the passcode for [deviceName]? A new passcode will be generated and displayed.',
     },
     {
-      label: "Remove Passcode",
-      type: "POST",
+      label: 'Remove Passcode',
+      type: 'POST',
       icon: <Password />,
-      url: "/api/ExecDevicePasscodeAction",
+      url: '/api/ExecDevicePasscodeAction',
       data: {
-        GUID: "id",
-        Action: "resetPasscode",
+        GUID: 'id',
+        Action: 'resetPasscode',
       },
-      condition: (row) => row.operatingSystem === "iOS",
+      condition: (row) => row.operatingSystem === 'iOS',
       confirmText:
-        "Are you sure you want to remove the passcode from [deviceName]? This will remove the device passcode requirement.",
+        'Are you sure you want to remove the passcode from [deviceName]? This will remove the device passcode requirement.',
     },
     {
-      label: "Windows Defender Full Scan",
-      type: "POST",
+      label: 'Windows Defender Full Scan',
+      type: 'POST',
       icon: <Security />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "WindowsDefenderScan",
+        GUID: 'id',
+        Action: 'WindowsDefenderScan',
         quickScan: false,
       },
-      confirmText: "Are you sure you want to perform a full scan on [deviceName]?",
+      confirmText: 'Are you sure you want to perform a full scan on [deviceName]?',
     },
     {
-      label: "Windows Defender Quick Scan",
-      type: "POST",
+      label: 'Windows Defender Quick Scan',
+      type: 'POST',
       icon: <FindInPage />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "WindowsDefenderScan",
+        GUID: 'id',
+        Action: 'WindowsDefenderScan',
         quickScan: true,
       },
-      confirmText: "Are you sure you want to perform a quick scan on [deviceName]?",
+      confirmText: 'Are you sure you want to perform a quick scan on [deviceName]?',
     },
     {
-      label: "Update Windows Defender",
-      type: "POST",
+      label: 'Update Windows Defender',
+      type: 'POST',
       icon: <Shield />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "windowsDefenderUpdateSignatures",
+        GUID: 'id',
+        Action: 'windowsDefenderUpdateSignatures',
       },
       confirmText:
-        "Are you sure you want to update the Windows Defender signatures for [deviceName]?",
+        'Are you sure you want to update the Windows Defender signatures for [deviceName]?',
     },
     {
-      label: "Generate logs and ship to MEM",
-      type: "POST",
+      label: 'Generate logs and ship to MEM',
+      type: 'POST',
       icon: <Archive />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "createDeviceLogCollectionRequest",
+        GUID: 'id',
+        Action: 'createDeviceLogCollectionRequest',
       },
-      condition: (row) => row.operatingSystem === "Windows",
+      condition: (row) => row.operatingSystem === 'Windows',
       confirmText:
-        "Are you sure you want to generate logs for device [deviceName] and ship these to MEM?",
+        'Are you sure you want to generate logs for device [deviceName] and ship these to MEM?',
     },
     {
-      label: "Fresh Start (Remove user data)",
-      type: "POST",
+      label: 'Fresh Start (Remove user data)',
+      type: 'POST',
       icon: <RestartAlt />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "cleanWindowsDevice",
+        GUID: 'id',
+        Action: 'cleanWindowsDevice',
         keepUserData: false,
       },
-      condition: (row) => row.operatingSystem === "Windows",
-      confirmText: "Are you sure you want to Fresh Start [deviceName]?",
+      condition: (row) => row.operatingSystem === 'Windows',
+      confirmText: 'Are you sure you want to Fresh Start [deviceName]?',
     },
     {
-      label: "Fresh Start (Do not remove user data)",
-      type: "POST",
+      label: 'Fresh Start (Do not remove user data)',
+      type: 'POST',
       icon: <RestartAlt />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "cleanWindowsDevice",
+        GUID: 'id',
+        Action: 'cleanWindowsDevice',
         keepUserData: true,
       },
-      condition: (row) => row.operatingSystem === "Windows",
-      confirmText: "Are you sure you want to Fresh Start [deviceName]?",
+      condition: (row) => row.operatingSystem === 'Windows',
+      confirmText: 'Are you sure you want to Fresh Start [deviceName]?',
     },
     {
-      label: "Wipe Device, keep enrollment data",
-      type: "POST",
+      label: 'Wipe Device, keep enrollment data',
+      type: 'POST',
       icon: <RestartAlt />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "cleanWindowsDevice",
+        GUID: 'id',
+        Action: 'cleanWindowsDevice',
         keepUserData: false,
         keepEnrollmentData: true,
       },
-      condition: (row) => row.operatingSystem === "Windows",
-      confirmText: "Are you sure you want to wipe [deviceName], and retain enrollment data?",
+      condition: (row) => row.operatingSystem === 'Windows',
+      confirmText: 'Are you sure you want to wipe [deviceName], and retain enrollment data?',
     },
     {
-      label: "Wipe Device, remove enrollment data",
-      type: "POST",
+      label: 'Wipe Device, remove enrollment data',
+      type: 'POST',
       icon: <RestartAlt />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "cleanWindowsDevice",
+        GUID: 'id',
+        Action: 'cleanWindowsDevice',
         keepUserData: false,
         keepEnrollmentData: false,
       },
-      condition: (row) => row.operatingSystem === "Windows",
-      confirmText: "Are you sure you want to wipe [deviceName], and remove enrollment data?",
+      condition: (row) => row.operatingSystem === 'Windows',
+      confirmText: 'Are you sure you want to wipe [deviceName], and remove enrollment data?',
     },
     {
-      label: "Wipe Device, keep enrollment data, and continue at powerloss",
-      type: "POST",
+      label: 'Wipe Device, keep enrollment data, and continue at powerloss',
+      type: 'POST',
       icon: <RestartAlt />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "cleanWindowsDevice",
+        GUID: 'id',
+        Action: 'cleanWindowsDevice',
         keepEnrollmentData: true,
         keepUserData: false,
         useProtectedWipe: true,
       },
-      condition: (row) => row.operatingSystem === "Windows",
+      condition: (row) => row.operatingSystem === 'Windows',
       confirmText:
-        "Are you sure you want to wipe [deviceName]? This will retain enrollment data. Continuing at powerloss may cause boot issues if wipe is interrupted.",
+        'Are you sure you want to wipe [deviceName]? This will retain enrollment data. Continuing at powerloss may cause boot issues if wipe is interrupted.',
     },
     {
-      label: "Wipe Device, remove enrollment data, and continue at powerloss",
-      type: "POST",
+      label: 'Wipe Device, remove enrollment data, and continue at powerloss',
+      type: 'POST',
       icon: <RestartAlt />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "cleanWindowsDevice",
+        GUID: 'id',
+        Action: 'cleanWindowsDevice',
         keepEnrollmentData: false,
         keepUserData: false,
         useProtectedWipe: true,
       },
-      condition: (row) => row.operatingSystem === "Windows",
+      condition: (row) => row.operatingSystem === 'Windows',
       confirmText:
-        "Are you sure you want to wipe [deviceName]? This will also remove enrollment data. Continuing at powerloss may cause boot issues if wipe is interrupted.",
+        'Are you sure you want to wipe [deviceName]? This will also remove enrollment data. Continuing at powerloss may cause boot issues if wipe is interrupted.',
     },
     {
-      label: "Autopilot Reset",
-      type: "POST",
+      label: 'Autopilot Reset',
+      type: 'POST',
       icon: <AutoMode />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "wipe",
-        keepUserData: "false",
-        keepEnrollmentData: "true",
+        GUID: 'id',
+        Action: 'wipe',
+        keepUserData: 'false',
+        keepEnrollmentData: 'true',
       },
-      condition: (row) => row.operatingSystem === "Windows",
-      confirmText: "Are you sure you want to Autopilot Reset [deviceName]?",
+      condition: (row) => row.operatingSystem === 'Windows',
+      confirmText: 'Are you sure you want to Autopilot Reset [deviceName]?',
     },
     {
-      label: "Delete device",
-      type: "POST",
+      label: 'Delete device',
+      type: 'POST',
       icon: <Recycling />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "delete",
+        GUID: 'id',
+        Action: 'delete',
       },
-      confirmText: "Are you sure you want to delete [deviceName]?",
+      confirmText: 'Are you sure you want to delete [deviceName]?',
     },
     {
-      label: "Retire device",
-      type: "POST",
+      label: 'Retire device',
+      type: 'POST',
       icon: <Recycling />,
-      url: "/api/ExecDeviceAction",
+      url: '/api/ExecDeviceAction',
       data: {
-        GUID: "id",
-        Action: "retire",
+        GUID: 'id',
+        Action: 'retire',
       },
-      confirmText: "Are you sure you want to retire [deviceName]?",
+      confirmText: 'Are you sure you want to retire [deviceName]?',
     },
-  ];
+  ]
 
   const offCanvas = {
-    extendedInfoFields: ["deviceName", "userPrincipalName"],
+    extendedInfoFields: ['deviceName', 'userPrincipalName'],
     actions: actions,
-  };
+  }
 
   const simpleColumns = [
-    "deviceName",
-    "userPrincipalName",
-    "complianceState",
-    "manufacturer",
-    "model",
-    "operatingSystem",
-    "osVersion",
-    "enrolledDateTime",
-    "managedDeviceOwnerType",
-    "deviceEnrollmentType",
-    "joinType",
-  ];
+    'deviceName',
+    'userPrincipalName',
+    'complianceState',
+    'manufacturer',
+    'model',
+    'operatingSystem',
+    'osVersion',
+    'enrolledDateTime',
+    'managedDeviceOwnerType',
+    'deviceEnrollmentType',
+    'joinType',
+  ]
 
   return (
     <>
@@ -404,7 +404,7 @@ const Page = () => {
         title={pageTitle}
         apiUrl="/api/ListGraphRequest"
         apiData={{
-          Endpoint: "deviceManagement/managedDevices",
+          Endpoint: 'deviceManagement/managedDevices',
         }}
         apiDataKey="Results"
         actions={actions}
@@ -412,7 +412,7 @@ const Page = () => {
         offCanvas={offCanvas}
         simpleColumns={simpleColumns}
         cardButton={
-          <Box sx={{ display: "flex", gap: 1 }}>
+          <Box sx={{ display: 'flex', gap: 1 }}>
             <Button onClick={depSyncDialog.handleOpen} startIcon={<Sync />}>
               Sync DEP
             </Button>
@@ -423,16 +423,16 @@ const Page = () => {
         title="Sync DEP Tokens"
         createDialog={depSyncDialog}
         api={{
-          type: "POST",
-          url: "/api/ExecSyncDEP",
+          type: 'POST',
+          url: '/api/ExecSyncDEP',
           data: {},
           confirmText: `Are you sure you want to sync Apple Device Enrollment Program (DEP) tokens? This will sync all DEP tokens for ${tenantFilter}. This may take several minutes to complete in the background, and can only be done every 15 minutes.`,
         }}
       />
     </>
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/endpoint/MEM/list-appprotection-policies/index.js
+++ b/src/pages/endpoint/MEM/list-appprotection-policies/index.js
@@ -1,47 +1,49 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { PermissionButton } from "../../../../utils/permissions.js";
-import { CippPolicyDeployDrawer } from "../../../../components/CippComponents/CippPolicyDeployDrawer.jsx";
-import { useSettings } from "../../../../hooks/use-settings.js";
-import { useCippIntunePolicyActions } from "../../../../components/CippComponents/CippIntunePolicyActions.jsx";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { PermissionButton } from '../../../../utils/permissions.js'
+import { CippPolicyDeployDrawer } from '../../../../components/CippComponents/CippPolicyDeployDrawer.jsx'
+import { useSettings } from '../../../../hooks/use-settings.js'
+import { useCippIntunePolicyActions } from '../../../../components/CippComponents/CippIntunePolicyActions.jsx'
 
 const Page = () => {
-  const pageTitle = "App Protection & Configuration Policies";
-  const cardButtonPermissions = ["Endpoint.MEM.ReadWrite"];
-  const tenant = useSettings().currentTenant;
+  const pageTitle = 'App Protection & Configuration Policies'
+  const cardButtonPermissions = ['Endpoint.MEM.ReadWrite']
+  const tenant = useSettings().currentTenant
 
-  const actions = useCippIntunePolicyActions(tenant, "URLName", {
+  const actions = useCippIntunePolicyActions(tenant, 'URLName', {
     templateData: {
-      ID: "id",
-      URLName: "managedAppPolicies",
+      ID: 'id',
+      URLName: 'managedAppPolicies',
     },
-    platformType: "deviceAppManagement",
-    deleteUrlName: "URLName",
-  });
+    platformType: 'deviceAppManagement',
+    deleteUrlName: 'URLName',
+  })
 
   const offCanvas = {
     extendedInfoFields: [
-      "createdDateTime",
-      "displayName",
-      "lastModifiedDateTime",
-      "PolicyTypeName",
-      "PolicySource",
+      'createdDateTime',
+      'displayName',
+      'lastModifiedDateTime',
+      'PolicyTypeName',
+      'PolicySource',
     ],
     actions: actions,
-  };
+  }
 
   const simpleColumns = [
-    "displayName",
-    "PolicyTypeName",
-    "PolicyAssignment",
-    "PolicyExclude",
-    "lastModifiedDateTime",
-  ];
+    'Tenant',
+    'displayName',
+    'PolicyTypeName',
+    'PolicyAssignment',
+    'PolicyExclude',
+    'lastModifiedDateTime',
+  ]
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListAppProtectionPolicies"
+      apiDataKey="Results"
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={simpleColumns}
@@ -53,8 +55,8 @@ const Page = () => {
         />
       }
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
+export default Page

--- a/src/pages/endpoint/MEM/list-compliance-policies/index.js
+++ b/src/pages/endpoint/MEM/list-compliance-policies/index.js
@@ -1,46 +1,48 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { PermissionButton } from "../../../../utils/permissions.js";
-import { CippPolicyDeployDrawer } from "../../../../components/CippComponents/CippPolicyDeployDrawer.jsx";
-import { useSettings } from "../../../../hooks/use-settings.js";
-import { useCippIntunePolicyActions } from "../../../../components/CippComponents/CippIntunePolicyActions.jsx";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { PermissionButton } from '../../../../utils/permissions.js'
+import { CippPolicyDeployDrawer } from '../../../../components/CippComponents/CippPolicyDeployDrawer.jsx'
+import { useSettings } from '../../../../hooks/use-settings.js'
+import { useCippIntunePolicyActions } from '../../../../components/CippComponents/CippIntunePolicyActions.jsx'
 
 const Page = () => {
-  const pageTitle = "Intune Compliance Policies";
-  const cardButtonPermissions = ["Endpoint.MEM.ReadWrite"];
-  const tenant = useSettings().currentTenant;
+  const pageTitle = 'Intune Compliance Policies'
+  const cardButtonPermissions = ['Endpoint.MEM.ReadWrite']
+  const tenant = useSettings().currentTenant
 
-  const actions = useCippIntunePolicyActions(tenant, "deviceCompliancePolicies", {
+  const actions = useCippIntunePolicyActions(tenant, 'deviceCompliancePolicies', {
     templateData: {
-      ID: "id",
-      ODataType: "@odata.type",
+      ID: 'id',
+      ODataType: '@odata.type',
     },
-    deleteUrlName: "deviceCompliancePolicies",
-  });
+    deleteUrlName: 'deviceCompliancePolicies',
+  })
 
   const offCanvas = {
     extendedInfoFields: [
-      "createdDateTime",
-      "displayName",
-      "lastModifiedDateTime",
-      "PolicyTypeName",
+      'createdDateTime',
+      'displayName',
+      'lastModifiedDateTime',
+      'PolicyTypeName',
     ],
     actions: actions,
-  };
+  }
 
   const simpleColumns = [
-    "displayName",
-    "PolicyTypeName",
-    "PolicyAssignment",
-    "PolicyExclude",
-    "description",
-    "lastModifiedDateTime",
-  ];
+    'Tenant',
+    'displayName',
+    'PolicyTypeName',
+    'PolicyAssignment',
+    'PolicyExclude',
+    'description',
+    'lastModifiedDateTime',
+  ]
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListCompliancePolicies"
+      apiDataKey="Results"
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={simpleColumns}
@@ -52,8 +54,8 @@ const Page = () => {
         />
       }
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
+export default Page

--- a/src/pages/endpoint/MEM/list-policies/index.js
+++ b/src/pages/endpoint/MEM/list-policies/index.js
@@ -1,46 +1,48 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { PermissionButton } from "../../../../utils/permissions.js";
-import { CippPolicyDeployDrawer } from "../../../../components/CippComponents/CippPolicyDeployDrawer.jsx";
-import { useSettings } from "../../../../hooks/use-settings.js";
-import { useCippIntunePolicyActions } from "../../../../components/CippComponents/CippIntunePolicyActions.jsx";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { PermissionButton } from '../../../../utils/permissions.js'
+import { CippPolicyDeployDrawer } from '../../../../components/CippComponents/CippPolicyDeployDrawer.jsx'
+import { useSettings } from '../../../../hooks/use-settings.js'
+import { useCippIntunePolicyActions } from '../../../../components/CippComponents/CippIntunePolicyActions.jsx'
 
 const Page = () => {
-  const pageTitle = "Configuration Policies";
-  const cardButtonPermissions = ["Endpoint.MEM.ReadWrite"];
-  const tenant = useSettings().currentTenant;
+  const pageTitle = 'Configuration Policies'
+  const cardButtonPermissions = ['Endpoint.MEM.ReadWrite']
+  const tenant = useSettings().currentTenant
 
-  const actions = useCippIntunePolicyActions(tenant, "URLName", {
+  const actions = useCippIntunePolicyActions(tenant, 'URLName', {
     templateData: {
-      ID: "id",
-      URLName: "URLName",
+      ID: 'id',
+      URLName: 'URLName',
     },
-    deleteUrlName: "URLName",
-  });
+    deleteUrlName: 'URLName',
+  })
 
   const offCanvas = {
     extendedInfoFields: [
-      "createdDateTime",
-      "displayName",
-      "lastModifiedDateTime",
-      "PolicyTypeName",
+      'createdDateTime',
+      'displayName',
+      'lastModifiedDateTime',
+      'PolicyTypeName',
     ],
     actions: actions,
-  };
+  }
 
   const simpleColumns = [
-    "displayName",
-    "PolicyTypeName",
-    "PolicyAssignment",
-    "PolicyExclude",
-    "description",
-    "lastModifiedDateTime",
-  ];
+    'Tenant',
+    'displayName',
+    'PolicyTypeName',
+    'PolicyAssignment',
+    'PolicyExclude',
+    'description',
+    'lastModifiedDateTime',
+  ]
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListIntunePolicy?type=ESP"
+      apiDataKey="Results"
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={simpleColumns}
@@ -52,8 +54,8 @@ const Page = () => {
         />
       }
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
+export default Page

--- a/src/pages/endpoint/MEM/list-scripts/index.jsx
+++ b/src/pages/endpoint/MEM/list-scripts/index.jsx
@@ -1,13 +1,13 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage";
+import { Layout as DashboardLayout } from '../../../../layouts/index'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage'
 import {
   TrashIcon,
   PencilIcon,
   UserIcon,
   UserGroupIcon,
   GlobeAltIcon,
-} from "@heroicons/react/24/outline";
-import { showToast } from "../../../../store/toasts";
+} from '@heroicons/react/24/outline'
+import { showToast } from '../../../../store/toasts'
 import {
   Button,
   Dialog,
@@ -16,92 +16,92 @@ import {
   IconButton,
   CircularProgress,
   DialogActions,
-} from "@mui/material";
-import { CippCodeBlock } from "../../../../components/CippComponents/CippCodeBlock";
-import { useState, useEffect, useMemo } from "react";
-import { useDispatch } from "react-redux";
-import { Close, Save, LaptopChromebook } from "@mui/icons-material";
-import { useSettings } from "../../../../hooks/use-settings";
-import { Stack } from "@mui/system";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+} from '@mui/material'
+import { CippCodeBlock } from '../../../../components/CippComponents/CippCodeBlock'
+import { useState, useEffect, useMemo } from 'react'
+import { useDispatch } from 'react-redux'
+import { Close, Save, LaptopChromebook } from '@mui/icons-material'
+import { useSettings } from '../../../../hooks/use-settings'
+import { Stack } from '@mui/system'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 const assignmentModeOptions = [
-  { label: "Replace existing assignments", value: "replace" },
-  { label: "Append to existing assignments", value: "append" },
-];
+  { label: 'Replace existing assignments', value: 'replace' },
+  { label: 'Append to existing assignments', value: 'append' },
+]
 
 const Page = () => {
-  const pageTitle = "Scripts";
-  const [codeOpen, setCodeOpen] = useState(false);
-  const [codeContent, setCodeContent] = useState("");
-  const [scriptId, setScriptId] = useState(null);
-  const [saveScript, setSaveScript] = useState(false);
-  const [codeContentChanged, setCodeContentChanged] = useState(false);
-  const [warnOpen, setWarnOpen] = useState(false);
-  const [currentScript, setCurrentScript] = useState(null);
+  const pageTitle = 'Scripts'
+  const [codeOpen, setCodeOpen] = useState(false)
+  const [codeContent, setCodeContent] = useState('')
+  const [scriptId, setScriptId] = useState(null)
+  const [saveScript, setSaveScript] = useState(false)
+  const [codeContentChanged, setCodeContentChanged] = useState(false)
+  const [warnOpen, setWarnOpen] = useState(false)
+  const [currentScript, setCurrentScript] = useState(null)
 
-  const dispatch = useDispatch();
+  const dispatch = useDispatch()
 
   const language = useMemo(() => {
-    return currentScript?.scriptType?.toLowerCase() === ("macos" || "linux")
-      ? "shell"
-      : "powershell";
-  }, [currentScript?.scriptType]);
+    return currentScript?.scriptType?.toLowerCase() === ('macos' || 'linux')
+      ? 'shell'
+      : 'powershell'
+  }, [currentScript?.scriptType])
 
-  const tenantFilter = useSettings().currentTenant;
+  const tenantFilter = useSettings().currentTenant
   const {
     isLoading: scriptIsLoading,
     isRefetching: scriptIsFetching,
     refetch: scriptRefetch,
     data,
   } = useQuery({
-    queryKey: ["script", { scriptId }],
+    queryKey: ['script', { scriptId }],
     queryFn: async () => {
       const response = await fetch(
         `/api/EditIntuneScript?TenantFilter=${tenantFilter}&ScriptId=${scriptId}`
-      );
-      return response.json();
+      )
+      return response.json()
     },
     refetchOnWindowFocus: false,
     enabled: false,
-  });
+  })
 
   // Refetch the script on scriptId change
   useEffect(() => {
     if (scriptId) {
       scriptRefetch().then(({ data }) => {
-        setCurrentScript(data);
-        const scriptBytes = Buffer.from(data.scriptContent, "base64");
-        setCodeContent(scriptBytes.toString("ascii"));
-      });
+        setCurrentScript(data)
+        const scriptBytes = Buffer.from(data.scriptContent, 'base64')
+        setCodeContent(scriptBytes.toString('ascii'))
+      })
     }
-  }, [scriptId, scriptRefetch]);
+  }, [scriptId, scriptRefetch])
 
   const handleScriptEdit = async (row, action) => {
-    setScriptId(row.id);
-    setCodeOpen(!codeOpen);
-  };
+    setScriptId(row.id)
+    setCodeOpen(!codeOpen)
+  }
 
   const codeChange = (newValue, evt) => {
-    setCodeContent(newValue);
-    setCodeContentChanged(true);
-  };
+    setCodeContent(newValue)
+    setCodeContentChanged(true)
+  }
 
   const codeClosed = () => {
     if (codeContentChanged) {
-      setWarnOpen(!warnOpen);
+      setWarnOpen(!warnOpen)
     } else {
-      setCodeOpen(!codeOpen);
-      setCodeContentChanged(false);
-      setScriptId(null);
-      setCodeContent("");
+      setCodeOpen(!codeOpen)
+      setCodeContentChanged(false)
+      setScriptId(null)
+      setCodeContent('')
     }
-  };
+  }
 
   const { refetch: saveScriptRefetch, isFetching: isSaving } = useQuery({
-    queryKey: ["saveScript"],
+    queryKey: ['saveScript'],
     queryFn: async () => {
-      const scriptBytes = Buffer.from(codeContent, "ascii");
+      const scriptBytes = Buffer.from(codeContent, 'ascii')
       const {
         runAs32Bit,
         id,
@@ -112,7 +112,7 @@ const Page = () => {
         fileName,
         roleScopeTagIds,
         scriptType,
-      } = currentScript;
+      } = currentScript
       const patchData = {
         TenantFilter: tenantFilter,
         ScriptId: id,
@@ -122,77 +122,77 @@ const Page = () => {
           id,
           displayName,
           description,
-          scriptContent: scriptBytes.toString("base64"), // Convert to base64
+          scriptContent: scriptBytes.toString('base64'), // Convert to base64
           runAsAccount,
           fileName,
           roleScopeTagIds,
         }),
-      };
+      }
 
-      const response = await fetch("/api/EditIntuneScript", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+      const response = await fetch('/api/EditIntuneScript', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(patchData),
-      });
+      })
 
       if (!response.ok) {
         dispatch(
           showToast({
-            title: "Script Save Error",
-            message: "Your Intune script could not be saved.",
-            type: "error",
+            title: 'Script Save Error',
+            message: 'Your Intune script could not be saved.',
+            type: 'error',
           })
-        );
+        )
       }
 
-      return response.json();
+      return response.json()
     },
     enabled: false,
     refetchOnWindowFocus: false,
-  });
+  })
 
-  const queryClient = useQueryClient();
+  const queryClient = useQueryClient()
 
   const saveCode = async () => {
-    const { data } = await saveScriptRefetch();
-    setCodeContentChanged(false);
-    setCodeOpen(!codeOpen);
+    const { data } = await saveScriptRefetch()
+    setCodeContentChanged(false)
+    setCodeOpen(!codeOpen)
     dispatch(
       showToast({
-        title: "Script Saved",
-        message: "Your Intune script has been saved successfully.",
-        type: "update",
+        title: 'Script Saved',
+        message: 'Your Intune script has been saved successfully.',
+        type: 'update',
       })
-    );
-  };
+    )
+  }
 
   // Map script type to Graph API endpoint
   const getScriptEndpoint = (scriptType) => {
     const mapping = {
-      Windows: "deviceManagementScripts",
-      MacOS: "deviceShellScripts",
-      Remediation: "deviceHealthScripts",
-      Linux: "configurationPolicies",
-    };
-    return mapping[scriptType] || "deviceManagementScripts";
-  };
+      Windows: 'deviceManagementScripts',
+      MacOS: 'deviceShellScripts',
+      Remediation: 'deviceHealthScripts',
+      Linux: 'configurationPolicies',
+    }
+    return mapping[scriptType] || 'deviceManagementScripts'
+  }
 
   const actions = [
     {
-      label: "Assign to All Users",
-      type: "POST",
-      url: "/api/ExecAssignPolicy",
+      label: 'Assign to All Users',
+      type: 'POST',
+      url: '/api/ExecAssignPolicy',
       icon: <UserIcon />,
-      color: "info",
+      color: 'info',
       fields: [
         {
-          type: "radio",
-          name: "assignmentMode",
-          label: "Assignment mode",
+          type: 'radio',
+          name: 'assignmentMode',
+          label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: "replace",
+          defaultValue: 'replace',
           helperText:
-            "Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.",
+            'Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.',
         },
       ],
       confirmText: 'Are you sure you want to assign "[displayName]" to all users?',
@@ -200,25 +200,25 @@ const Page = () => {
         tenantFilter: tenantFilter,
         ID: row?.id,
         Type: getScriptEndpoint(row?.scriptType),
-        AssignTo: "allLicensedUsers",
-        assignmentMode: formData?.assignmentMode || "replace",
+        AssignTo: 'allLicensedUsers',
+        assignmentMode: formData?.assignmentMode || 'replace',
       }),
     },
     {
-      label: "Assign to All Devices",
-      type: "POST",
-      url: "/api/ExecAssignPolicy",
+      label: 'Assign to All Devices',
+      type: 'POST',
+      url: '/api/ExecAssignPolicy',
       icon: <LaptopChromebook />,
-      color: "info",
+      color: 'info',
       fields: [
         {
-          type: "radio",
-          name: "assignmentMode",
-          label: "Assignment mode",
+          type: 'radio',
+          name: 'assignmentMode',
+          label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: "replace",
+          defaultValue: 'replace',
           helperText:
-            "Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.",
+            'Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.',
         },
       ],
       confirmText: 'Are you sure you want to assign "[displayName]" to all devices?',
@@ -226,25 +226,25 @@ const Page = () => {
         tenantFilter: tenantFilter,
         ID: row?.id,
         Type: getScriptEndpoint(row?.scriptType),
-        AssignTo: "AllDevices",
-        assignmentMode: formData?.assignmentMode || "replace",
+        AssignTo: 'AllDevices',
+        assignmentMode: formData?.assignmentMode || 'replace',
       }),
     },
     {
-      label: "Assign Globally (All Users / All Devices)",
-      type: "POST",
-      url: "/api/ExecAssignPolicy",
+      label: 'Assign Globally (All Users / All Devices)',
+      type: 'POST',
+      url: '/api/ExecAssignPolicy',
       icon: <GlobeAltIcon />,
-      color: "info",
+      color: 'info',
       fields: [
         {
-          type: "radio",
-          name: "assignmentMode",
-          label: "Assignment mode",
+          type: 'radio',
+          name: 'assignmentMode',
+          label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: "replace",
+          defaultValue: 'replace',
           helperText:
-            "Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.",
+            'Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.',
         },
       ],
       confirmText: 'Are you sure you want to assign "[displayName]" to all users and devices?',
@@ -252,122 +252,124 @@ const Page = () => {
         tenantFilter: tenantFilter,
         ID: row?.id,
         Type: getScriptEndpoint(row?.scriptType),
-        AssignTo: "AllDevicesAndUsers",
-        assignmentMode: formData?.assignmentMode || "replace",
+        AssignTo: 'AllDevicesAndUsers',
+        assignmentMode: formData?.assignmentMode || 'replace',
       }),
     },
     {
-      label: "Assign to Custom Group",
-      type: "POST",
-      url: "/api/ExecAssignPolicy",
+      label: 'Assign to Custom Group',
+      type: 'POST',
+      url: '/api/ExecAssignPolicy',
       icon: <UserGroupIcon />,
-      color: "info",
+      color: 'info',
       confirmText: 'Select the target groups for "[displayName]".',
       fields: [
         {
-          type: "autoComplete",
-          name: "groupTargets",
-          label: "Group(s)",
+          type: 'autoComplete',
+          name: 'groupTargets',
+          label: 'Group(s)',
           multiple: true,
           creatable: false,
           allowResubmit: true,
-          validators: { required: "Please select at least one group" },
+          validators: { required: 'Please select at least one group' },
           api: {
-            url: "/api/ListGraphRequest",
-            dataKey: "Results",
+            url: '/api/ListGraphRequest',
+            dataKey: 'Results',
             queryKey: `ListScriptAssignmentGroups-${tenantFilter}`,
             labelField: (group) =>
               group.id ? `${group.displayName} (${group.id})` : group.displayName,
-            valueField: "id",
+            valueField: 'id',
             addedField: {
-              description: "description",
+              description: 'description',
             },
             data: {
-              Endpoint: "groups",
+              Endpoint: 'groups',
               manualPagination: true,
-              $select: "id,displayName,description",
-              $orderby: "displayName",
+              $select: 'id,displayName,description',
+              $orderby: 'displayName',
               $top: 999,
               $count: true,
             },
           },
         },
         {
-          type: "radio",
-          name: "assignmentMode",
-          label: "Assignment mode",
+          type: 'radio',
+          name: 'assignmentMode',
+          label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: "replace",
+          defaultValue: 'replace',
           helperText:
-            "Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.",
+            'Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.',
         },
       ],
       customDataformatter: (row, action, formData) => {
-        const selectedGroups = Array.isArray(formData?.groupTargets) ? formData.groupTargets : [];
+        const selectedGroups = Array.isArray(formData?.groupTargets) ? formData.groupTargets : []
         return {
           tenantFilter: tenantFilter,
           ID: row?.id,
           Type: getScriptEndpoint(row?.scriptType),
           GroupIds: selectedGroups.map((group) => group.value).filter(Boolean),
           GroupNames: selectedGroups.map((group) => group.label).filter(Boolean),
-          assignmentMode: formData?.assignmentMode || "replace",
-        };
+          assignmentMode: formData?.assignmentMode || 'replace',
+        }
       },
     },
     {
-      label: "Edit Script",
+      label: 'Edit Script',
       icon: <PencilIcon />,
-      color: "primary",
+      color: 'primary',
       noConfirm: true,
       customFunction: handleScriptEdit,
     },
     {
-      label: "Delete Script",
-      type: "POST",
-      url: "/api/RemoveIntuneScript",
+      label: 'Delete Script',
+      type: 'POST',
+      url: '/api/RemoveIntuneScript',
       data: {
-        ID: "id",
-        displayName: "displayName",
-        ScriptType: "scriptType",
+        ID: 'id',
+        displayName: 'displayName',
+        ScriptType: 'scriptType',
       },
-      confirmText: "Are you sure you want to delete this script?",
+      confirmText: 'Are you sure you want to delete this script?',
       icon: <TrashIcon />,
-      color: "danger",
+      color: 'danger',
     },
-  ];
+  ]
 
   const offCanvas = {
     extendedInfoFields: [
-      "scriptType",
-      "id",
-      "fileName",
-      "displayName",
-      "description",
-      "lastModifiedDateTime",
-      "runAsAccount",
-      "createdDateTime",
-      "runAs32Bit",
-      "executionFrequency",
-      "enforceSignatureCheck",
+      'scriptType',
+      'id',
+      'fileName',
+      'displayName',
+      'description',
+      'lastModifiedDateTime',
+      'runAsAccount',
+      'createdDateTime',
+      'runAs32Bit',
+      'executionFrequency',
+      'enforceSignatureCheck',
     ],
     actions: actions,
-  };
+  }
 
   const simpleColumns = [
-    "scriptType",
-    "displayName",
-    "ScriptAssignment",
-    "ScriptExclude",
-    "description",
-    "runAsAccount",
-    "lastModifiedDateTime",
-  ];
+    'Tenant',
+    'scriptType',
+    'displayName',
+    'ScriptAssignment',
+    'ScriptExclude',
+    'description',
+    'runAsAccount',
+    'lastModifiedDateTime',
+  ]
 
   return (
     <>
       <CippTablePage
         title={pageTitle}
         apiUrl="/api/ListIntuneScript"
+        apiDataKey="Results"
         actions={actions}
         offCanvas={offCanvas}
         simpleColumns={simpleColumns}
@@ -380,7 +382,7 @@ const Page = () => {
             <IconButton
               aria-label="close"
               onClick={codeClosed}
-              sx={{ position: "absolute", right: 8, top: 8 }}
+              sx={{ position: 'absolute', right: 8, top: 8 }}
             >
               <Close />
             </IconButton>
@@ -389,13 +391,13 @@ const Page = () => {
             <IconButton
               aria-label="save"
               onClick={saveCode}
-              sx={{ position: "absolute", right: 50, top: 8 }}
+              sx={{ position: 'absolute', right: 50, top: 8 }}
             >
               <Save />
             </IconButton>
           )}
           {isSaving && (
-            <CircularProgress size={20} sx={{ position: "absolute", right: 55, top: 14 }} />
+            <CircularProgress size={20} sx={{ position: 'absolute', right: 55, top: 14 }} />
           )}
         </DialogTitle>
         <DialogContent dividers>
@@ -423,11 +425,11 @@ const Page = () => {
           <Button
             variant="contained"
             onClick={() => {
-              setCodeOpen(false);
-              setWarnOpen(false);
-              setCodeContent("");
-              setScriptId(null);
-              setCodeContentChanged(false);
+              setCodeOpen(false)
+              setWarnOpen(false)
+              setCodeContent('')
+              setScriptId(null)
+              setCodeContentChanged(false)
             }}
           >
             Confirm
@@ -435,8 +437,8 @@ const Page = () => {
         </DialogActions>
       </Dialog>
     </>
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout allTenantsSupport={false}>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
+export default Page

--- a/src/pages/endpoint/MEM/reusable-settings/index.js
+++ b/src/pages/endpoint/MEM/reusable-settings/index.js
@@ -1,67 +1,68 @@
-import { Book, DeleteForever } from "@mui/icons-material";
-import { CippReusableSettingsDeployDrawer } from "../../../../components/CippComponents/CippReusableSettingsDeployDrawer.jsx";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { useSettings } from "../../../../hooks/use-settings";
-import CippJsonView from "../../../../components/CippFormPages/CippJSONView";
+import { Book, DeleteForever } from '@mui/icons-material'
+import { CippReusableSettingsDeployDrawer } from '../../../../components/CippComponents/CippReusableSettingsDeployDrawer.jsx'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { useSettings } from '../../../../hooks/use-settings'
+import CippJsonView from '../../../../components/CippFormPages/CippJSONView'
 
 const Page = () => {
-  const { currentTenant } = useSettings();
-  const pageTitle = "Reusable Settings";
+  const { currentTenant } = useSettings()
+  const pageTitle = 'Reusable Settings'
 
   const actions = [
     {
-      label: "Edit Reusable Setting",
+      label: 'Edit Reusable Setting',
       link: `/endpoint/MEM/reusable-settings/edit?id=[id]&tenant=${currentTenant}&tenantFilter=${currentTenant}`,
     },
     {
-      label: "Delete Reusable Setting",
-      type: "POST",
-      url: "/api/RemoveIntuneReusableSetting",
+      label: 'Delete Reusable Setting',
+      type: 'POST',
+      url: '/api/RemoveIntuneReusableSetting',
       icon: <DeleteForever />,
-      color: "error",
+      color: 'error',
       data: {
-        ID: "id",
-        DisplayName: "displayName",
+        ID: 'id',
+        DisplayName: 'displayName',
       },
-      confirmText: "Delete this reusable setting from the tenant?",
+      confirmText: 'Delete this reusable setting from the tenant?',
       multiPost: false,
     },
     {
-      label: "Create Template from Setting",
-      type: "POST",
-      url: "/api/AddIntuneReusableSettingTemplate",
+      label: 'Create Template from Setting',
+      type: 'POST',
+      url: '/api/AddIntuneReusableSettingTemplate',
       icon: <Book />,
       data: {
-        displayName: "displayName",
-        description: "description",
-        rawJSON: "RawJSON",
+        displayName: 'displayName',
+        description: 'description',
+        rawJSON: 'RawJSON',
       },
-      confirmText: "Create a reusable settings template from this entry?",
+      confirmText: 'Create a reusable settings template from this entry?',
       multiPost: false,
     },
-  ];
+  ]
 
   const offCanvas = {
-    children: (row) => <CippJsonView object={row} type={"intune"} defaultOpen={true} />,
-    size: "lg",
-  };
+    children: (row) => <CippJsonView object={row} type={'intune'} defaultOpen={true} />,
+    size: 'lg',
+  }
 
   return (
     <CippTablePage
       title={pageTitle}
       cardButton={
-        <CippReusableSettingsDeployDrawer requiredPermissions={["Endpoint.MEM.ReadWrite"]} />
+        <CippReusableSettingsDeployDrawer requiredPermissions={['Endpoint.MEM.ReadWrite']} />
       }
       apiUrl="/api/ListIntuneReusableSettings"
+      apiDataKey="Results"
       queryKey={`ListIntuneReusableSettings-${currentTenant}`}
       actions={actions}
       offCanvas={offCanvas}
-      simpleColumns={["displayName", "description", "id", "version"]}
+      simpleColumns={['Tenant', 'displayName', 'description', 'id', 'version']}
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/endpoint/applications/list/index.js
+++ b/src/pages/endpoint/applications/list/index.js
@@ -1,314 +1,317 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { CippApiDialog } from "../../../../components/CippComponents/CippApiDialog.jsx";
-import { GlobeAltIcon, TrashIcon, UserIcon, UserGroupIcon } from "@heroicons/react/24/outline";
-import { LaptopMac, Sync, BookmarkAdd } from "@mui/icons-material";
-import { CippApplicationDeployDrawer } from "../../../../components/CippComponents/CippApplicationDeployDrawer";
-import { Button, Box } from "@mui/material";
-import { useSettings } from "../../../../hooks/use-settings.js";
-import { useDialog } from "../../../../hooks/use-dialog.js";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { CippApiDialog } from '../../../../components/CippComponents/CippApiDialog.jsx'
+import { GlobeAltIcon, TrashIcon, UserIcon, UserGroupIcon } from '@heroicons/react/24/outline'
+import { LaptopMac, Sync, BookmarkAdd } from '@mui/icons-material'
+import { CippApplicationDeployDrawer } from '../../../../components/CippComponents/CippApplicationDeployDrawer'
+import { Button, Box } from '@mui/material'
+import { useSettings } from '../../../../hooks/use-settings.js'
+import { useDialog } from '../../../../hooks/use-dialog.js'
 
 const assignmentIntentOptions = [
-  { label: "Required", value: "Required" },
-  { label: "Available", value: "Available" },
-  { label: "Available without enrollment", value: "AvailableWithoutEnrollment" },
-  { label: "Uninstall", value: "Uninstall" },
-];
+  { label: 'Required', value: 'Required' },
+  { label: 'Available', value: 'Available' },
+  { label: 'Available without enrollment', value: 'AvailableWithoutEnrollment' },
+  { label: 'Uninstall', value: 'Uninstall' },
+]
 
 const assignmentModeOptions = [
-  { label: "Replace existing assignments", value: "replace" },
-  { label: "Append to existing assignments", value: "append" },
-];
+  { label: 'Replace existing assignments', value: 'replace' },
+  { label: 'Append to existing assignments', value: 'append' },
+]
 
 const assignmentFilterTypeOptions = [
-  { label: "Include - Apply to devices matching filter", value: "include" },
-  { label: "Exclude - Apply to devices NOT matching filter", value: "exclude" },
-];
+  { label: 'Include - Apply to devices matching filter', value: 'include' },
+  { label: 'Exclude - Apply to devices NOT matching filter', value: 'exclude' },
+]
 
 const getAppAssignmentSettingsType = (odataType) => {
-  if (!odataType || typeof odataType !== "string") {
-    return undefined;
+  if (!odataType || typeof odataType !== 'string') {
+    return undefined
   }
 
-  return odataType.replace("#microsoft.graph.", "").replace(/App$/i, "");
-};
+  return odataType.replace('#microsoft.graph.', '').replace(/App$/i, '')
+}
 
 const mapOdataToAppType = (odataType) => {
-  if (!odataType) return "win32ScriptApp";
-  const type = odataType.toLowerCase();
-  if (type.includes("wingetapp")) return "StoreApp";
-  if (type.includes("win32lobapp")) return "chocolateyApp";
-  if (type.includes("officesuiteapp")) return "officeApp";
-  return "win32ScriptApp";
-};
+  if (!odataType) return 'win32ScriptApp'
+  const type = odataType.toLowerCase()
+  if (type.includes('wingetapp')) return 'StoreApp'
+  if (type.includes('win32lobapp')) return 'chocolateyApp'
+  if (type.includes('officesuiteapp')) return 'officeApp'
+  return 'win32ScriptApp'
+}
 
 const Page = () => {
-  const pageTitle = "Applications";
-  const syncDialog = useDialog();
-  const tenant = useSettings().currentTenant;
+  const pageTitle = 'Applications'
+  const syncDialog = useDialog()
+  const tenant = useSettings().currentTenant
 
   const getAssignmentFilterFields = () => [
     {
-      type: "autoComplete",
-      name: "assignmentFilter",
-      label: "Assignment Filter (Optional)",
+      type: 'autoComplete',
+      name: 'assignmentFilter',
+      label: 'Assignment Filter (Optional)',
       multiple: false,
       creatable: false,
       api: {
-        url: "/api/ListAssignmentFilters",
+        url: '/api/ListAssignmentFilters',
+        dataKey: 'Results',
         queryKey: `ListAssignmentFilters-${tenant}`,
         labelField: (filter) => filter.displayName,
-        valueField: "displayName",
+        valueField: 'displayName',
       },
     },
     {
-      type: "radio",
-      name: "assignmentFilterType",
-      label: "Assignment Filter Mode",
+      type: 'radio',
+      name: 'assignmentFilterType',
+      label: 'Assignment Filter Mode',
       options: assignmentFilterTypeOptions,
-      defaultValue: "include",
-      helperText: "Choose whether to include or exclude devices matching the filter.",
+      defaultValue: 'include',
+      helperText: 'Choose whether to include or exclude devices matching the filter.',
     },
-  ];
+  ]
 
   // Builds a customDataformatter that handles both single-row and bulk (array) inputs.
   const makeAssignFormatter = (getRowData) => (row, action, formData) => {
     const formatRow = (singleRow) => {
       const tenantFilterValue =
-        tenant === "AllTenants" && singleRow?.Tenant ? singleRow.Tenant : tenant;
+        tenant === 'AllTenants' && singleRow?.Tenant ? singleRow.Tenant : tenant
       return {
         tenantFilter: tenantFilterValue,
         ID: singleRow?.id,
-        AppType: getAppAssignmentSettingsType(singleRow?.["@odata.type"]),
+        AppType: getAppAssignmentSettingsType(singleRow?.['@odata.type']),
         AssignmentFilterName: formData?.assignmentFilter?.value || null,
         AssignmentFilterType: formData?.assignmentFilter?.value
-          ? formData?.assignmentFilterType || "include"
+          ? formData?.assignmentFilterType || 'include'
           : null,
         ...getRowData(singleRow, formData),
-      };
-    };
-    return Array.isArray(row) ? row.map(formatRow) : formatRow(row);
-  };
+      }
+    }
+    return Array.isArray(row) ? row.map(formatRow) : formatRow(row)
+  }
 
   const assignmentFields = [
     {
-      type: "radio",
-      name: "Intent",
-      label: "Assignment intent",
+      type: 'radio',
+      name: 'Intent',
+      label: 'Assignment intent',
       options: assignmentIntentOptions,
-      defaultValue: "Required",
-      validators: { required: "Select an assignment intent" },
+      defaultValue: 'Required',
+      validators: { required: 'Select an assignment intent' },
       helperText:
-        "Available assigns to Company Portal, Required installs automatically, Uninstall removes the app, Available without enrollment exposes it without device enrollment.",
+        'Available assigns to Company Portal, Required installs automatically, Uninstall removes the app, Available without enrollment exposes it without device enrollment.',
     },
     {
-      type: "radio",
-      name: "assignmentMode",
-      label: "Assignment mode",
+      type: 'radio',
+      name: 'assignmentMode',
+      label: 'Assignment mode',
       options: assignmentModeOptions,
-      defaultValue: "replace",
+      defaultValue: 'replace',
       helperText:
-        "Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups/intents.",
+        'Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups/intents.',
     },
     ...getAssignmentFilterFields(),
-  ];
+  ]
 
   const actions = [
     {
-      label: "Assign to All Users",
-      type: "POST",
-      url: "/api/ExecAssignApp",
+      label: 'Assign to All Users',
+      type: 'POST',
+      url: '/api/ExecAssignApp',
       fields: assignmentFields,
       customDataformatter: makeAssignFormatter((_singleRow, formData) => ({
-        AssignTo: "AllUsers",
-        Intent: formData?.Intent || "Required",
-        assignmentMode: formData?.assignmentMode || "replace",
+        AssignTo: 'AllUsers',
+        Intent: formData?.Intent || 'Required',
+        assignmentMode: formData?.assignmentMode || 'replace',
       })),
       confirmText: 'Are you sure you want to assign "[displayName]" to all users?',
       icon: <UserIcon />,
-      color: "info",
+      color: 'info',
     },
     {
-      label: "Assign to All Devices",
-      type: "POST",
-      url: "/api/ExecAssignApp",
+      label: 'Assign to All Devices',
+      type: 'POST',
+      url: '/api/ExecAssignApp',
       fields: assignmentFields,
       customDataformatter: makeAssignFormatter((_singleRow, formData) => ({
-        AssignTo: "AllDevices",
-        Intent: formData?.Intent || "Required",
-        assignmentMode: formData?.assignmentMode || "replace",
+        AssignTo: 'AllDevices',
+        Intent: formData?.Intent || 'Required',
+        assignmentMode: formData?.assignmentMode || 'replace',
       })),
       confirmText: 'Are you sure you want to assign "[displayName]" to all devices?',
       icon: <LaptopMac />,
-      color: "info",
+      color: 'info',
     },
     {
-      label: "Assign Globally (All Users / All Devices)",
-      type: "POST",
-      url: "/api/ExecAssignApp",
+      label: 'Assign Globally (All Users / All Devices)',
+      type: 'POST',
+      url: '/api/ExecAssignApp',
       fields: assignmentFields,
       customDataformatter: makeAssignFormatter((_singleRow, formData) => ({
-        AssignTo: "AllDevicesAndUsers",
-        Intent: formData?.Intent || "Required",
-        assignmentMode: formData?.assignmentMode || "replace",
+        AssignTo: 'AllDevicesAndUsers',
+        Intent: formData?.Intent || 'Required',
+        assignmentMode: formData?.assignmentMode || 'replace',
       })),
       confirmText: 'Are you sure you want to assign "[displayName]" to all users and devices?',
       icon: <GlobeAltIcon />,
-      color: "info",
+      color: 'info',
     },
     {
-      label: "Assign to Custom Group",
-      type: "POST",
-      url: "/api/ExecAssignApp",
+      label: 'Assign to Custom Group',
+      type: 'POST',
+      url: '/api/ExecAssignApp',
       icon: <UserGroupIcon />,
-      color: "info",
+      color: 'info',
       confirmText: 'Select the target groups and intent for "[displayName]".',
       fields: [
         {
-          type: "autoComplete",
-          name: "groupTargets",
-          label: "Group(s)",
+          type: 'autoComplete',
+          name: 'groupTargets',
+          label: 'Group(s)',
           multiple: true,
           creatable: false,
           allowResubmit: true,
-          validators: { required: "Please select at least one group" },
+          validators: { required: 'Please select at least one group' },
           api: {
-            url: "/api/ListGraphRequest",
-            dataKey: "Results",
+            url: '/api/ListGraphRequest',
+            dataKey: 'Results',
             queryKey: `ListAppAssignmentGroups-${tenant}`,
             labelField: (group) =>
               group.id ? `${group.displayName} (${group.id})` : group.displayName,
-            valueField: "id",
+            valueField: 'id',
             addedField: {
-              description: "description",
+              description: 'description',
             },
             data: {
-              Endpoint: "groups",
+              Endpoint: 'groups',
               manualPagination: true,
-              $select: "id,displayName,description",
-              $orderby: "displayName",
+              $select: 'id,displayName,description',
+              $orderby: 'displayName',
               $top: 999,
               $count: true,
             },
           },
         },
         {
-          type: "radio",
-          name: "assignmentIntent",
-          label: "Assignment intent",
+          type: 'radio',
+          name: 'assignmentIntent',
+          label: 'Assignment intent',
           options: assignmentIntentOptions,
-          defaultValue: "Required",
-          validators: { required: "Select an assignment intent" },
+          defaultValue: 'Required',
+          validators: { required: 'Select an assignment intent' },
           helperText:
-            "Available assigns to Company Portal, Required installs automatically, Uninstall removes the app, Available without enrollment exposes it without device enrollment.",
+            'Available assigns to Company Portal, Required installs automatically, Uninstall removes the app, Available without enrollment exposes it without device enrollment.',
         },
         {
-          type: "radio",
-          name: "assignmentMode",
-          label: "Assignment mode",
+          type: 'radio',
+          name: 'assignmentMode',
+          label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: "replace",
+          defaultValue: 'replace',
           helperText:
-            "Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups/intents.",
+            'Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups/intents.',
         },
         ...getAssignmentFilterFields(),
       ],
       customDataformatter: makeAssignFormatter((_singleRow, formData) => {
-        const selectedGroups = Array.isArray(formData?.groupTargets) ? formData.groupTargets : [];
+        const selectedGroups = Array.isArray(formData?.groupTargets) ? formData.groupTargets : []
         return {
           GroupIds: selectedGroups.map((group) => group.value).filter(Boolean),
           GroupNames: selectedGroups.map((group) => group.label).filter(Boolean),
-          Intent: formData?.assignmentIntent || "Required",
-          AssignmentMode: formData?.assignmentMode || "replace",
-        };
+          Intent: formData?.assignmentIntent || 'Required',
+          AssignmentMode: formData?.assignmentMode || 'replace',
+        }
       }),
     },
     {
-      label: "Save as Template",
-      type: "POST",
-      url: "/api/AddAppTemplate",
+      label: 'Save as Template',
+      type: 'POST',
+      url: '/api/AddAppTemplate',
       icon: <BookmarkAdd />,
-      color: "info",
+      color: 'info',
       fields: [
         {
-          type: "textField",
-          name: "displayName",
-          label: "Template Name",
-          validators: { required: "Template name is required" },
+          type: 'textField',
+          name: 'displayName',
+          label: 'Template Name',
+          validators: { required: 'Template name is required' },
         },
         {
-          type: "textField",
-          name: "description",
-          label: "Description",
+          type: 'textField',
+          name: 'description',
+          label: 'Description',
         },
       ],
       customDataformatter: (row, action, formData) => {
-        const rows = Array.isArray(row) ? row : [row];
+        const rows = Array.isArray(row) ? row : [row]
         return {
           displayName: formData?.displayName,
-          description: formData?.description || "",
+          description: formData?.description || '',
           apps: rows.map((r) => ({
-            appType: mapOdataToAppType(r["@odata.type"]),
+            appType: mapOdataToAppType(r['@odata.type']),
             appName: r.displayName,
             config: JSON.stringify({
               ApplicationName: r.displayName,
               IntuneBody: r,
-              assignTo: "On",
+              assignTo: 'On',
             }),
           })),
-        };
+        }
       },
       confirmText: 'Save selected application(s) as a reusable template?',
     },
     {
-      label: "Delete Application",
-      type: "POST",
-      url: "/api/RemoveApp",
+      label: 'Delete Application',
+      type: 'POST',
+      url: '/api/RemoveApp',
       data: {
-        ID: "id",
+        ID: 'id',
       },
       confirmText: 'Are you sure you want to delete "[displayName]"?',
       icon: <TrashIcon />,
-      color: "danger",
+      color: 'danger',
     },
-  ];
+  ]
 
   const offCanvas = {
     extendedInfoFields: [
-      "installExperience.runAsAccount",
-      "installExperience.deviceRestartBehavior",
-      "isAssigned",
-      "createdDateTime",
-      "lastModifiedDateTime",
-      "isFeatured",
-      "publishingState",
-      "dependentAppCount",
-      "rules.0.ruleType",
-      "rules.0.fileOrFolderName",
-      "rules.0.path",
+      'installExperience.runAsAccount',
+      'installExperience.deviceRestartBehavior',
+      'isAssigned',
+      'createdDateTime',
+      'lastModifiedDateTime',
+      'isFeatured',
+      'publishingState',
+      'dependentAppCount',
+      'rules.0.ruleType',
+      'rules.0.fileOrFolderName',
+      'rules.0.path',
     ],
     actions: actions,
-  };
+  }
 
   const simpleColumns = [
-    "displayName",
-    "AppAssignment",
-    "AppExclude",
-    "publishingState",
-    "lastModifiedDateTime",
-    "createdDateTime",
-  ];
+    'Tenant',
+    'displayName',
+    'AppAssignment',
+    'AppExclude',
+    'publishingState',
+    'lastModifiedDateTime',
+    'createdDateTime',
+  ]
 
   return (
     <>
       <CippTablePage
         title={pageTitle}
         apiUrl="/api/ListApps"
+        apiDataKey="Results"
         actions={actions}
         offCanvas={offCanvas}
         simpleColumns={simpleColumns}
         cardButton={
-          <Box sx={{ display: "flex", gap: 1 }}>
+          <Box sx={{ display: 'flex', gap: 1 }}>
             <CippApplicationDeployDrawer />
             <Button onClick={syncDialog.handleOpen} startIcon={<Sync />}>
               Sync VPP
@@ -320,15 +323,15 @@ const Page = () => {
         title="Sync VPP Tokens"
         createDialog={syncDialog}
         api={{
-          type: "POST",
-          url: "/api/ExecSyncVPP",
+          type: 'POST',
+          url: '/api/ExecSyncVPP',
           data: {},
           confirmText: `Are you sure you want to sync Apple Volume Purchase Program (VPP) tokens? This will sync all VPP tokens for ${tenant}.`,
         }}
       />
     </>
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
+export default Page

--- a/src/pages/endpoint/autopilot/list-devices/index.js
+++ b/src/pages/endpoint/autopilot/list-devices/index.js
@@ -1,148 +1,154 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { CippApiDialog } from "../../../../components/CippComponents/CippApiDialog.jsx";
-import { Button } from "@mui/material";
-import { PersonAdd, Delete, Sync, Add, Edit, Sell } from "@mui/icons-material";
-import { useDialog } from "../../../../hooks/use-dialog";
-import Link from "next/link";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { CippApiDialog } from '../../../../components/CippComponents/CippApiDialog.jsx'
+import { Button } from '@mui/material'
+import { PersonAdd, Delete, Sync, Add, Edit, Sell } from '@mui/icons-material'
+import { useDialog } from '../../../../hooks/use-dialog'
+import Link from 'next/link'
 
 const Page = () => {
-  const pageTitle = "Autopilot Devices";
-  const createDialog = useDialog();
+  const pageTitle = 'Autopilot Devices'
+  const createDialog = useDialog()
 
   const actions = [
     {
-      label: "Assign device",
+      label: 'Assign device',
       icon: <PersonAdd />,
-      type: "POST",
-      url: "/api/ExecAssignAPDevice",
+      type: 'POST',
+      url: '/api/ExecAssignAPDevice',
       data: {
-        device: "id",
-        serialNumber: "serialNumber",
+        device: 'id',
+        serialNumber: 'serialNumber',
       },
-      confirmText: "Select the user to assign the device to",
+      confirmText: 'Select the user to assign the device to',
       fields: [
         {
-          type: "autoComplete",
-          name: "user",
-          label: "Select User",
+          type: 'autoComplete',
+          name: 'user',
+          label: 'Select User',
           multiple: false,
           creatable: false,
           api: {
-            url: "/api/listUsers",
+            url: '/api/listUsers',
             labelField: (user) => `${user.displayName} (${user.userPrincipalName})`,
-            valueField: "userPrincipalName",
+            valueField: 'userPrincipalName',
             addedField: {
-              userPrincipalName: "userPrincipalName",
-              addressableUserName: "displayName",
+              userPrincipalName: 'userPrincipalName',
+              addressableUserName: 'displayName',
             },
           },
         },
       ],
-      color: "info",
+      color: 'info',
     },
     {
-      label: "Rename Device",
+      label: 'Rename Device',
       icon: <Edit />,
-      type: "POST",
-      url: "/api/ExecRenameAPDevice",
+      type: 'POST',
+      url: '/api/ExecRenameAPDevice',
       data: {
-        deviceId: "id",
-        serialNumber: "serialNumber",
+        deviceId: 'id',
+        serialNumber: 'serialNumber',
       },
-      confirmText: "Enter the new display name for the device.",
+      confirmText: 'Enter the new display name for the device.',
       fields: [
         {
-          type: "textField",
-          name: "displayName",
-          label: "New Display Name",
+          type: 'textField',
+          name: 'displayName',
+          label: 'New Display Name',
           required: true,
           validate: (value) => {
             if (!value) {
-              return "Display name is required.";
+              return 'Display name is required.'
             }
             if (value.length > 15) {
-              return "Display name must be 15 characters or less.";
+              return 'Display name must be 15 characters or less.'
             }
             if (/\s/.test(value)) {
-              return "Display name cannot contain spaces.";
+              return 'Display name cannot contain spaces.'
             }
             if (!/^[a-zA-Z0-9-]+$/.test(value)) {
-              return "Display name can only contain letters, numbers, and hyphens.";
+              return 'Display name can only contain letters, numbers, and hyphens.'
             }
             if (/^[0-9]+$/.test(value)) {
-              return "Display name cannot contain only numbers.";
+              return 'Display name cannot contain only numbers.'
             }
-            return true; // Indicates validation passed
+            return true // Indicates validation passed
           },
         },
       ],
-      color: "secondary",
+      color: 'secondary',
     },
     {
-      label: "Edit Group Tag",
+      label: 'Edit Group Tag',
       icon: <Sell />,
-      type: "POST",
-      url: "/api/ExecSetAPDeviceGroupTag",
+      type: 'POST',
+      url: '/api/ExecSetAPDeviceGroupTag',
       data: {
-        deviceId: "id",
-        serialNumber: "serialNumber",
+        deviceId: 'id',
+        serialNumber: 'serialNumber',
       },
-      confirmText: "Enter the new group tag for the device.",
+      confirmText: 'Enter the new group tag for the device.',
       fields: [
         {
-          type: "textField",
-          name: "groupTag",
-          label: "Group Tag",
+          type: 'textField',
+          name: 'groupTag',
+          label: 'Group Tag',
           validate: (value) => {
             if (value && value.length > 128) {
-              return "Group tag cannot exceed 128 characters.";
+              return 'Group tag cannot exceed 128 characters.'
             }
-            return true; // Validation passed
+            return true // Validation passed
           },
         },
       ],
-      color: "secondary",
+      color: 'secondary',
     },
     {
-      label: "Delete Device",
+      label: 'Delete Device',
       icon: <Delete />,
-      type: "POST",
-      url: "/api/RemoveAPDevice",
-      data: { ID: "id" },
-      confirmText: "Are you sure you want to delete this device?",
-      color: "danger",
+      type: 'POST',
+      url: '/api/RemoveAPDevice',
+      data: { ID: 'id' },
+      confirmText: 'Are you sure you want to delete this device?',
+      color: 'danger',
     },
-  ];
+  ]
 
   const offCanvas = {
     extendedInfoFields: [
-      "userPrincipalName",
-      "productKey",
-      "serialNumber",
-      "model",
-      "manufacturer",
+      'userPrincipalName',
+      'productKey',
+      'serialNumber',
+      'model',
+      'manufacturer',
     ],
     actions: actions,
-  };
+  }
 
   const simpleColumns = [
-    "displayName",
-    "serialNumber",
-    "model",
-    "manufacturer",
-    "groupTag",
-    "enrollmentState",
-  ];
+    'Tenant',
+    'displayName',
+    'serialNumber',
+    'model',
+    'manufacturer',
+    'groupTag',
+    'enrollmentState',
+  ]
 
   return (
     <>
       <CippTablePage
         title={pageTitle}
-        apiUrl="/api/ListAPDevices"
+        apiUrl="/api/ListGraphRequest"
+        apiData={{
+          Endpoint: 'deviceManagement/windowsAutopilotDeviceIdentities',
+          $top: 999,
+        }}
         actions={actions}
         offCanvas={offCanvas}
         simpleColumns={simpleColumns}
+        apiDataKey="Results"
         cardButton={
           <>
             <Button component={Link} href="/endpoint/autopilot/add-device" startIcon={<Add />}>
@@ -158,16 +164,16 @@ const Page = () => {
         title="Sync Autopilot Devices"
         createDialog={createDialog}
         api={{
-          type: "POST",
-          url: "/api/ExecSyncAPDevices",
+          type: 'POST',
+          url: '/api/ExecSyncAPDevices',
           data: {},
           confirmText:
-            "Are you sure you want to sync Autopilot devices? This can only be done every 10 minutes.",
+            'Are you sure you want to sync Autopilot devices? This can only be done every 10 minutes.',
         }}
       />
     </>
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
+export default Page

--- a/src/pages/endpoint/autopilot/list-profiles/index.js
+++ b/src/pages/endpoint/autopilot/list-profiles/index.js
@@ -1,45 +1,46 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { Delete } from "@mui/icons-material";
-import CippJsonView from "../../../../components/CippFormPages/CippJSONView";
-import { CippAutopilotProfileDrawer } from "../../../../components/CippComponents/CippAutopilotProfileDrawer";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { Delete } from '@mui/icons-material'
+import CippJsonView from '../../../../components/CippFormPages/CippJSONView'
+import { CippAutopilotProfileDrawer } from '../../../../components/CippComponents/CippAutopilotProfileDrawer'
 
 const Page = () => {
-  const pageTitle = "Autopilot Profiles";
+  const pageTitle = 'Autopilot Profiles'
 
   const actions = [
     {
-      label: "Delete Profile",
+      label: 'Delete Profile',
       icon: <Delete />,
-      type: "POST",
-      url: "/api/RemoveAutopilotConfig",
-      data: { ID: "id", displayName: "displayName", assignments: "assignments" },
+      type: 'POST',
+      url: '/api/RemoveAutopilotConfig',
+      data: { ID: 'id', displayName: 'displayName', assignments: 'assignments' },
       confirmText:
-        "Are you sure you want to delete this Autopilot profile? This action cannot be undone.",
-      color: "danger",
+        'Are you sure you want to delete this Autopilot profile? This action cannot be undone.',
+      color: 'danger',
     },
-  ];
+  ]
 
   const offCanvas = {
     children: (row) => <CippJsonView object={row} type="intune" defaultOpen={true} />,
-    size: "xl",
-  };
+    size: 'xl',
+  }
 
   const simpleColumns = [
-    "displayName",
-    "description",
-    "language",
-    "extractHardwareHash",
-    "deviceNameTemplate",
-  ];
+    'Tenant',
+    'displayName',
+    'description',
+    'language',
+    'extractHardwareHash',
+    'deviceNameTemplate',
+  ]
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListGraphRequest"
       apiData={{
-        Endpoint: "deviceManagement/windowsAutopilotDeploymentProfiles",
-        $expand: "assignments",
+        Endpoint: 'deviceManagement/windowsAutopilotDeploymentProfiles',
+        $expand: 'assignments',
       }}
       apiDataKey="Results"
       actions={actions}
@@ -51,8 +52,8 @@ const Page = () => {
         </>
       }
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
+export default Page

--- a/src/pages/endpoint/autopilot/list-status-pages/index.js
+++ b/src/pages/endpoint/autopilot/list-status-pages/index.js
@@ -1,26 +1,34 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { CippAutopilotStatusPageDrawer } from "../../../../components/CippComponents/CippAutopilotStatusPageDrawer";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { CippAutopilotStatusPageDrawer } from '../../../../components/CippComponents/CippAutopilotStatusPageDrawer'
 
 const Page = () => {
-  const pageTitle = "Autopilot Status Pages";
+  const pageTitle = 'Autopilot Status Pages'
 
   const simpleColumns = [
-    "displayName",
-    "Description",
-    "installProgressTimeoutInMinutes",
-    "showInstallationProgress",
-    "blockDeviceSetupRetryByUser",
-    "allowDeviceResetOnInstallFailure",
-    "allowDeviceUseOnInstallFailure",
-  ];
+    'Tenant',
+    'displayName',
+    'Description',
+    'installProgressTimeoutInMinutes',
+    'showInstallationProgress',
+    'blockDeviceSetupRetryByUser',
+    'allowDeviceResetOnInstallFailure',
+    'allowDeviceUseOnInstallFailure',
+  ]
 
   // No actions specified in the original file, so none are included here.
 
   return (
     <CippTablePage
       title={pageTitle}
-      apiUrl="/api/ListAutopilotConfig?type=ESP"
+      apiUrl="/api/ListGraphRequest"
+      apiData={{
+        Endpoint: 'deviceManagement/deviceEnrollmentConfigurations',
+        $expand: 'assignments',
+        $filter:
+          "deviceEnrollmentConfigurationType eq 'windows10EnrollmentCompletionPageConfiguration'",
+      }}
+      apiDataKey="Results"
       simpleColumns={simpleColumns}
       cardButton={
         <>
@@ -28,8 +36,8 @@ const Page = () => {
         </>
       }
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
+export default Page

--- a/src/pages/teams-share/onedrive/index.js
+++ b/src/pages/teams-share/onedrive/index.js
@@ -1,43 +1,43 @@
-import { Layout as DashboardLayout } from "../../../layouts/index.js";
-import { CippTablePage } from "../../../components/CippComponents/CippTablePage.jsx";
-import { PersonAdd, PersonRemove } from "@mui/icons-material";
+import { Layout as DashboardLayout } from '../../../layouts/index.js'
+import { CippTablePage } from '../../../components/CippComponents/CippTablePage.jsx'
+import { PersonAdd, PersonRemove } from '@mui/icons-material'
 
 const Page = () => {
-  const pageTitle = "OneDrive";
+  const pageTitle = 'OneDrive'
 
   const actions = [
     {
-      label: "Add permissions to OneDrive",
+      label: 'Add permissions to OneDrive',
       icon: <PersonAdd />,
-      type: "POST",
-      url: "/api/ExecSharePointPerms",
+      type: 'POST',
+      url: '/api/ExecSharePointPerms',
       data: {
-        UPN: "ownerPrincipalName",
-        URL: "webUrl",
+        UPN: 'ownerPrincipalName',
+        URL: 'webUrl',
         RemovePermission: false,
       },
       confirmText: "Select the User to add to this user's OneDrive permissions",
       fields: [
         {
-          type: "autoComplete",
-          name: "onedriveAccessUser",
-          label: "Select User",
+          type: 'autoComplete',
+          name: 'onedriveAccessUser',
+          label: 'Select User',
           multiple: false,
           creatable: false,
           api: {
-            url: "/api/ListGraphRequest",
+            url: '/api/ListGraphRequest',
             data: {
-              Endpoint: "users",
-              $select: "id,displayName,userPrincipalName",
+              Endpoint: 'users',
+              $select: 'id,displayName,userPrincipalName',
               $top: 999,
               $count: true,
             },
-            queryKey: "ListUsersAutoComplete",
-            dataKey: "Results",
+            queryKey: 'ListUsersAutoComplete',
+            dataKey: 'Results',
             labelField: (user) => `${user.displayName} (${user.userPrincipalName})`,
-            valueField: "userPrincipalName",
+            valueField: 'userPrincipalName',
             addedField: {
-              id: "id",
+              id: 'id',
             },
             showRefresh: true,
           },
@@ -45,57 +45,59 @@ const Page = () => {
       ],
     },
     {
-      label: "Remove permissions from OneDrive",
+      label: 'Remove permissions from OneDrive',
       icon: <PersonRemove />,
-      type: "POST",
-      url: "/api/ExecSharePointPerms",
+      type: 'POST',
+      url: '/api/ExecSharePointPerms',
       data: {
-        UPN: "ownerPrincipalName",
-        URL: "webUrl",
+        UPN: 'ownerPrincipalName',
+        URL: 'webUrl',
         RemovePermission: true,
       },
       confirmText: "Select the User to remove from this user's OneDrive permissions",
       fields: [
         {
-          type: "autoComplete",
-          name: "onedriveAccessUser",
-          label: "Select User",
+          type: 'autoComplete',
+          name: 'onedriveAccessUser',
+          label: 'Select User',
           multiple: false,
           creatable: false,
           api: {
-            url: "/api/listUsers",
+            url: '/api/listUsers',
             labelField: (onedriveAccessUser) =>
               `${onedriveAccessUser.displayName} (${onedriveAccessUser.userPrincipalName})`,
-            valueField: "userPrincipalName",
+            valueField: 'userPrincipalName',
             addedField: {
-              displayName: "displayName",
+              displayName: 'displayName',
             },
           },
         },
       ],
     },
-  ];
+  ]
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListSites?type=OneDriveUsageAccount"
+      apiDataKey="Results"
       actions={actions}
       simpleColumns={[
-        "displayName",
-        "createdDateTime",
-        "ownerPrincipalName",
-        "lastActivityDate",
-        "fileCount",
-        "storageUsedInGigabytes",
-        "storageAllocatedInGigabytes",
-        "reportRefreshDate",
-        "webUrl",
+        'Tenant',
+        'displayName',
+        'createdDateTime',
+        'ownerPrincipalName',
+        'lastActivityDate',
+        'fileCount',
+        'storageUsedInGigabytes',
+        'storageAllocatedInGigabytes',
+        'reportRefreshDate',
+        'webUrl',
       ]}
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/teams-share/sharepoint/index.js
+++ b/src/pages/teams-share/sharepoint/index.js
@@ -1,6 +1,6 @@
-import { Layout as DashboardLayout } from "../../../layouts/index.js";
-import { CippTablePage } from "../../../components/CippComponents/CippTablePage.jsx";
-import { Button } from "@mui/material";
+import { Layout as DashboardLayout } from '../../../layouts/index.js'
+import { CippTablePage } from '../../../components/CippComponents/CippTablePage.jsx'
+import { Button } from '@mui/material'
 import {
   Add,
   AddToPhotos,
@@ -9,49 +9,49 @@ import {
   AdminPanelSettings,
   NoAccounts,
   Delete,
-} from "@mui/icons-material";
-import Link from "next/link";
-import { CippDataTable } from "../../../components/CippTable/CippDataTable";
-import { useSettings } from "../../../hooks/use-settings";
+} from '@mui/icons-material'
+import Link from 'next/link'
+import { CippDataTable } from '../../../components/CippTable/CippDataTable'
+import { useSettings } from '../../../hooks/use-settings'
 
 const Page = () => {
-  const pageTitle = "SharePoint Sites";
-  const tenantFilter = useSettings().currentTenant;
+  const pageTitle = 'SharePoint Sites'
+  const tenantFilter = useSettings().currentTenant
 
   const actions = [
     {
-      label: "Add Member",
-      type: "POST",
+      label: 'Add Member',
+      type: 'POST',
       icon: <PersonAdd />,
-      url: "/api/ExecSetSharePointMember",
+      url: '/api/ExecSetSharePointMember',
       data: {
-        groupId: "ownerPrincipalName",
+        groupId: 'ownerPrincipalName',
         add: true,
-        URL: "webUrl",
-        SharePointType: "rootWebTemplate",
+        URL: 'webUrl',
+        SharePointType: 'rootWebTemplate',
       },
-      confirmText: "Select the User to add as a member.",
+      confirmText: 'Select the User to add as a member.',
       fields: [
         {
-          type: "autoComplete",
-          name: "user",
-          label: "Select User",
+          type: 'autoComplete',
+          name: 'user',
+          label: 'Select User',
           multiple: false,
           creatable: false,
           api: {
-            url: "/api/ListGraphRequest",
+            url: '/api/ListGraphRequest',
             data: {
-              Endpoint: "users",
-              $select: "id,displayName,userPrincipalName",
+              Endpoint: 'users',
+              $select: 'id,displayName,userPrincipalName',
               $top: 999,
               $count: true,
             },
-            queryKey: "ListUsersAutoComplete",
-            dataKey: "Results",
+            queryKey: 'ListUsersAutoComplete',
+            dataKey: 'Results',
             labelField: (user) => `${user.displayName} (${user.userPrincipalName})`,
-            valueField: "userPrincipalName",
+            valueField: 'userPrincipalName',
             addedField: {
-              id: "id",
+              id: 'id',
             },
             showRefresh: true,
           },
@@ -60,38 +60,38 @@ const Page = () => {
       multiPost: false,
     },
     {
-      label: "Remove Member",
-      type: "POST",
+      label: 'Remove Member',
+      type: 'POST',
       icon: <PersonRemove />,
-      url: "/api/ExecSetSharePointMember",
+      url: '/api/ExecSetSharePointMember',
       data: {
-        groupId: "ownerPrincipalName",
+        groupId: 'ownerPrincipalName',
         add: false,
-        URL: "URL",
-        SharePointType: "rootWebTemplate",
+        URL: 'URL',
+        SharePointType: 'rootWebTemplate',
       },
-      confirmText: "Select the User to remove as a member.",
+      confirmText: 'Select the User to remove as a member.',
       fields: [
         {
-          type: "autoComplete",
-          name: "user",
-          label: "Select User",
+          type: 'autoComplete',
+          name: 'user',
+          label: 'Select User',
           multiple: false,
           creatable: false,
           api: {
-            url: "/api/ListGraphRequest",
+            url: '/api/ListGraphRequest',
             data: {
-              Endpoint: "users",
-              $select: "id,displayName,userPrincipalName",
+              Endpoint: 'users',
+              $select: 'id,displayName,userPrincipalName',
               $top: 999,
               $count: true,
             },
-            queryKey: "ListUsersAutoComplete",
-            dataKey: "Results",
+            queryKey: 'ListUsersAutoComplete',
+            dataKey: 'Results',
             labelField: (user) => `${user.displayName} (${user.userPrincipalName})`,
-            valueField: "userPrincipalName",
+            valueField: 'userPrincipalName',
             addedField: {
-              id: "id",
+              id: 'id',
             },
             showRefresh: true,
           },
@@ -100,37 +100,37 @@ const Page = () => {
       multiPost: false,
     },
     {
-      label: "Add Site Admin",
-      type: "POST",
+      label: 'Add Site Admin',
+      type: 'POST',
       icon: <AdminPanelSettings />,
-      url: "/api/ExecSharePointPerms",
+      url: '/api/ExecSharePointPerms',
       data: {
-        UPN: "ownerPrincipalName",
+        UPN: 'ownerPrincipalName',
         RemovePermission: false,
-        URL: "webUrl",
+        URL: 'webUrl',
       },
-      confirmText: "Select the User to add to the Site Admins permissions",
+      confirmText: 'Select the User to add to the Site Admins permissions',
       fields: [
         {
-          type: "autoComplete",
-          name: "user",
-          label: "Select User",
+          type: 'autoComplete',
+          name: 'user',
+          label: 'Select User',
           multiple: false,
           creatable: false,
           api: {
-            url: "/api/ListGraphRequest",
+            url: '/api/ListGraphRequest',
             data: {
-              Endpoint: "users",
-              $select: "id,displayName,userPrincipalName",
+              Endpoint: 'users',
+              $select: 'id,displayName,userPrincipalName',
               $top: 999,
               $count: true,
             },
-            queryKey: "ListUsersAutoComplete",
-            dataKey: "Results",
+            queryKey: 'ListUsersAutoComplete',
+            dataKey: 'Results',
             labelField: (user) => `${user.displayName} (${user.userPrincipalName})`,
-            valueField: "userPrincipalName",
+            valueField: 'userPrincipalName',
             addedField: {
-              id: "id",
+              id: 'id',
             },
             showRefresh: true,
           },
@@ -139,37 +139,37 @@ const Page = () => {
       multiPost: false,
     },
     {
-      label: "Remove Site Admin",
-      type: "POST",
+      label: 'Remove Site Admin',
+      type: 'POST',
       icon: <NoAccounts />,
-      url: "/api/ExecSharePointPerms",
+      url: '/api/ExecSharePointPerms',
       data: {
-        UPN: "ownerPrincipalName",
+        UPN: 'ownerPrincipalName',
         RemovePermission: true,
-        URL: "webUrl",
+        URL: 'webUrl',
       },
-      confirmText: "Select the User to remove from the Site Admins permissions",
+      confirmText: 'Select the User to remove from the Site Admins permissions',
       fields: [
         {
-          type: "autoComplete",
-          name: "user",
-          label: "Select User",
+          type: 'autoComplete',
+          name: 'user',
+          label: 'Select User',
           multiple: false,
           creatable: false,
           api: {
-            url: "/api/ListGraphRequest",
+            url: '/api/ListGraphRequest',
             data: {
-              Endpoint: "users",
-              $select: "id,displayName,userPrincipalName",
+              Endpoint: 'users',
+              $select: 'id,displayName,userPrincipalName',
               $top: 999,
               $count: true,
             },
-            queryKey: "ListUsersAutoComplete",
-            dataKey: "Results",
+            queryKey: 'ListUsersAutoComplete',
+            dataKey: 'Results',
             labelField: (user) => `${user.displayName} (${user.userPrincipalName})`,
-            valueField: "userPrincipalName",
+            valueField: 'userPrincipalName',
             addedField: {
-              id: "id",
+              id: 'id',
             },
             showRefresh: true,
           },
@@ -178,56 +178,59 @@ const Page = () => {
       multiPost: false,
     },
     {
-      label: "Delete Site",
-      type: "POST",
+      label: 'Delete Site',
+      type: 'POST',
       icon: <Delete />,
-      url: "/api/DeleteSharepointSite",
+      url: '/api/DeleteSharepointSite',
       data: {
-        SiteId: "siteId",
+        SiteId: 'siteId',
       },
-      confirmText: "Are you sure you want to delete this SharePoint site? This action cannot be undone.",
-      color: "error",
+      confirmText:
+        'Are you sure you want to delete this SharePoint site? This action cannot be undone.',
+      color: 'error',
       multiPost: false,
     },
-  ];
+  ]
 
   const offCanvas = {
-    extendedInfoFields: ["displayName", "description", "webUrl"],
+    extendedInfoFields: ['displayName', 'description', 'webUrl'],
     actions: actions,
     children: (row) => (
       <CippDataTable
         title="Site Members"
         queryKey={`site-members-${row.siteId}`}
         api={{
-          url: "/api/ListSiteMembers",
+          url: '/api/ListSiteMembers',
           data: {
             SiteId: row.siteId,
             tenantFilter: tenantFilter,
           },
-          dataKey: "Results",
+          dataKey: 'Results',
         }}
-        simpleColumns={["fields.Title", "fields.EMail", "fields.IsSiteAdmin"]}
+        simpleColumns={['fields.Title', 'fields.EMail', 'fields.IsSiteAdmin']}
       />
     ),
-    size: "lg", // Make the offcanvas extra large
-  };
+    size: 'lg', // Make the offcanvas extra large
+  }
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListSites?type=SharePointSiteUsage"
+      apiDataKey="Results"
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={[
-        "displayName",
-        "createdDateTime",
-        "ownerPrincipalName",
-        "lastActivityDate",
-        "fileCount",
-        "storageUsedInGigabytes",
-        "storageAllocatedInGigabytes",
-        "reportRefreshDate",
-        "webUrl",
+        'Tenant',
+        'displayName',
+        'createdDateTime',
+        'ownerPrincipalName',
+        'lastActivityDate',
+        'fileCount',
+        'storageUsedInGigabytes',
+        'storageAllocatedInGigabytes',
+        'reportRefreshDate',
+        'webUrl',
       ]}
       cardButton={
         <>
@@ -244,9 +247,9 @@ const Page = () => {
         </>
       }
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/teams-share/teams/business-voice/index.js
+++ b/src/pages/teams-share/teams/business-voice/index.js
@@ -1,114 +1,116 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { PersonAdd, PersonRemove, LocationOn } from "@mui/icons-material";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { PersonAdd, PersonRemove, LocationOn } from '@mui/icons-material'
 
 const Page = () => {
-  const pageTitle = "Teams Business Voice";
+  const pageTitle = 'Teams Business Voice'
 
   const actions = [
     // the modal dropdowns that were added below may not exist yet, and will need to be tested.
     {
-      label: "Assign User",
-      type: "POST",
+      label: 'Assign User',
+      type: 'POST',
       icon: <PersonAdd />,
-      url: "/api/ExecTeamsVoicePhoneNumberAssignment",
+      url: '/api/ExecTeamsVoicePhoneNumberAssignment',
       data: {
-        PhoneNumber: "TelephoneNumber",
-        PhoneNumberType: "NumberType",
+        PhoneNumber: 'TelephoneNumber',
+        PhoneNumberType: 'NumberType',
         locationOnly: false,
       },
       fields: [
         {
-          type: "autoComplete",
-          name: "input",
-          label: "Select User",
+          type: 'autoComplete',
+          name: 'input',
+          label: 'Select User',
           multiple: false,
           creatable: false,
           api: {
-            url: "/api/listUsers",
+            url: '/api/listUsers',
             labelField: (input) => `${input.displayName} (${input.userPrincipalName})`,
-            valueField: "userPrincipalName",
+            valueField: 'userPrincipalName',
           },
         },
       ],
-      confirmText: "Select the User to assign the phone number to.",
+      confirmText: 'Select the User to assign the phone number to.',
     },
     {
-      label: "Unassign User",
-      type: "POST",
+      label: 'Unassign User',
+      type: 'POST',
       icon: <PersonRemove />,
-      url: "/api/ExecRemoveTeamsVoicePhoneNumberAssignment",
+      url: '/api/ExecRemoveTeamsVoicePhoneNumberAssignment',
       data: {
-        PhoneNumber: "TelephoneNumber",
-        AssignedTo: "AssignedTo",
-        PhoneNumberType: "NumberType",
+        PhoneNumber: 'TelephoneNumber',
+        AssignedTo: 'AssignedTo',
+        PhoneNumberType: 'NumberType',
       },
-      confirmText: "Are you sure you want to remove the assignment?",
+      confirmText: 'Are you sure you want to remove the assignment?',
     },
     {
-      label: "Set Emergency Location",
-      type: "POST",
+      label: 'Set Emergency Location',
+      type: 'POST',
       icon: <LocationOn />,
-      url: "/api/ExecTeamsVoicePhoneNumberAssignment",
+      url: '/api/ExecTeamsVoicePhoneNumberAssignment',
       data: {
-        PhoneNumber: "TelephoneNumber",
+        PhoneNumber: 'TelephoneNumber',
         locationOnly: true,
       },
       fields: [
         {
-          type: "autoComplete",
-          name: "input",
-          label: "Emergency Location",
+          type: 'autoComplete',
+          name: 'input',
+          label: 'Emergency Location',
           api: {
-            url: "/api/ListTeamsLisLocation",
-            labelField: "Description",
-            valueField: "LocationId",
+            url: '/api/ListTeamsLisLocation',
+            labelField: 'Description',
+            valueField: 'LocationId',
           },
         },
       ],
-      confirmText: "Select the Emergency Location.",
+      confirmText: 'Select the Emergency Location.',
     },
-  ];
+  ]
 
   const offCanvas = {
     extendedInfoFields: [
-      "TelephoneNumber",
-      "AcquiredCapabilities",
-      "AssignmentStatus",
-      "AssignedTo",
+      'TelephoneNumber',
+      'AcquiredCapabilities',
+      'AssignmentStatus',
+      'AssignedTo',
     ],
     actions: actions,
-  };
+  }
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListTeamsVoice"
+      apiDataKey="Results"
       actions={actions}
       offCanvas={offCanvas}
       simpleColumns={[
-        "AssignedTo",
-        "TelephoneNumber",
-        "AssignmentStatus",
-        "NumberType",
-        "AcquiredCapabilities",
-        "IsoCountryCode",
-        "PlaceName",
-        "ActivationState",
-        "IsOperatorConnect",
-        "AcquisitionDate",
+        'Tenant',
+        'AssignedTo',
+        'TelephoneNumber',
+        'AssignmentStatus',
+        'NumberType',
+        'AcquiredCapabilities',
+        'IsoCountryCode',
+        'PlaceName',
+        'ActivationState',
+        'IsOperatorConnect',
+        'AcquisitionDate',
       ]}
       filterlist={[
         {
-          filterName: "Unassigned User Numbers",
+          filterName: 'Unassigned User Numbers',
           filter:
-            "Complex: AssignmentStatus eq Unassigned; AcquiredCapabilities like UserAssignment",
+            'Complex: AssignmentStatus eq Unassigned; AcquiredCapabilities like UserAssignment',
         },
       ]}
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/teams-share/teams/list-team/index.js
+++ b/src/pages/teams-share/teams/list-team/index.js
@@ -1,42 +1,43 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { Button } from "@mui/material";
-import { Delete, GroupAdd } from "@mui/icons-material";
-import Link from "next/link";
-import { Edit } from "@mui/icons-material";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { Button } from '@mui/material'
+import { Delete, GroupAdd } from '@mui/icons-material'
+import Link from 'next/link'
+import { Edit } from '@mui/icons-material'
 
 const Page = () => {
-  const pageTitle = "Teams";
+  const pageTitle = 'Teams'
 
   const actions = [
     {
-      label: "Edit Group",
-      link: "/identity/administration/groups/edit?groupId=[id]&groupType=Microsoft 365",
+      label: 'Edit Group',
+      link: '/identity/administration/groups/edit?groupId=[id]&groupType=Microsoft 365',
       multiPost: false,
-      color: "warning",
+      color: 'warning',
       icon: <Edit />,
     },
     {
-      label: "Delete Team",
-      type: "POST",
-      url: "/api/ExecGroupsDelete",
+      label: 'Delete Team',
+      type: 'POST',
+      url: '/api/ExecGroupsDelete',
       icon: <Delete />,
       data: {
-        ID: "id",
-        GroupType: "!Microsoft 365",
-        DisplayName: "displayName",
+        ID: 'id',
+        GroupType: '!Microsoft 365',
+        DisplayName: 'displayName',
       },
-      confirmText: "Are you sure you want to delete this team?",
+      confirmText: 'Are you sure you want to delete this team?',
       multiPost: false,
     },
-  ];
+  ]
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListTeams?type=list"
+      apiDataKey="Results"
       actions={actions}
-      simpleColumns={["displayName", "description", "visibility", "mailNickname", "id"]}
+      simpleColumns={['Tenant', 'displayName', 'description', 'visibility', 'mailNickname', 'id']}
       cardButton={
         <>
           <Button component={Link} href="/teams-share/teams/list-team/add" startIcon={<GroupAdd />}>
@@ -45,9 +46,9 @@ const Page = () => {
         </>
       }
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page

--- a/src/pages/teams-share/teams/teams-activity/index.js
+++ b/src/pages/teams-share/teams/teams-activity/index.js
@@ -1,18 +1,19 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
 
 const Page = () => {
-  const pageTitle = "Teams Activity List";
+  const pageTitle = 'Teams Activity List'
 
   return (
     <CippTablePage
       title={pageTitle}
       apiUrl="/api/ListTeamsActivity?type=TeamsUserActivityUser"
-      simpleColumns={["UPN", "LastActive", "MeetingCount", "CallCount", "TeamsChat"]}
+      apiDataKey="Results"
+      simpleColumns={['Tenant', 'UPN', 'LastActive', 'MeetingCount', 'CallCount', 'TeamsChat']}
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
 
-export default Page;
+export default Page


### PR DESCRIPTION
Introduce allTenants support for app, compliance policies, devices, scripts, and autopilot pages, enhancing functionality and consistency across the application.
Oh and lots of linter stuff

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1971