### PR TITLE
Feat: Include excluded licenses in selectors

### DIFF
--- a/src/components/CippComponents/CippFormLicenseSelector.jsx
+++ b/src/components/CippComponents/CippFormLicenseSelector.jsx
@@ -32,6 +32,7 @@ export const CippFormLicenseSelector = ({
         data: {
           Endpoint: 'subscribedSkus',
           $count: true,
+          IncludeExcluded: true,
         },
         showRefresh,
       }}

--- a/src/components/CippComponents/CippUserActions.jsx
+++ b/src/components/CippComponents/CippUserActions.jsx
@@ -133,6 +133,7 @@ const ManageLicensesForm = ({ formControl, tenant }) => {
             valueField: 'skuId',
             data: { IncludeExcluded: true },
             queryKey: `ListLicenses-${tenant}`,
+            showRefresh: true,
           }}
         />
       )}
@@ -152,6 +153,7 @@ const ManageLicensesForm = ({ formControl, tenant }) => {
             valueField: 'skuId',
             data: { IncludeExcluded: true },
             queryKey: `ListLicenses-${tenant}`,
+            showRefresh: true,
           }}
         />
       )}
@@ -174,6 +176,7 @@ const ManageLicensesForm = ({ formControl, tenant }) => {
             valueField: 'skuId',
             data: { IncludeExcluded: true },
             queryKey: `ListLicenses-Available-${tenant}`,
+            showRefresh: true,
           }}
         />
       )}

--- a/src/components/CippComponents/CippUserActions.jsx
+++ b/src/components/CippComponents/CippUserActions.jsx
@@ -131,6 +131,7 @@ const ManageLicensesForm = ({ formControl, tenant }) => {
             url: '/api/ListLicenses',
             labelField: (option) => option.displayName || option.skuPartNumber,
             valueField: 'skuId',
+            data: { IncludeExcluded: true },
             queryKey: `ListLicenses-${tenant}`,
           }}
         />
@@ -149,6 +150,7 @@ const ManageLicensesForm = ({ formControl, tenant }) => {
             url: '/api/ListLicenses',
             labelField: (option) => option.displayName || option.skuPartNumber,
             valueField: 'skuId',
+            data: { IncludeExcluded: true },
             queryKey: `ListLicenses-${tenant}`,
           }}
         />
@@ -170,6 +172,7 @@ const ManageLicensesForm = ({ formControl, tenant }) => {
                 option.availableUnits || 0
               } available)`,
             valueField: 'skuId',
+            data: { IncludeExcluded: true },
             queryKey: `ListLicenses-Available-${tenant}`,
           }}
         />

--- a/src/pages/cipp/settings/licenses.js
+++ b/src/pages/cipp/settings/licenses.js
@@ -4,7 +4,7 @@ import { Layout as DashboardLayout } from '../../../layouts/index.js'
 import { CippTablePage } from '../../../components/CippComponents/CippTablePage.jsx'
 import { Button, SvgIcon, Stack, Box } from '@mui/material'
 import { TrashIcon } from '@heroicons/react/24/outline'
-import { Add, RestartAlt, NotificationsOff } from '@mui/icons-material'
+import { Add, RestartAlt, NotificationsOff, Visibility, VisibilityOff } from '@mui/icons-material'
 import { CippApiDialog } from '../../../components/CippComponents/CippApiDialog'
 import { useDialog } from '../../../hooks/use-dialog'
 import CippFormComponent from '../../../components/CippComponents/CippFormComponent'
@@ -18,7 +18,7 @@ const Page = () => {
   const apiUrl = '/api/ListExcludedLicenses'
   const createDialog = useDialog()
   const resetDialog = useDialog()
-  const simpleColumns = ['Product_Display_Name', 'GUID', 'ExclusionType']
+  const simpleColumns = ['Product_Display_Name', 'GUID', 'ExclusionType', 'ShowInLicenseDropdown']
 
   const allLicenseOptions = useMemo(() => {
     const allLicenses = [...M365LicensesDefault, ...M365LicensesAdditional]
@@ -57,6 +57,34 @@ const Page = () => {
       confirmText:
         'This license will remain visible in CIPP but will be excluded from alerts. Continue?',
       icon: <NotificationsOff fontSize="small" />,
+    },
+    {
+      label: 'Show in License Dropdowns',
+      type: 'POST',
+      url: '/api/ExecExcludeLicenses',
+      data: {
+        Action: '!SetShowInDropdown',
+        GUID: 'GUID',
+        SKUName: 'Product_Display_Name',
+        ShowInDropdown: true,
+      },
+      confirmText: '[Product_Display_Name] will be available in license dropdowns. Continue?',
+      icon: <Visibility fontSize="small" />,
+      condition: (row) => row.ShowInLicenseDropdown !== true,
+    },
+    {
+      label: 'Hide from License Dropdowns',
+      type: 'POST',
+      url: '/api/ExecExcludeLicenses',
+      data: {
+        Action: '!SetShowInDropdown',
+        GUID: 'GUID',
+        SKUName: 'Product_Display_Name',
+        ShowInDropdown: false,
+      },
+      confirmText: '[Product_Display_Name] will be hidden from license dropdowns. Continue?',
+      icon: <VisibilityOff fontSize="small" />,
+      condition: (row) => row.ShowInLicenseDropdown === true,
     },
     {
       label: 'Delete Exclusion',
@@ -103,7 +131,7 @@ const Page = () => {
   }
 
   const offCanvas = {
-    extendedInfoFields: ['Product_Display_Name', 'GUID', 'ExclusionType'],
+    extendedInfoFields: ['Product_Display_Name', 'GUID', 'ExclusionType', 'ShowInLicenseDropdown'],
     actions: actions,
   }
 

--- a/src/pages/tenant/manage/user-defaults.js
+++ b/src/pages/tenant/manage/user-defaults.js
@@ -124,6 +124,7 @@ const Page = () => {
         labelField: (option) =>
           `${option.License || option.skuPartNumber} (${option.availableUnits || 0} available)`,
         valueField: 'skuId',
+        data: { IncludeExcluded: true },
         queryKey: `ListLicenses-${userSettings.currentTenant}`,
       },
       multiple: true,


### PR DESCRIPTION
Update license selectors to include excluded licenses so it's possible to assign the excluded free licenses again.

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/2078