### PR TITLE
Add additional portal links to Invoke-HuduExtensionSync (part 1)

### DIFF
--- a/src/data/Extensions.json
+++ b/src/data/Extensions.json
@@ -615,6 +615,50 @@
         }
       },
       {
+        "type": "switch",
+        "name": "Hudu.HideEmptyRoles",
+        "label": "Hide Empty Roles in Magic Dash",
+        "condition": {
+          "field": "Hudu.Enabled",
+          "compareType": "is",
+          "compareValue": true,
+          "action": "disable"
+        }
+      },
+      {
+        "type": "switch",
+        "name": "Hudu.IncludeParterCenterLink",
+        "label": "Include link to Partner Center Service management page (partner.microsoft.com)",
+        "condition": {
+          "field": "Hudu.Enabled",
+          "compareType": "is",
+          "compareValue": true,
+          "action": "disable"
+        }
+      },
+      {
+        "type": "switch",
+        "name": "Hudu.IncludeDefenderLink",
+        "label": "Include link to Defender Portal (security.microsoft.com)",
+        "condition": {
+          "field": "Hudu.Enabled",
+          "compareType": "is",
+          "compareValue": true,
+          "action": "disable"
+        }
+      },
+      {
+        "type": "switch",
+        "name": "Hudu.IncludeComplianceLink",
+        "label": "Include link to Compliance Portal (compliance.microsoft.com)",
+        "condition": {
+          "field": "Hudu.Enabled",
+          "compareType": "is",
+          "compareValue": true,
+          "action": "disable"
+        }
+      },
+      {
         "_comment": "I have added this switch as a logic check for the Hudu integration script to check against when CIPP first connects to the Hudu Instance via Connect-HuduAPI.ps1",
         "type": "switch",
         "name": "Hudu.CFEnabled",


### PR DESCRIPTION
Added links to Defender, Compliance (purview) and the partner center page that is managed by Microsoft.