### PR TITLE
Fix Sign-in report export showing "No data" for Location (and other object columns)

### DIFF
--- a/src/components/CippTable/util-columnsFromAPI.js
+++ b/src/components/CippTable/util-columnsFromAPI.js
@@ -2,8 +2,7 @@ import { getCippFilterVariant } from '../../utils/get-cipp-filter-variant'
 import { getCippFormatting } from '../../utils/get-cipp-formatting'
 import { getCippTranslation } from '../../utils/get-cipp-translation'
 import { getCippColumnSize } from '../../utils/get-cipp-column-size'
-
-const skipRecursion = ['location', 'ScheduledBackupValues', 'Tenant']
+import { SKIP_RECURSION_KEYS as skipRecursion } from '../../utils/skip-recursion-keys'
 
 // Number of rows to sample when measuring column content width.
 const MAX_SIZE_SAMPLE = 30

--- a/src/components/csvExportButton.js
+++ b/src/components/csvExportButton.js
@@ -2,6 +2,7 @@ import { BackupTableTwoTone } from '@mui/icons-material'
 import { IconButton, Tooltip } from '@mui/material'
 import { mkConfig, generateCsv, download } from 'export-to-csv'
 import { getCippFormatting } from '../utils/get-cipp-formatting'
+import { SKIP_RECURSION_KEYS } from '../utils/skip-recursion-keys'
 const csvConfig = mkConfig({
   fieldSeparator: ',',
   decimalSeparator: '.',
@@ -13,7 +14,12 @@ const flattenObject = (obj, parentKey = '') => {
   const flattened = {}
   Object.keys(obj).forEach((key) => {
     const fullKey = parentKey ? `${parentKey}.${key}` : key
-    if (typeof obj[key] === 'object' && obj[key] !== null && !Array.isArray(obj[key])) {
+    if (
+      typeof obj[key] === 'object' &&
+      obj[key] !== null &&
+      !Array.isArray(obj[key]) &&
+      !SKIP_RECURSION_KEYS.includes(key)
+    ) {
       Object.assign(flattened, flattenObject(obj[key], fullKey))
     } else if (Array.isArray(obj[key]) && typeof obj[key][0] === 'string') {
       flattened[fullKey] = obj[key]

--- a/src/components/pdfExportButton.js
+++ b/src/components/pdfExportButton.js
@@ -1,6 +1,7 @@
 import { IconButton, Tooltip } from '@mui/material'
 import { PictureAsPdf } from '@mui/icons-material'
 import { getCippFormatting } from '../utils/get-cipp-formatting'
+import { SKIP_RECURSION_KEYS } from '../utils/skip-recursion-keys'
 import { useSettings } from '../hooks/use-settings'
 
 // Flatten nested objects so deeply nested properties export properly.
@@ -9,7 +10,12 @@ const flattenObject = (obj, parentKey = '') => {
   const flattened = {}
   Object.keys(obj).forEach((key) => {
     const fullKey = parentKey ? `${parentKey}.${key}` : key
-    if (typeof obj[key] === 'object' && obj[key] !== null && !Array.isArray(obj[key])) {
+    if (
+      typeof obj[key] === 'object' &&
+      obj[key] !== null &&
+      !Array.isArray(obj[key]) &&
+      !SKIP_RECURSION_KEYS.includes(key)
+    ) {
       Object.assign(flattened, flattenObject(obj[key], fullKey))
     } else {
       // Store the raw value - formatting will happen in a single pass later

--- a/src/utils/skip-recursion-keys.js
+++ b/src/utils/skip-recursion-keys.js
@@ -1,0 +1,9 @@
+// Keys whose nested objects are intentionally NOT recursed into.
+//
+// The data table renders these as a single column (via getCippFormatting) rather
+// than splitting them into dotted sub-columns. The CSV and PDF exporters must use
+// the same list when flattening rows, otherwise a value like `location` is
+// flattened to `location.city` / `location.countryOrRegion` while the column id
+// stays `location`, so the export looks up `location`, finds nothing, and writes
+// "No data" for every row (GitHub issue #6237).
+export const SKIP_RECURSION_KEYS = ['location', 'ScheduledBackupValues', 'Tenant']


### PR DESCRIPTION
## What

The Sign-in Report (and any report containing an object column such as `location`) exports "No data" in CSV and PDF for columns that display correctly in the UI. Reported in #6237 for the Location column.

## Cause

`util-columnsFromAPI` keeps a `skipRecursion` list (`location`, `ScheduledBackupValues`, `Tenant`) so those objects render as a single column via `getCippFormatting` rather than being split into dotted sub-columns. The CSV and PDF exporters (`csvExportButton.js` / `pdfExportButton.js`) have their own `flattenObject` helpers that didn't know about that list, so they recursed into `location.city` / `location.countryOrRegion` while the column id stayed `location`. The exporter then looked up `location`, found no matching key, and wrote "No data" for every row.

## Fix

Moved the skip-recursion key list into a shared `src/utils/skip-recursion-keys.js` and had the column builder and both exporters import it. The exporters now keep the `location` object intact and format it through `getCippFormatting`, exactly as the table does, so the export matches the UI. This fixes it for every report with a `location`-type column, not just sign-ins.

## Testing

- Verified against a real Sign-in Report export (500 rows): the Location column went from "No data" to e.g. "Tower Hamlets, GB" in both CSV and PDF.
- `eslint` and `next build` both pass; no other columns or exports changed.

Fixes #6237
