### PR TITLE
Feat: Add configurable TAP lifetime for JIT Admin

### DIFF
--- a/src/pages/identity/administration/jit-admin/add.jsx
+++ b/src/pages/identity/administration/jit-admin/add.jsx
@@ -31,6 +31,12 @@ const Page = () => {
 
   const watcher = useWatch({ control: formControl.control });
   const useTAP = useWatch({ control: formControl.control, name: "UseTAP" });
+  const startDate = useWatch({ control: formControl.control, name: "startDate" });
+  const endDate = useWatch({ control: formControl.control, name: "endDate" });
+  const tapLifetimeInMinutes = useWatch({
+    control: formControl.control,
+    name: "tapLifetimeInMinutes",
+  });
 
   const tapPolicy = ApiGetCall({
     url: selectedTenant
@@ -46,6 +52,22 @@ const Page = () => {
   const tapEnabled = tapPolicy.isSuccess && tapPolicy.data?.Results?.[0]?.state === "enabled";
   const useRoles = useWatch({ control: formControl.control, name: "useRoles" });
   const useGroups = useWatch({ control: formControl.control, name: "useGroups" });
+
+  useEffect(() => {
+    if (!useTAP || !startDate || !endDate) {
+      formControl.setValue("tapLifetimeInMinutes", null);
+      return;
+    }
+
+    const requestedMinutes = Math.max(1, Math.round((endDate - startDate) / 60));
+    const tapPolicyConfig = tapPolicy.data?.Results?.[0];
+    const policyMax = tapPolicyConfig?.maximumLifetimeInMinutes ?? 1440;
+    const policyMin = Math.min(tapPolicyConfig?.minimumLifetimeInMinutes ?? 1, policyMax);
+    formControl.setValue(
+      "tapLifetimeInMinutes",
+      Math.min(Math.max(requestedMinutes, policyMin), policyMax)
+    );
+  }, [useTAP, startDate, endDate, tapPolicy.data, formControl]);
 
   // Clear fields when switches are toggled off
   useEffect(() => {
@@ -502,6 +524,11 @@ const Page = () => {
             </Grid>
             <Grid size={{ md: 12, xs: 12 }}>
               <CippFormComponent
+                type="hidden"
+                name="tapLifetimeInMinutes"
+                formControl={formControl}
+              />
+              <CippFormComponent
                 type="switch"
                 label="Generate TAP"
                 name="UseTAP"
@@ -510,6 +537,11 @@ const Page = () => {
               {useTAP && tapPolicy.isSuccess && !tapEnabled && (
                 <Box sx={{ color: "error.main", fontSize: "0.875rem", mt: 0.5 }}>
                   TAP is not enabled in this tenant. TAP generation will fail.
+                </Box>
+              )}
+              {useTAP && tapLifetimeInMinutes && (
+                <Box sx={{ color: "text.secondary", fontSize: "0.875rem", mt: 0.5 }}>
+                  TAP will be valid for {tapLifetimeInMinutes} minutes.
                 </Box>
               )}
             </Grid>


### PR DESCRIPTION
Introduce the ability to set a custom TAP expiration time for JIT Admin accounts, based on the start and end time.

Fixes #5965
API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/2045