### PR TITLE
feat/fix: Add MTD role toggle and enhance iOS sync controls

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -7257,6 +7257,12 @@
       },
       {
         "type": "switch",
+        "name": "standards.DefenderCompliancePolicy.grantMobileThreatDefensePartnerRole",
+        "label": "Grant MTD role to MDE on enrolled Android COBO/COPE devices",
+        "defaultValue": false
+      },
+      {
+        "type": "switch",
         "name": "standards.DefenderCompliancePolicy.ConnectIos",
         "label": "Connect iOS/iPadOS devices to MDE",
         "defaultValue": false
@@ -7264,13 +7270,19 @@
       {
         "type": "switch",
         "name": "standards.DefenderCompliancePolicy.ConnectIosCompliance",
-        "label": "Connect iOS 13.0+ (App-based MAM)",
+        "label": "Connect iOS/iPadOS devices for app protection policy evaluation (MAM)",
         "defaultValue": false
       },
       {
         "type": "switch",
         "name": "standards.DefenderCompliancePolicy.appSync",
-        "label": "Enable App Sync for iOS",
+        "label": "Enable App Sync (sending application inventory) for iOS/iPadOS devices",
+        "defaultValue": false
+      },
+      {
+        "type": "switch",
+        "name": "standards.DefenderCompliancePolicy.allowPartnerToCollectIosPersonalApplicationMetadata",
+        "label": "Send full application inventory data on personally-owned iOS/iPadOS devices",
         "defaultValue": false
       },
       {
@@ -7282,13 +7294,13 @@
       {
         "type": "switch",
         "name": "standards.DefenderCompliancePolicy.allowPartnerToCollectIosCertificateMetadata",
-        "label": "Collect certificate metadata from iOS",
+        "label": "Enable Certificate Sync for iOS/iPadOS devices",
         "defaultValue": false
       },
       {
         "type": "switch",
         "name": "standards.DefenderCompliancePolicy.allowPartnerToCollectIosPersonalCertificateMetadata",
-        "label": "Collect personal certificate metadata from iOS",
+        "label": "Send full certificate inventory data on personally-owned iOS/iPadOS devices",
         "defaultValue": false
       },
       {

--- a/src/pages/security/defender/deployment/index.js
+++ b/src/pages/security/defender/deployment/index.js
@@ -138,6 +138,12 @@ const DeployDefenderForm = () => {
                             formControl={formControl}
                           />
                         </CippFormCondition>
+                        <CippFormComponent
+                          type="switch"
+                          label="Grant MTD role permissions to Microsoft Defender for Endpoint on enrolled Android COBO and COPE devices"
+                          name="Compliance.grantMobileThreatDefensePartnerRole"
+                          formControl={formControl}
+                        />
                       </CippFormCondition>
                     </CardContent>
                   </Card>
@@ -249,7 +255,7 @@ const DeployDefenderForm = () => {
                         >
                           <CippFormComponent
                             type="switch"
-                            label="Connect iOS/iPadOS devices version 13.0 and above to Microsoft Defender for Endpoint (Compliance)"
+                            label="Connect iOS/iPadOS devices for app protection policy evaluation (MAM)"
                             name="Compliance.ConnectIosCompliance"
                             formControl={formControl}
                           />
@@ -259,6 +265,20 @@ const DeployDefenderForm = () => {
                             name="Compliance.AppSync"
                             formControl={formControl}
                           />
+                          <CippFormCondition
+                            formControl={formControl}
+                            field="Compliance.AppSync"
+                            compareType="is"
+                            compareValue={true}
+                            action="disable"
+                          >
+                            <CippFormComponent
+                              type="switch"
+                              label="Send full application inventory data on personally-owned iOS/iPadOS devices"
+                              name="Compliance.allowPartnerToCollectIosPersonalApplicationMetadata"
+                              formControl={formControl}
+                            />
+                          </CippFormCondition>
                           <CippFormComponent
                             type="switch"
                             label="Block iOS device access when Microsoft Defender for Endpoint is unavailable"
@@ -267,16 +287,24 @@ const DeployDefenderForm = () => {
                           />
                           <CippFormComponent
                             type="switch"
-                            label="Allow partner to collect iOS certificate metadata"
+                            label="Enable Certificate Sync for iOS/iPadOS devices"
                             name="Compliance.allowPartnerToCollectIosCertificateMetadata"
                             formControl={formControl}
                           />
-                          <CippFormComponent
-                            type="switch"
-                            label="Allow partner to collect iOS personal certificate metadata"
-                            name="Compliance.allowPartnerToCollectIosPersonalCertificateMetadata"
+                          <CippFormCondition
                             formControl={formControl}
-                          />
+                            field="Compliance.allowPartnerToCollectIosCertificateMetadata"
+                            compareType="is"
+                            compareValue={true}
+                            action="disable"
+                          >
+                            <CippFormComponent
+                              type="switch"
+                              label="Send full certificate inventory data on personally-owned iOS/iPadOS devices"
+                              name="Compliance.allowPartnerToCollectIosPersonalCertificateMetadata"
+                              formControl={formControl}
+                            />
+                          </CippFormCondition>
                         </CippFormCondition>
                       </CippFormCondition>
                     </CardContent>


### PR DESCRIPTION
Introduce a toggle for granting MTD role permissions in the Defender deployment wizard for Android. Align iOS App Sync and Certificate Sync controls with Intune, adding missing toggles and updating labels.

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/2108