### PR TITLE
feat: Move AP devices and status page to generic graph request endpoint

### DIFF
--- a/src/pages/endpoint/autopilot/list-devices/index.js
+++ b/src/pages/endpoint/autopilot/list-devices/index.js
@@ -1,145 +1,151 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { CippApiDialog } from "../../../../components/CippComponents/CippApiDialog.jsx";
-import { Button } from "@mui/material";
-import { PersonAdd, Delete, Sync, Add, Edit, Sell } from "@mui/icons-material";
-import { useDialog } from "../../../../hooks/use-dialog";
-import Link from "next/link";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { CippApiDialog } from '../../../../components/CippComponents/CippApiDialog.jsx'
+import { Button } from '@mui/material'
+import { PersonAdd, Delete, Sync, Add, Edit, Sell } from '@mui/icons-material'
+import { useDialog } from '../../../../hooks/use-dialog'
+import Link from 'next/link'
 
 const Page = () => {
-  const pageTitle = "Autopilot Devices";
-  const createDialog = useDialog();
+  const pageTitle = 'Autopilot Devices'
+  const createDialog = useDialog()
 
   const actions = [
     {
-      label: "Assign device",
+      label: 'Assign device',
       icon: <PersonAdd />,
-      type: "POST",
-      url: "/api/ExecAssignAPDevice",
+      type: 'POST',
+      url: '/api/ExecAssignAPDevice',
       data: {
-        device: "id",
-        serialNumber: "serialNumber",
+        device: 'id',
+        serialNumber: 'serialNumber',
       },
-      confirmText: "Select the user to assign the device to",
+      confirmText: 'Select the user to assign the device to',
       fields: [
         {
-          type: "autoComplete",
-          name: "user",
-          label: "Select User",
+          type: 'autoComplete',
+          name: 'user',
+          label: 'Select User',
           multiple: false,
           creatable: false,
           api: {
-            url: "/api/listUsers",
+            url: '/api/listUsers',
             labelField: (user) => `${user.displayName} (${user.userPrincipalName})`,
-            valueField: "userPrincipalName",
+            valueField: 'userPrincipalName',
             addedField: {
-              userPrincipalName: "userPrincipalName",
-              addressableUserName: "displayName",
+              userPrincipalName: 'userPrincipalName',
+              addressableUserName: 'displayName',
             },
           },
         },
       ],
-      color: "info",
+      color: 'info',
     },
     {
-      label: "Rename Device",
+      label: 'Rename Device',
       icon: <Edit />,
-      type: "POST",
-      url: "/api/ExecRenameAPDevice",
+      type: 'POST',
+      url: '/api/ExecRenameAPDevice',
       data: {
-        deviceId: "id",
-        serialNumber: "serialNumber",
+        deviceId: 'id',
+        serialNumber: 'serialNumber',
       },
-      confirmText: "Enter the new display name for the device.",
+      confirmText: 'Enter the new display name for the device.',
       fields: [
         {
-          type: "textField",
-          name: "displayName",
-          label: "New Display Name",
+          type: 'textField',
+          name: 'displayName',
+          label: 'New Display Name',
           required: true,
           validate: (value) => {
             if (!value) {
-              return "Display name is required.";
+              return 'Display name is required.'
             }
             if (value.length > 15) {
-              return "Display name must be 15 characters or less.";
+              return 'Display name must be 15 characters or less.'
             }
             if (/\s/.test(value)) {
-              return "Display name cannot contain spaces.";
+              return 'Display name cannot contain spaces.'
             }
             if (!/^[a-zA-Z0-9-]+$/.test(value)) {
-              return "Display name can only contain letters, numbers, and hyphens.";
+              return 'Display name can only contain letters, numbers, and hyphens.'
             }
             if (/^[0-9]+$/.test(value)) {
-              return "Display name cannot contain only numbers.";
+              return 'Display name cannot contain only numbers.'
             }
-            return true; // Indicates validation passed
+            return true // Indicates validation passed
           },
         },
       ],
-      color: "secondary",
+      color: 'secondary',
     },
     {
-      label: "Edit Group Tag",
+      label: 'Edit Group Tag',
       icon: <Sell />,
-      type: "POST",
-      url: "/api/ExecSetAPDeviceGroupTag",
+      type: 'POST',
+      url: '/api/ExecSetAPDeviceGroupTag',
       data: {
-        deviceId: "id",
-        serialNumber: "serialNumber",
+        deviceId: 'id',
+        serialNumber: 'serialNumber',
       },
-      confirmText: "Enter the new group tag for the device.",
+      confirmText: 'Enter the new group tag for the device.',
       fields: [
         {
-          type: "textField",
-          name: "groupTag",
-          label: "Group Tag",
+          type: 'textField',
+          name: 'groupTag',
+          label: 'Group Tag',
           validate: (value) => {
             if (value && value.length > 128) {
-              return "Group tag cannot exceed 128 characters.";
+              return 'Group tag cannot exceed 128 characters.'
             }
-            return true; // Validation passed
+            return true // Validation passed
           },
         },
       ],
-      color: "secondary",
+      color: 'secondary',
     },
     {
-      label: "Delete Device",
+      label: 'Delete Device',
       icon: <Delete />,
-      type: "POST",
-      url: "/api/RemoveAPDevice",
-      data: { ID: "id" },
-      confirmText: "Are you sure you want to delete this device?",
-      color: "danger",
+      type: 'POST',
+      url: '/api/RemoveAPDevice',
+      data: { ID: 'id' },
+      confirmText: 'Are you sure you want to delete this device?',
+      color: 'danger',
     },
-  ];
+  ]
 
   const offCanvas = {
     extendedInfoFields: [
-      "userPrincipalName",
-      "productKey",
-      "serialNumber",
-      "model",
-      "manufacturer",
+      'userPrincipalName',
+      'productKey',
+      'serialNumber',
+      'model',
+      'manufacturer',
     ],
     actions: actions,
-  };
+  }
 
   const simpleColumns = [
-    "displayName",
-    "serialNumber",
-    "model",
-    "manufacturer",
-    "groupTag",
-    "enrollmentState",
-  ];
+    'Tenant',
+    'displayName',
+    'serialNumber',
+    'model',
+    'manufacturer',
+    'groupTag',
+    'enrollmentState',
+  ]
 
   return (
     <>
       <CippTablePage
         title={pageTitle}
-        apiUrl="/api/ListAPDevices"
+        apiUrl="/api/ListGraphRequest"
+        apiData={{
+          Endpoint: 'deviceManagement/windowsAutopilotDeviceIdentities',
+          $top: 999,
+        }}
+        apiDataKey="Results"
         actions={actions}
         offCanvas={offCanvas}
         simpleColumns={simpleColumns}
@@ -158,16 +164,16 @@ const Page = () => {
         title="Sync Autopilot Devices"
         createDialog={createDialog}
         api={{
-          type: "POST",
-          url: "/api/ExecSyncAPDevices",
+          type: 'POST',
+          url: '/api/ExecSyncAPDevices',
           data: {},
           confirmText:
-            "Are you sure you want to sync Autopilot devices? This can only be done every 10 minutes.",
+            'Are you sure you want to sync Autopilot devices? This can only be done every 10 minutes.',
         }}
       />
     </>
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>
+export default Page

--- a/src/pages/endpoint/autopilot/list-status-pages/index.js
+++ b/src/pages/endpoint/autopilot/list-status-pages/index.js
@@ -1,26 +1,34 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { CippAutopilotStatusPageDrawer } from "../../../../components/CippComponents/CippAutopilotStatusPageDrawer";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { CippAutopilotStatusPageDrawer } from '../../../../components/CippComponents/CippAutopilotStatusPageDrawer'
 
 const Page = () => {
-  const pageTitle = "Autopilot Status Pages";
+  const pageTitle = 'Autopilot Status Pages'
 
   const simpleColumns = [
-    "displayName",
-    "Description",
-    "installProgressTimeoutInMinutes",
-    "showInstallationProgress",
-    "blockDeviceSetupRetryByUser",
-    "allowDeviceResetOnInstallFailure",
-    "allowDeviceUseOnInstallFailure",
-  ];
+    'Tenant',
+    'displayName',
+    'Description',
+    'installProgressTimeoutInMinutes',
+    'showInstallationProgress',
+    'blockDeviceSetupRetryByUser',
+    'allowDeviceResetOnInstallFailure',
+    'allowDeviceUseOnInstallFailure',
+  ]
 
   // No actions specified in the original file, so none are included here.
 
   return (
     <CippTablePage
       title={pageTitle}
-      apiUrl="/api/ListAutopilotConfig?type=ESP"
+      apiUrl="/api/ListGraphRequest"
+      apiData={{
+        Endpoint: 'deviceManagement/deviceEnrollmentConfigurations',
+        $expand: 'assignments',
+        $filter:
+          "deviceEnrollmentConfigurationType eq 'windows10EnrollmentCompletionPageConfiguration'",
+      }}
+      apiDataKey="Results"
       simpleColumns={simpleColumns}
       cardButton={
         <>
@@ -28,8 +36,8 @@ const Page = () => {
         </>
       }
     />
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>
+export default Page


### PR DESCRIPTION
Refactor the API calls for Autopilot Devices and Status Pages to utilize a generic Graph request endpoint, enhancing consistency and maintainability. Adjustments include updating API URLs and data structures accordingly.

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/1987