### PR TITLE
Feat: Add column order management in tables

### DIFF
--- a/src/components/CippTable/CIPPTableToptoolbar.js
+++ b/src/components/CippTable/CIPPTableToptoolbar.js
@@ -287,10 +287,13 @@ export const CIPPTableToptoolbar = React.memo(
     // default-order frame is committed but never shown — eliminating the visible reflow on
     // load. Mirrors the columnVisibility effect above.
     useIsomorphicLayoutEffect(() => {
-      if (settings?.columnOrderDefaults?.[pageName]?.length > 0) {
+      // Skip in dialogs: a popout shares the parent's pageName, so applying the saved order
+      // here would push the parent table's column order onto the popout. See savedColumnOrder
+      // in CippDataTable.js.
+      if (!isInDialog && settings?.columnOrderDefaults?.[pageName]?.length > 0) {
         setColumnOrder(settings.columnOrderDefaults[pageName])
       }
-    }, [settings?.columnOrderDefaults?.[pageName], router, usedColumns])
+    }, [settings?.columnOrderDefaults?.[pageName], router, usedColumns, isInDialog])
 
     useEffect(() => {
       setOriginalSimpleColumns(simpleColumns)
@@ -913,15 +916,21 @@ export const CIPPTableToptoolbar = React.memo(
                     },
                   }}
                 >
-                  <MenuItem onClick={resetToPreferedVisibility}>
-                    <ListItemText primary="Reset to preferred columns" />
-                  </MenuItem>
-                  <MenuItem onClick={saveAsPreferedColumns}>
-                    <ListItemText primary="Save as preferred columns" />
-                  </MenuItem>
-                  <MenuItem onClick={resetToDefaultVisibility}>
-                    <ListItemText primary="Delete preferred columns" />
-                  </MenuItem>
+                  {!isInDialog && (
+                    <MenuItem onClick={resetToPreferedVisibility}>
+                      <ListItemText primary="Reset to preferred columns" />
+                    </MenuItem>
+                  )}
+                  {!isInDialog && (
+                    <MenuItem onClick={saveAsPreferedColumns}>
+                      <ListItemText primary="Save as preferred columns" />
+                    </MenuItem>
+                  )}
+                  {!isInDialog && (
+                    <MenuItem onClick={resetToDefaultVisibility}>
+                      <ListItemText primary="Delete preferred columns" />
+                    </MenuItem>
+                  )}
                   <Divider />
                   {table
                     .getAllColumns()
@@ -1104,15 +1113,21 @@ export const CIPPTableToptoolbar = React.memo(
                 },
               }}
             >
