### PR TITLE
fix: Remove accidentally committed .claude/worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ AGENTS.md
 # azurite
 __*
 AzuriteConfig
+# Claude/Cursor worktrees and local AI tooling
+.claude/


### PR DESCRIPTION
Fixes #6011

## Summary
- Remove `.claude/worktrees` directory that was accidentally committed
- Add `.claude/` to `.gitignore` to prevent future accidents

## Problem
The `.claude/worktrees/blissful-golick-d405ab` directory was committed to the dev branch, causing CI failures:

```
fatal: No url found for submodule path '.claude/worktrees/blissful-golick-d405ab' in .gitmodules
```

Git treats this directory as a submodule but there's no corresponding entry in `.gitmodules`, breaking the Azure Static Web Apps deployment.

## Test plan
- [x] CI should pass after this merge