### PR TITLE
fix: Change User Select language value to empty string for Graph API

### DIFF
--- a/src/components/CippComponents/CippAutopilotProfileDrawer.jsx
+++ b/src/components/CippComponents/CippAutopilotProfileDrawer.jsx
@@ -156,7 +156,7 @@ export const CippAutopilotProfileDrawer = ({
               name="languages"
               options={[
                 { value: "os-default", label: "Operating system default" },
-                { value: "user-select", label: "User Select" },
+                { value: "", label: "User Select" },
                 ...languageList.map(({ language, tag, "Geographic area": geographicArea }) => ({
                   value: tag,
                   label: `${language} - ${geographicArea}`, // Format as "language - geographic area" for display


### PR DESCRIPTION
## Bug Description
When deploying an AP profile with Language set to "User Select", it doesn't work because the Graph API expects an empty string for this option, not the string "user-select".

## Fix
Changed the value for "User Select" option from "user-select" to "" (empty string) in the Autopilot Profile Drawer component.

## Issue Reference
Fixes #5761

## Testing
- This is a minimal one-line change that aligns the frontend value with what the Graph API expects
- The previous commit that introduced this feature worked with empty string: https://github.com/KelvinTegelaar/CIPP/commit/12747e55a930e30d30e76fda6e513ab85655fd8c