### PR TITLE
Add Usage Location field to JIT Admin and template forms (#5910)

### DIFF
--- a/src/pages/identity/administration/jit-admin-templates/add.jsx
+++ b/src/pages/identity/administration/jit-admin-templates/add.jsx
@@ -9,6 +9,7 @@ import { CippFormDomainSelector } from "../../../../components/CippComponents/Ci
 import { CippFormUserSelector } from "../../../../components/CippComponents/CippFormUserSelector";
 import { CippFormGroupSelector } from "../../../../components/CippComponents/CippFormGroupSelector";
 import gdaproles from "../../../../data/GDAPRoles.json";
+import countryList from "../../../../data/countryList.json";
 import { useSettings } from "../../../../hooks/use-settings";
 import { useEffect } from "react";
 
@@ -352,6 +353,19 @@ const Page = () => {
                   />
                 </Grid>
               )}
+              <Grid size={{ md: 6, xs: 12 }}>
+                <CippFormComponent
+                  type="autoComplete"
+                  label="Default Usage Location"
+                  name="defaultUsageLocation"
+                  multiple={false}
+                  options={countryList.map(({ Code, Name }) => ({
+                    label: Name,
+                    value: Code,
+                  }))}
+                  formControl={formControl}
+                />
+              </Grid>
             </CippFormCondition>
 
             <CippFormCondition

--- a/src/pages/identity/administration/jit-admin-templates/edit.jsx
+++ b/src/pages/identity/administration/jit-admin-templates/edit.jsx
@@ -9,6 +9,7 @@ import { CippFormDomainSelector } from "../../../../components/CippComponents/Ci
 import { CippFormUserSelector } from "../../../../components/CippComponents/CippFormUserSelector";
 import { CippFormGroupSelector } from "../../../../components/CippComponents/CippFormGroupSelector";
 import gdaproles from "../../../../data/GDAPRoles.json";
+import countryList from "../../../../data/countryList.json";
 import { useSettings } from "../../../../hooks/use-settings";
 import { useRouter } from "next/router";
 import { ApiGetCall } from "../../../../api/ApiCall";
@@ -375,6 +376,19 @@ const Page = () => {
                   />
                 </Grid>
               )}
+              <Grid size={{ md: 6, xs: 12 }}>
+                <CippFormComponent
+                  type="autoComplete"
+                  label="Default Usage Location"
+                  name="defaultUsageLocation"
+                  multiple={false}
+                  options={countryList.map(({ Code, Name }) => ({
+                    label: Name,
+                    value: Code,
+                  }))}
+                  formControl={formControl}
+                />
+              </Grid>
             </CippFormCondition>
 
             <CippFormCondition

--- a/src/pages/identity/administration/jit-admin/add.jsx
+++ b/src/pages/identity/administration/jit-admin/add.jsx
@@ -7,6 +7,7 @@ import { useForm, useWatch } from "react-hook-form";
 import CippFormComponent from "../../../../components/CippComponents/CippFormComponent";
 import { CippFormCondition } from "../../../../components/CippComponents/CippFormCondition";
 import gdaproles from "../../../../data/GDAPRoles.json";
+import countryList from "../../../../data/countryList.json";
 import { CippFormDomainSelector } from "../../../../components/CippComponents/CippFormDomainSelector";
 import { CippFormUserSelector } from "../../../../components/CippComponents/CippFormUserSelector";
 import { CippFormGroupSelector } from "../../../../components/CippComponents/CippFormGroupSelector";
@@ -205,6 +206,9 @@ const Page = () => {
     if (template.defaultExistingUser) {
       formControl.setValue("existingUser", template.defaultExistingUser, { shouldDirty: true });
     }
+    if (template.defaultUsageLocation) {
+      formControl.setValue("usageLocation", template.defaultUsageLocation, { shouldDirty: true });
+    }
 
     // Dates
     if (template.defaultDuration) {
@@ -341,6 +345,19 @@ const Page = () => {
                   label="Domain Name"
                   required={true}
                   validators={{ required: "Domain is required" }}
+                />
+              </Grid>
+              <Grid size={{ md: 6, xs: 12 }}>
+                <CippFormComponent
+                  type="autoComplete"
+                  label="Usage Location"
+                  name="usageLocation"
+                  multiple={false}
+                  options={countryList.map(({ Code, Name }) => ({
+                    label: Name,
+                    value: Code,
+                  }))}
+                  formControl={formControl}
                 />
               </Grid>
               <Grid size={{ md: 12, xs: 12 }}>


### PR DESCRIPTION
## Summary
- Adds "Usage Location" country selector to JIT Admin user creation form
- Adds "Default Usage Location" field to JIT Admin template forms (add and edit)
- Templates with a default usage location auto-populate the field when selected
- Uses existing `countryList.json` and matches the pattern from `CippAddEditUser.jsx`

Fixes https://github.com/KelvinTegelaar/CIPP/issues/5910

Companion PR (backend): https://github.com/KelvinTegelaar/CIPP-API/pull/2041

## Changes
- `jit-admin-templates/add.jsx` — adds Default Usage Location autocomplete field
- `jit-admin-templates/edit.jsx` — same for template editing
- `jit-admin/add.jsx` — adds Usage Location field + template prefill in useEffect