### PR TITLE
feat: show full MDE connector details on single tenant view

### DIFF
--- a/src/pages/security/reports/mde-onboarding/index.js
+++ b/src/pages/security/reports/mde-onboarding/index.js
@@ -14,11 +14,14 @@ import {
   SvgIcon,
 } from "@mui/material";
 import { Sync, OpenInNew } from "@mui/icons-material";
+import { Grid } from "@mui/system";
 import { ApiGetCall } from "../../../../api/ApiCall";
 import { CippHead } from "../../../../components/CippComponents/CippHead";
 import { useDialog } from "../../../../hooks/use-dialog";
 import { CippApiDialog } from "../../../../components/CippComponents/CippApiDialog";
 import { CippQueueTracker } from "../../../../components/CippTable/CippQueueTracker";
+import { CippPropertyListCard } from "../../../../components/CippCards/CippPropertyListCard";
+import { getCippFormatting } from "../../../../utils/get-cipp-formatting";
 import { useState } from "react";
 import { useCippReportDB } from "../../../../components/CippComponents/CippReportDBControls";
 
@@ -63,73 +66,232 @@ const SingleTenantView = ({ tenant }) => {
   const item = Array.isArray(data) ? data[0] : data;
   const status = item?.partnerState || "Unknown";
 
+  const platformItems = [
+    {
+      label: "Windows",
+      value: getCippFormatting(item?.windowsEnabled, "windowsEnabled"),
+    },
+    {
+      label: "iOS",
+      value: getCippFormatting(item?.iosEnabled, "iosEnabled"),
+    },
+    {
+      label: "Android",
+      value: getCippFormatting(item?.androidEnabled, "androidEnabled"),
+    },
+    {
+      label: "macOS",
+      value: getCippFormatting(item?.macEnabled, "macEnabled"),
+    },
+  ];
+
+  const mamItems = [
+    {
+      label: "iOS MAM",
+      value: getCippFormatting(
+        item?.iosMobileApplicationManagementEnabled,
+        "iosMobileApplicationManagementEnabled"
+      ),
+    },
+    {
+      label: "Android MAM",
+      value: getCippFormatting(
+        item?.androidMobileApplicationManagementEnabled,
+        "androidMobileApplicationManagementEnabled"
+      ),
+    },
+    {
+      label: "Windows MAM",
+      value: getCippFormatting(
+        item?.windowsMobileApplicationManagementEnabled,
+        "windowsMobileApplicationManagementEnabled"
+      ),
+    },
+    {
+      label: "MDE Attach",
+      value: getCippFormatting(
+        item?.microsoftDefenderForEndpointAttachEnabled,
+        "microsoftDefenderForEndpointAttachEnabled"
+      ),
+    },
+  ];
+
+  const dataCollectionItems = [
+    {
+      label: "Block iOS on missing partner data",
+      value: getCippFormatting(
+        item?.iosDeviceBlockedOnMissingPartnerData,
+        "iosDeviceBlockedOnMissingPartnerData"
+      ),
+    },
+    {
+      label: "Block Android on missing partner data",
+      value: getCippFormatting(
+        item?.androidDeviceBlockedOnMissingPartnerData,
+        "androidDeviceBlockedOnMissingPartnerData"
+      ),
+    },
+    {
+      label: "Block Windows on missing partner data",
+      value: getCippFormatting(
+        item?.windowsDeviceBlockedOnMissingPartnerData,
+        "windowsDeviceBlockedOnMissingPartnerData"
+      ),
+    },
+    {
+      label: "Block macOS on missing partner data",
+      value: getCippFormatting(
+        item?.macDeviceBlockedOnMissingPartnerData,
+        "macDeviceBlockedOnMissingPartnerData"
+      ),
+    },
+    {
+      label: "Block unsupported OS versions",
+      value: getCippFormatting(
+        item?.partnerUnsupportedOsVersionBlocked,
+        "partnerUnsupportedOsVersionBlocked"
+      ),
+    },
+    {
+      label: "Unresponsiveness threshold (days)",
+      value:
+        item?.partnerUnresponsivenessThresholdInDays ??
+        getCippFormatting(null, "partnerUnresponsivenessThresholdInDays"),
+    },
+    {
+      label: "Collect iOS app metadata",
+      value: getCippFormatting(
+        item?.allowPartnerToCollectIOSApplicationMetadata,
+        "allowPartnerToCollectIOSApplicationMetadata"
+      ),
+    },
+    {
+      label: "Collect iOS personal app metadata",
+      value: getCippFormatting(
+        item?.allowPartnerToCollectIOSPersonalApplicationMetadata,
+        "allowPartnerToCollectIOSPersonalApplicationMetadata"
+      ),
+    },
+    {
+      label: "Collect iOS certificate metadata",
+      value: getCippFormatting(
+        item?.allowPartnerToCollectIosCertificateMetadata,
+        "allowPartnerToCollectIosCertificateMetadata"
+      ),
+    },
+    {
+      label: "Collect iOS personal certificate metadata",
+      value: getCippFormatting(
+        item?.allowPartnerToCollectIosPersonalCertificateMetadata,
+        "allowPartnerToCollectIosPersonalCertificateMetadata"
+      ),
+    },
+  ];
+
   return (
     <>
       <CippHead title="MDE Onboarding Status" />
-      <Container maxWidth="lg" sx={{ mt: 2 }}>
-        <Card>
-          <CardHeader
-            title="Microsoft Defender for Endpoint - Onboarding Status"
-            action={
-              <Stack direction="row" spacing={1} alignItems="center">
-                <CippQueueTracker
-                  queueId={syncQueueId}
-                  queryKey={`MDEOnboarding-${tenant}`}
-                  title="MDE Onboarding Sync"
-                />
-                <Button
-                  startIcon={
-                    <SvgIcon fontSize="small">
-                      <Sync />
-                    </SvgIcon>
-                  }
-                  size="small"
-                  onClick={syncDialog.handleOpen}
-                >
-                  Sync
-                </Button>
-              </Stack>
-            }
-          />
-          <CardContent>
-            {isFetching ? (
-              <CircularProgress />
-            ) : (
-              <Stack spacing={2}>
-                <Stack direction="row" spacing={2} alignItems="center">
-                  <Typography variant="body1">Status:</Typography>
-                  <Chip
-                    label={statusLabels[status] || status}
-                    color={statusColors[status] || "default"}
-                    size="medium"
+      <Container maxWidth="xl" sx={{ mt: 2 }}>
+        <Stack spacing={3}>
+          <Card>
+            <CardHeader
+              title="Microsoft Defender for Endpoint - Onboarding Status"
+              action={
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <CippQueueTracker
+                    queueId={syncQueueId}
+                    queryKey={`MDEOnboarding-${tenant}`}
+                    title="MDE Onboarding Sync"
                   />
-                </Stack>
-                {item?.CacheTimestamp && (
-                  <Typography variant="caption" color="text.secondary">
-                    Last synced: {new Date(item.CacheTimestamp).toLocaleString()}
-                  </Typography>
-                )}
-                {item?.error && (
-                  <Typography variant="body2" color="error">
-                    {item.error}
-                  </Typography>
-                )}
-                {tenantId && status !== "enabled" && status !== "available" && (
                   <Button
-                    variant="contained"
-                    startIcon={<OpenInNew />}
-                    href={`https://security.microsoft.com/securitysettings/endpoints/onboarding?tid=${tenantId}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    sx={{ alignSelf: "flex-start" }}
+                    startIcon={
+                      <SvgIcon fontSize="small">
+                        <Sync />
+                      </SvgIcon>
+                    }
+                    size="small"
+                    onClick={syncDialog.handleOpen}
                   >
-                    Start Onboarding
+                    Sync
                   </Button>
-                )}
-              </Stack>
-            )}
-          </CardContent>
-        </Card>
+                </Stack>
+              }
+            />
+            <CardContent>
+              {isFetching ? (
+                <CircularProgress />
+              ) : (
+                <Stack spacing={2}>
+                  <Stack direction="row" spacing={2} alignItems="center">
+                    <Typography variant="body1">Status:</Typography>
+                    <Chip
+                      label={statusLabels[status] || status}
+                      color={statusColors[status] || "default"}
+                      size="medium"
+                    />
+                  </Stack>
+                  {item?.lastHeartbeatDateTime && (
+                    <Typography variant="body2" color="text.secondary">
+                      Last heartbeat:{" "}
+                      {new Date(item.lastHeartbeatDateTime).toLocaleString()}
+                    </Typography>
+                  )}
+                  {item?.CacheTimestamp && (
+                    <Typography variant="caption" color="text.secondary">
+                      Last synced: {new Date(item.CacheTimestamp).toLocaleString()}
+                    </Typography>
+                  )}
+                  {item?.error && (
+                    <Typography variant="body2" color="error">
+                      {item.error}
+                    </Typography>
+                  )}
+                  {tenantId && status !== "enabled" && status !== "available" && (
+                    <Button
+                      variant="contained"
+                      startIcon={<OpenInNew />}
+                      href={`https://security.microsoft.com/securitysettings/endpoints/onboarding?tid=${tenantId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{ alignSelf: "flex-start" }}
+                    >
+                      Start Onboarding
+                    </Button>
+                  )}
+                </Stack>
+              )}
+            </CardContent>
+          </Card>
+
+          {!isFetching && item && (
+            <Grid container spacing={3}>
+              <Grid size={{ xs: 12, md: 6, lg: 4 }}>
+                <CippPropertyListCard
+                  title="Platform Support"
+                  propertyItems={platformItems}
+                  isFetching={isFetching}
+                  showDivider={false}
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 6, lg: 4 }}>
+                <CippPropertyListCard
+                  title="App Management & Attach"
+                  propertyItems={mamItems}
+                  isFetching={isFetching}
+                  showDivider={false}
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 12, lg: 4 }}>
+                <CippPropertyListCard
+                  title="Data Collection & Compliance"
+                  propertyItems={dataCollectionItems}
+                  isFetching={isFetching}
+                  showDivider={false}
+                />
+              </Grid>
+            </Grid>
+          )}
+        </Stack>
       </Container>
       <CippApiDialog
         createDialog={syncDialog}