-              <MenuItem onClick={resetToPreferedVisibility}>
-                <ListItemText primary="Reset to preferred columns" />
-              </MenuItem>
-              <MenuItem onClick={saveAsPreferedColumns}>
-                <ListItemText primary="Save as preferred columns" />
-              </MenuItem>
-              <MenuItem onClick={resetToDefaultVisibility}>
-                <ListItemText primary="Delete preferred columns" />
-              </MenuItem>
+              {!isInDialog && (
+                <MenuItem onClick={resetToPreferedVisibility}>
+                  <ListItemText primary="Reset to preferred columns" />
+                </MenuItem>
+              )}
+              {!isInDialog && (
+                <MenuItem onClick={saveAsPreferedColumns}>
+                  <ListItemText primary="Save as preferred columns" />
+                </MenuItem>
+              )}
+              {!isInDialog && (
+                <MenuItem onClick={resetToDefaultVisibility}>
+                  <ListItemText primary="Delete preferred columns" />
+                </MenuItem>
+              )}
               <Divider />
               {table
                 .getAllColumns()

--- a/src/components/CippTable/CIPPTableToptoolbar.js
+++ b/src/components/CippTable/CIPPTableToptoolbar.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react'
+import React, { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react'
 import {
   Box,
   Button,
@@ -52,6 +52,11 @@ import { ApiGetCall } from '../../api/ApiCall'
 import GraphExplorerPresets from '../../data/GraphExplorerPresets.json'
 import CippGraphExplorerFilter from './CippGraphExplorerFilter'
 import { Stack } from '@mui/system'
+
+// Run a layout effect on the client (where it flushes before paint, preventing a flash of
+// the wrong column order) but fall back to useEffect during SSR to avoid React's
+// "useLayoutEffect does nothing on the server" warning.
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
 // Styled components for modern design
 const ModernSearchContainer = styled(Paper)(({ theme }) => ({
@@ -148,7 +153,9 @@ export const CIPPTableToptoolbar = React.memo(
     usedColumns,
     usedData,
     columnVisibility,
+    columnOrder,
     setColumnVisibility,
+    setColumnOrder,
     title,
     actions,
     filters = [],
@@ -270,6 +277,20 @@ export const CIPPTableToptoolbar = React.memo(
         setColumnVisibility(settings?.columnDefaults?.[pageName])
       }
     }, [settings?.columnDefaults?.[pageName], router, usedColumns])
+
+    // Re-apply the saved column order whenever the real columns arrive, BEFORE the browser
+    // paints. usedColumns is a REQUIRED dependency: MRT rebuilds the column order when the
+    // leaf-column count changes (its reconciliation effect compares columnOrder.length to
+    // table.options.columns.length), and that rebuild falls back to API/definition order
+    // unless our saved order is the winning write in the same commit. Using a layout effect
+    // (vs useEffect) flushes this reorder synchronously before paint, so the brief
+    // default-order frame is committed but never shown — eliminating the visible reflow on
+    // load. Mirrors the columnVisibility effect above.
+    useIsomorphicLayoutEffect(() => {
+      if (settings?.columnOrderDefaults?.[pageName]?.length > 0) {
+        setColumnOrder(settings.columnOrderDefaults[pageName])
+      }
+    }, [settings?.columnOrderDefaults?.[pageName], router, usedColumns])
 
     useEffect(() => {
       setOriginalSimpleColumns(simpleColumns)
@@ -480,10 +501,15 @@ export const CIPPTableToptoolbar = React.memo(
         }
         return updatedVisibility
       })
+      setColumnOrder([])
       settings.handleUpdate({
         columnDefaults: {
           ...settings?.columnDefaults,
           [pageName]: {},
+        },
+        columnOrderDefaults: {
+          ...settings?.columnOrderDefaults,
+          [pageName]: [],
         },
       })
       setColumnsAnchor(null)
@@ -506,6 +532,11 @@ export const CIPPTableToptoolbar = React.memo(
           return updatedVisibility
         })
       }
+      if (settings?.columnOrderDefaults?.[pageName]?.length > 0) {
+        setColumnOrder(settings.columnOrderDefaults[pageName])
+      } else {
+        setColumnOrder([])
+      }
       setColumnsAnchor(null)
     }
 
@@ -514,6 +545,10 @@ export const CIPPTableToptoolbar = React.memo(
         columnDefaults: {
           ...settings?.columnDefaults,
           [pageName]: columnVisibility,
+        },
+        columnOrderDefaults: {
+          ...settings?.columnOrderDefaults,
+          [pageName]: columnOrder,
         },
       })
       setColumnsAnchor(null)

--- a/src/components/CippTable/CippDataTable.js
+++ b/src/components/CippTable/CippDataTable.js
@@ -732,7 +732,9 @@ export const CippDataTable = (props) => {
   // (SettingsProvider hydrates from localStorage in an effect), so we derive the order during
   // render instead of applying it from an effect: the first render that has both columns and a
   // hydrated saved order already carries that order, eliminating the post-paint reorder flash.
-  const savedColumnOrder = settings?.columnOrderDefaults?.[pageName]
+  // Dialog/popout tables share the parent's route (same pageName); they must NOT inherit the
+  // page's saved column order, which is built for the parent's columns and breaks popout layout.
+  const savedColumnOrder = isInDialog ? undefined : settings?.columnOrderDefaults?.[pageName]
   const effectiveColumnOrder = useMemo(() => {
     // A user-driven order (drag, or the toolbar's restore/reset handlers) wins once present.
     if (columnOrder.length > 0) return columnOrder
@@ -915,7 +917,7 @@ export const CippDataTable = (props) => {
     enableRowVirtualization: true,
     enableColumnVirtualization: true,
     enableColumnResizing: true,
-    enableColumnOrdering: true,
+    enableColumnOrdering: !isInDialog,
     columnResizeMode: 'onChange',
     rowVirtualizerOptions: {
       overscan: 5,

--- a/src/components/CippTable/CippDataTable.js
+++ b/src/components/CippTable/CippDataTable.js
@@ -26,6 +26,7 @@ import { Box } from '@mui/system'
 import { useSettings } from '../../hooks/use-settings'
 import { isEqual } from 'lodash' // Import lodash for deep comparison
 import { useLicenseBackfill } from '../../hooks/use-license-backfill'
+import { useRouter } from 'next/router'
 
 // Resolve dot-delimited property paths against arbitrary data objects.
 const getNestedValue = (source, path) => {
@@ -380,6 +381,7 @@ export const CippDataTable = (props) => {
   const previousFiltersRef = useRef(null)
 
   const [columnVisibility, setColumnVisibility] = useState(initialColumnVisibility)
+  const [columnOrder, setColumnOrder] = useState([])
   const [configuredSimpleColumns, setConfiguredSimpleColumns] = useState(simpleColumns)
   const [usedData, setUsedData] = useState(data)
   const [usedColumns, setUsedColumns] = useState([])
@@ -396,6 +398,9 @@ export const CippDataTable = (props) => {
   const waitingBool = api?.url ? true : false
 
   const settings = useSettings()
+  const router = useRouter()
+  // Per-page key for saved column prefs — must match the toolbar's derivation exactly.
+  const pageName = router.pathname.split('/').slice(1).join('/')
 
   // Hook to trigger re-render when license backfill completes
   const { updateTrigger } = useLicenseBackfill()
@@ -489,6 +494,13 @@ export const CippDataTable = (props) => {
 
   // Derive columns from data — only when the data schema actually changes.
   useEffect(() => {
+    // Wait for persisted settings (incl. the saved column order) to hydrate from localStorage
+    // before building columns, so columns never paint before their saved order is known —
+    // otherwise cached data races ahead of hydration and the order flashes on load. Pairs with
+    // effectiveColumnOrder below, which applies the resolved order during render.
+    if (!settings?.isInitialized) {
+      return
+    }
     if (
       !Array.isArray(usedData) ||
       usedData.length === 0 ||
@@ -577,7 +589,14 @@ export const CippDataTable = (props) => {
     }
     setUsedColumns(finalColumns)
     setColumnVisibility(newVisibility)
-  }, [columns.length, usedData, queryKey, settings?.currentTenant, filterTypeMap])
+  }, [
+    columns.length,
+    usedData,
+    queryKey,
+    settings?.currentTenant,
+    settings?.isInitialized,
+    filterTypeMap,
+  ])
 
   const createDialog = useDialog()
   const hasActions = !!actions
@@ -709,15 +728,34 @@ export const CippDataTable = (props) => {
       ? getRequestData.isFetching
       : isFetching
 
+  // Resolve which column order to control. The saved per-page order isn't known at mount
+  // (SettingsProvider hydrates from localStorage in an effect), so we derive the order during
+  // render instead of applying it from an effect: the first render that has both columns and a
+  // hydrated saved order already carries that order, eliminating the post-paint reorder flash.
+  const savedColumnOrder = settings?.columnOrderDefaults?.[pageName]
+  const effectiveColumnOrder = useMemo(() => {
+    // A user-driven order (drag, or the toolbar's restore/reset handlers) wins once present.
+    if (columnOrder.length > 0) return columnOrder
+    // Otherwise fall back to the saved per-page order when one exists.
+    return savedColumnOrder?.length > 0 ? savedColumnOrder : []
+  }, [columnOrder, savedColumnOrder])
+
   // Memoize state object to avoid creating a new reference every render when values haven't changed.
   const tableState = useMemo(
     () => ({
       columnVisibility: sanitizedColumnVisibility,
+      // Control columnOrder with the resolved order (user-driven, else the saved per-page order).
+      // Omit the key entirely when empty so MRT keeps its internal order, seeded from
+      // initialState.columnOrder ([...simpleColumns] via util-tablemode); its
+      // useMRT_Effects then rebuilds a full order that preserves the simpleColumns
+      // sequence. Do NOT pass `[]` (MRT rebuilds from scratch in raw API order) or
+      // `undefined` (crashes the MRT effect that reads columnOrder.length).
+      ...(effectiveColumnOrder.length > 0 ? { columnOrder: effectiveColumnOrder } : {}),
       sorting,
       columnFilters,
       showSkeletons,
     }),
-    [sanitizedColumnVisibility, sorting, columnFilters, showSkeletons]
+    [sanitizedColumnVisibility, effectiveColumnOrder, sorting, columnFilters, showSkeletons]
   )
 
   // Memoize renderRowActionMenuItems to avoid re-creating on each render.
@@ -827,6 +865,7 @@ export const CippDataTable = (props) => {
               simpleColumns={simpleColumns}
               data={data}
               columnVisibility={columnVisibility}
+              columnOrder={columnOrder}
               getRequestData={getRequestData}
               usedColumns={usedColumns}
               usedData={memoizedData ?? []}
@@ -835,6 +874,7 @@ export const CippDataTable = (props) => {
               exportEnabled={exportEnabled}
               refreshFunction={refreshFunction}
               setColumnVisibility={setColumnVisibility}
+              setColumnOrder={setColumnOrder}
               filters={filters}
               queryKeys={queryKey ? queryKey : title}
               graphFilterData={graphFilterData}
@@ -855,6 +895,7 @@ export const CippDataTable = (props) => {
       simpleColumns,
       data,
       columnVisibility,
+      columnOrder,
       getRequestData,
       usedColumns,
       memoizedData,
@@ -874,6 +915,7 @@ export const CippDataTable = (props) => {
     enableRowVirtualization: true,
     enableColumnVirtualization: true,
     enableColumnResizing: true,
+    enableColumnOrdering: true,
     columnResizeMode: 'onChange',
     rowVirtualizerOptions: {
       overscan: 5,
@@ -895,6 +937,7 @@ export const CippDataTable = (props) => {
     onColumnFiltersChange: setColumnFilters,
     renderEmptyRowsFallback,
     onColumnVisibilityChange: setColumnVisibility,
+    onColumnOrderChange: setColumnOrder,
     ...modeInfo,
     renderRowActionMenuItems,
     renderTopToolbar,

--- a/src/components/CippTable/util-tablemode.js
+++ b/src/components/CippTable/util-tablemode.js
@@ -66,12 +66,21 @@ export const utilTableMode = (
         },
       },
       initialState: {
-        // Include the leading/trailing display columns (selection checkbox + row actions)
-        // around the data columns. MRT's column-drag handler re-derives columnPinning by
-        // filtering it against columnOrder, dropping any pinned id not present — so an
-        // order missing these (e.g. the post-reset fallback) would unpin the checkbox
-        // column and let it drift right. The ids are harmless when those columns are off.
-        columnOrder: ['mrt-row-select', ...simpleColumns, 'mrt-row-actions'],
+        // Seed the order with the leading/trailing display columns (selection checkbox + row
+        // actions) ONLY when they actually exist (same conditions as enableRowSelection /
+        // enableRowActions below). They keep MRT's column-drag handler from dropping the
+        // checkbox column's pin (it re-derives columnPinning by filtering against columnOrder).
+        // But seeding ids for columns that DON'T exist poisons the order: MRT only rebuilds
+        // columnOrder when its length differs from the data-column count, so a 2-id seed
+        // (['mrt-row-select','mrt-row-actions']) against a 2-column table — e.g. a read-only
+        // dialog popout with no selection/actions — compares equal, never rebuilds, and renders
+        // two phantom ids with the real columns unplaced (the "breaks with exactly 2 properties"
+        // popout bug).
+        columnOrder: [
+          ...(actions || onChange ? ['mrt-row-select'] : []),
+          ...simpleColumns,
+          ...(actions ? ['mrt-row-actions'] : []),
+        ],
         columnVisibility: { ...columnVisibility },
         showGlobalFilter: true,
         density: 'compact',

--- a/src/components/CippTable/util-tablemode.js
+++ b/src/components/CippTable/util-tablemode.js
@@ -66,7 +66,12 @@ export const utilTableMode = (
         },
       },
       initialState: {
-        columnOrder: [...simpleColumns],
+        // Include the leading/trailing display columns (selection checkbox + row actions)
+        // around the data columns. MRT's column-drag handler re-derives columnPinning by
+        // filtering it against columnOrder, dropping any pinned id not present — so an
+        // order missing these (e.g. the post-reset fallback) would unpin the checkbox
+        // column and let it drift right. The ids are harmless when those columns are off.
+        columnOrder: ['mrt-row-select', ...simpleColumns, 'mrt-row-actions'],
         columnVisibility: { ...columnVisibility },
         showGlobalFilter: true,
         density: 'compact',


### PR DESCRIPTION
Implement column order management to enhance user experience by allowing users to customize the order of columns in tables. This change includes handling saved column orders and ensuring the correct order is applied during rendering to prevent visual reflows.
Also fixes saved columns not being honeored bug 