### PR TITLE
feat(BEC): add sent messages check and update checks numbering

### DIFF
--- a/src/pages/identity/administration/users/user/bec.jsx
+++ b/src/pages/identity/administration/users/user/bec.jsx
@@ -147,6 +147,14 @@ const Page = () => {
     return "No mailbox permission changes found.";
   };
 
+  const getSentMessagesMessage = () => {
+    if (!becPollingCall.data) return null;
+    if (becPollingCall.data.SentMessages && becPollingCall.data.SentMessages.length > 0) {
+      return "Sent messages have been found. Please review the list below for any suspicious activity.";
+    }
+    return "No sent messages found in the specified time range.";
+  };
+
   const subtitle = userRequest.isSuccess
     ? [
         {
@@ -459,12 +467,56 @@ const Page = () => {
                     )}
                 </CippButtonCard>
 
+                {/* Check 5: Sent Messages */}
                 <CippButtonCard
                   variant="outlined"
                   isFetching={false}
                   title={
                     <Stack direction="row" justifyContent={"space-between"}>
-                      <Box>Check 5: MFA Devices</Box>
+                      <Box>Check 5: Sent Messages</Box>
+                      <Stack direction="row" spacing={2}>
+                        {becPollingCall.data &&
+                        becPollingCall.data.SentMessages &&
+                        becPollingCall.data.SentMessages.length > 0 ? (
+                          <SvgIcon color="success">
+                            <CheckCircle />
+                          </SvgIcon>
+                        ) : (
+                          <SvgIcon color="disabled">
+                            <CheckCircle />
+                          </SvgIcon>
+                        )}
+                      </Stack>
+                    </Stack>
+                  }
+                >
+                  <Typography variant="body2" gutterBottom>
+                    {getSentMessagesMessage()}
+                  </Typography>
+                  {/* Display sent messages */}
+                  {becPollingCall.data &&
+                    becPollingCall.data.SentMessages &&
+                    becPollingCall.data.SentMessages.length > 0 && (
+                      <Box mt={2}>
+                        <PropertyList>
+                          {becPollingCall.data.SentMessages.map((message, index) => (
+                            <PropertyListItem
+                              key={index}
+                              label={`${message?.Subject} to ${message?.RecipientAddress}`}
+                              value={`Status: ${message?.Status} | Sent: ${message?.Received} | From IP: ${message?.FromIP}`}
+                            />
+                          ))}
+                        </PropertyList>
+                      </Box>
+                    )}
+                </CippButtonCard>
+
+                <CippButtonCard
+                  variant="outlined"
+                  isFetching={false}
+                  title={
+                    <Stack direction="row" justifyContent={"space-between"}>
+                      <Box>Check 6: MFA Devices</Box>
                       <Stack direction="row" spacing={2}>
                         {becPollingCall.data &&
                         becPollingCall.data.MFADevices &&
@@ -508,7 +560,7 @@ const Page = () => {
                   isFetching={false}
                   title={
                     <Stack direction="row" justifyContent={"space-between"}>
-                      <Box>Check 6: Password Changes</Box>
+                      <Box>Check 7: Password Changes</Box>
                       <Stack direction="row" spacing={2}>
                         {becPollingCall.data &&
                         becPollingCall.data.ChangedPasswords &&
@@ -546,7 +598,7 @@ const Page = () => {
                     )}
                 </CippButtonCard>
 
-                {/* Check 6: Report Data */}
+                {/* Check 8: Report Data */}
                 <CippButtonCard
                   variant="outlined"
                   isFetching={false}


### PR DESCRIPTION
This pull request adds a new "Sent Messages" check to the user BEC (Business Email Compromise) investigation page and updates the numbering of subsequent checks to accommodate this addition. The new check displays a summary and details of any sent messages found for the user, helping reviewers quickly identify suspicious activity.

**New Sent Messages Check:**

* Introduced a new function `getSentMessagesMessage` to generate a summary message about sent messages associated with the user.
* Added a new "Check 5: Sent Messages" section using `CippButtonCard`, which displays a status icon, a summary message, and a list of sent messages (including subject, recipient, status, sent time, and originating IP) if any are found.

**UI and Numbering Updates:**

* Updated the titles and order of subsequent checks: "MFA Devices" is now "Check 6", "Password Changes" is now "Check 7", and "Report Data" is now "Check 8" to reflect the insertion of the new check. [[1]](diffhunk://#diff-5061f9a1228ce1f4cf71056065f1a3e843e751c65ac5c6d90c6e101138ce169dR470-R519) [[2]](diffhunk://#diff-5061f9a1228ce1f4cf71056065f1a3e843e751c65ac5c6d90c6e101138ce169dL511-R563) [[3]](diffhunk://#diff-5061f9a1228ce1f4cf71056065f1a3e843e751c65ac5c6d90c6e101138ce169dL549-R601)

UI Implementation of https://github.com/KelvinTegelaar/CIPP-API/pull/2098

<img width="897" height="272" alt="image" src="https://github.com/user-attachments/assets/1e6901fd-b945-4212-b4ee-345970503a1a" />