### PR TITLE
Fix: Update notification message to include instruction for reviewing new permissions

### DIFF
--- a/src/components/CippSettings/CippPermissionResults.jsx
+++ b/src/components/CippSettings/CippPermissionResults.jsx
@@ -133,7 +133,7 @@ export const CippPermissionResults = (props) => {
                   <SvgIcon fontSize="sm" style={{ marginRight: 4 }}>
                     <XMarkIcon />
                   </SvgIcon>
-                  There are new permissions to apply.
+                  There are new permissions to apply. Please click "Details" to review and apply the new permissions.
                 </Typography>
               </ListItem>
             )}


### PR DESCRIPTION
## Summary
- Clarifies the "new permissions to apply" notification by telling the user how to act on it — they now see "Please click \"Details\" to review and apply the new permissions."