### PR TITLE
feat: add AI Administrator role to GDAPRoles.json

### DIFF
--- a/src/data/GDAPRoles.json
+++ b/src/data/GDAPRoles.json
@@ -814,5 +814,13 @@
     "IsSystem": true,
     "Name": "Customer Delegated Admin Relationship Administrator",
     "ObjectId": "fc8ad4e2-40e4-4724-8317-bcda7503ecbf"
+  },
+  {
+    "ExtensionData": {},
+    "Description": "Assign the AI Administrator role to users who need to manage all aspects of Microsoft 365 Copilot, AI-related enterprise services, copilot agents, and view usage reports and service health dashboards.",
+    "IsEnabled": true,
+    "IsSystem": true,
+    "Name": "AI Administrator",
+    "ObjectId": "d2562ede-74db-457e-a7b6-544e236ebb61"
   }
 ]


### PR DESCRIPTION
## Description

Adds the **AI Administrator** role (Template ID: `d2562ede-74db-457e-a7b6-544e236ebb61`) to `GDAPRoles.json`.

This is a privileged Entra ID role that grants permissions to manage Microsoft 365 Copilot, AI-related enterprise services, extensibility, and copilot agents from the Integrated apps page in the Microsoft 365 admin center.

## Why this matters

With the growing adoption of Microsoft 365 Copilot across tenants, this role is becoming increasingly relevant for MSPs and admins. Adding it to the GDAPRoles list benefits CIPP users in two main ways:

- **JIT (Just-in-Time) access**: Users can elevate to AI Administrator on demand via CIPP's JIT interface, following least-privilege principles rather than holding the role permanently.
- **GDAP relationships**: The role becomes available for selection when creating or extending GDAP relationships with customer tenants, enabling partners to manage Copilot and AI services on behalf of customers.

## Role permissions summary

Per Microsoft's documentation, the AI Administrator role can:
- Manage all aspects of Microsoft 365 Copilot
- Manage AI-related enterprise services, extensibility, and copilot agents from Integrated apps
- Approve and publish line-of-business copilot agents
- Allow users to install apps (where no permission is required)
- Read and configure Azure and Microsoft 365 service health dashboards
- View usage reports, adoption insights, and organizational insights
- Create and manage support tickets

## Testing

- [x] Validated JSON syntax
- [x] Confirmed Template ID against Microsoft's official documentation
- [x] Role description follows the same format as existing entries

## References

- [Microsoft Entra built-in roles — AI Administrator](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference#ai-administrator)