### PR TITLE
Refactor: Change default visibility to private when creating teams

### DIFF
--- a/src/pages/teams-share/teams/list-team/add.jsx
+++ b/src/pages/teams-share/teams/list-team/add.jsx
@@ -17,7 +17,7 @@ const TeamsAddTeamForm = () => {
       displayName: "",
       description: "",
       owner: null,
-      visibility: "public",
+      visibility: "private",
     },
   });
 


### PR DESCRIPTION
This update changes the default visibility setting for new teams from public to private.

Fixes #6168