@@ -178,7 +340,21 @@ const Page = () => {
         apiUrl={reportDB.resolvedApiUrl}
         apiData={reportDB.resolvedApiData}
         queryKey={reportDB.resolvedQueryKey}
-        simpleColumns={["Tenant", "partnerState", "CacheTimestamp"]}
+        simpleColumns={[
+          "Tenant",
+          "partnerState",
+          "lastHeartbeatDateTime",
+          "microsoftDefenderForEndpointAttachEnabled",
+          "windowsEnabled",
+          "iosEnabled",
+          "androidEnabled",
+          "macEnabled",
+          "iosMobileApplicationManagementEnabled",
+          "androidMobileApplicationManagementEnabled",
+          "windowsMobileApplicationManagementEnabled",
+          "partnerUnresponsivenessThresholdInDays",
+          "CacheTimestamp",
+        ]}
         cardButton={reportDB.controls}
       />
       {reportDB.syncDialog}


### PR DESCRIPTION
## Summary
- Adds three property cards under the status header: Platform Support, App Management & Attach, Data Collection & Compliance.
- Shows last heartbeat next to the status chip.
- Expands the AllTenants table with the new columns.

<img width="1259" height="941" alt="image" src="https://github.com/user-attachments/assets/3936667b-010e-4ef1-a633-60c135943d7a" />


> Depends on KelvinTegelaar/CIPP-API#2026.