### PR TITLE
Feat: Enhance Intune group assignment functionality with excludes

### DIFF
--- a/src/components/CippComponents/CippApiDialog.jsx
+++ b/src/components/CippComponents/CippApiDialog.jsx
@@ -15,6 +15,7 @@ import { useRouter } from "next/router";
 import { useForm, useFormState } from "react-hook-form";
 import { useSettings } from "../../hooks/use-settings";
 import CippFormComponent from "./CippFormComponent";
+import { CippFormCondition } from "./CippFormCondition";
 
 export const CippApiDialog = (props) => {
   const {
@@ -382,17 +383,29 @@ export const CippApiDialog = (props) => {
                   )
                 ) : (
                   <>
-                    {fields?.map((fieldProps, i) => (
-                      <Box key={i} sx={{ width: "100%" }}>
+                    {fields?.map((fieldProps, i) => {
+                      const { condition, ...rest } = fieldProps;
+                      const fieldElement = (
                         <CippFormComponent
                           formControl={formHook}
                           addedFieldData={addedFieldData}
                           setAddedFieldData={setAddedFieldData}
                           row={row}
-                          {...fieldProps}
+                          {...rest}
                         />
-                      </Box>
-                    ))}
+                      );
+                      return (
+                        <Box key={i} sx={{ width: "100%" }}>
+                          {condition ? (
+                            <CippFormCondition {...condition} formControl={formHook}>
+                              {fieldElement}
+                            </CippFormCondition>
+                          ) : (
+                            fieldElement
+                          )}
+                        </Box>
+                      );
+                    })}
                   </>
                 )}
               </Stack>

--- a/src/components/CippComponents/CippIntunePolicyActions.jsx
+++ b/src/components/CippComponents/CippIntunePolicyActions.jsx
@@ -18,6 +18,11 @@ const assignmentFilterTypeOptions = [
   { label: 'Exclude - Apply policy to devices NOT matching filter', value: 'exclude' },
 ]
 
+const assignmentDirectionOptions = [
+  { label: 'Include these group(s)', value: 'include' },
+  { label: 'Exclude these group(s)', value: 'exclude' },
+]
+
 /**
  * Get assignment actions for Intune policies
  * @param {string} tenant - The tenant filter
@@ -43,15 +48,56 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
     templateData = null,
   } = options
 
-  const getAssignmentFields = () => [
+  // Group picker (by ID) reused for both include and exclude selection
+  const getGroupPickerField = (name, label, required) => ({
+    type: 'autoComplete',
+    name,
+    label,
+    multiple: true,
+    creatable: false,
+    allowResubmit: true,
+    ...(required && { validators: { required: 'Please select at least one group' } }),
+    api: {
+      url: '/api/ListGraphRequest',
+      dataKey: 'Results',
+      queryKey: `ListPolicyAssignmentGroups-${tenant}`,
+      labelField: (group) => (group.id ? `${group.displayName} (${group.id})` : group.displayName),
+      valueField: 'id',
+      addedField: {
+        description: 'description',
+      },
+      data: {
+        Endpoint: 'groups',
+        manualPagination: true,
+        $select: 'id,displayName,description',
+        $orderby: 'displayName',
+        $top: 999,
+        $count: true,
+      },
+    },
+  })
+
+  // Assignment mode + optional device filter, shared by every assign action.
+  const getOptionsAndFilterFields = (modeHelperText) => [
+    {
+      type: 'heading',
+      label: 'Assignment options',
+    },
     {
       type: 'radio',
       name: 'assignmentMode',
       label: 'Assignment mode',
       options: assignmentModeOptions,
       defaultValue: 'replace',
+      // Re-validate the Custom Group picker (no-op for broad actions, which have no groupTargets).
+      validators: { deps: ['groupTargets'] },
       helperText:
+        modeHelperText ||
         'Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups.',
+    },
+    {
+      type: 'heading',
+      label: 'Device filter (optional)',
     },
     {
       type: 'autoComplete',
@@ -73,12 +119,56 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
       options: assignmentFilterTypeOptions,
       defaultValue: 'include',
       helperText: 'Choose whether to include or exclude devices matching the filter.',
+      condition: { field: 'assignmentFilter', compareType: 'hasValue', clearOnHide: false },
+    },
+  ]
+
+  // All Users / All Devices / Globally: fixed target, with an optional exclude-groups picker.
+  const getBroadAssignFields = () => [
+    {
+      type: 'heading',
+      label: 'Exclude groups (optional)',
+    },
+    getGroupPickerField('excludeGroupTargets', 'Exclude group(s)', false),
+    ...getOptionsAndFilterFields(),
+  ]
+
+  // Custom Group: one picker + a radio choosing whether those groups are included or excluded.
+  const getCustomGroupFields = () => [
+    {
+      type: 'heading',
+      label: 'Target groups',
     },
     {
-      type: 'textField',
-      name: 'excludeGroup',
-      label: 'Exclude Group Names separated by comma. Wildcards (*) are allowed',
+      ...getGroupPickerField('groupTargets', 'Group(s)', false),
+      helperText: 'Leave empty with Exclude + Replace to remove all exclusions (keeps includes).',
+      validators: {
+        // Required, except Exclude + Replace where an empty selection clears all exclusions.
+        validate: (value, formValues) => {
+          if (
+            formValues?.assignmentDirection === 'exclude' &&
+            (formValues?.assignmentMode || 'replace') === 'replace'
+          ) {
+            return true
+          }
+          return (Array.isArray(value) && value.length > 0) || 'Please select at least one group'
+        },
+      },
     },
+    {
+      type: 'radio',
+      name: 'assignmentDirection',
+      label: 'Assignment direction',
+      options: assignmentDirectionOptions,
+      defaultValue: 'include',
+      // Re-validate the picker so the empty-allowed rule updates when direction changes.
+      validators: { deps: ['groupTargets'] },
+      helperText:
+        'Include assigns to these groups; Exclude excludes them. Replace updates only this direction and keeps the other (and All Users/All Devices) intact.',
+    },
+    ...getOptionsAndFilterFields(
+      'Replace updates only the selected direction and keeps the other direction plus All Users/All Devices. Append adds the selected groups to existing assignments.'
+    ),
   ]
 
   const getCustomDataFormatter = (assignTo) => (row, action, formData) => {
@@ -90,7 +180,8 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
       ...(platformType && { platformType }),
       AssignTo: assignTo,
       assignmentMode: formData?.assignmentMode || 'replace',
-      excludeGroup: formData?.excludeGroup || null,
+      ExcludeGroupIds: (formData?.excludeGroupTargets || []).map((g) => g.value).filter(Boolean),
+      ExcludeGroupNames: (formData?.excludeGroupTargets || []).map((g) => g.label).filter(Boolean),
       AssignmentFilterName: formData?.assignmentFilter?.value || null,
       AssignmentFilterType: formData?.assignmentFilter?.value
         ? formData?.assignmentFilterType || 'include'
@@ -101,15 +192,20 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
   const getCustomDataFormatterForGroups = () => (row, action, formData) => {
     const rows = Array.isArray(row) ? row : [row]
     const selectedGroups = Array.isArray(formData?.groupTargets) ? formData.groupTargets : []
+    const isExclude = formData?.assignmentDirection === 'exclude'
+    const ids = selectedGroups.map((group) => group.value).filter(Boolean)
+    const names = selectedGroups.map((group) => group.label).filter(Boolean)
     return rows.map((item) => ({
       tenantFilter: tenant === 'AllTenants' && item?.Tenant ? item.Tenant : tenant,
       ID: item?.id,
       type: item?.URLName || policyType,
       ...(platformType && { platformType }),
-      GroupIds: selectedGroups.map((group) => group.value).filter(Boolean),
-      GroupNames: selectedGroups.map((group) => group.label).filter(Boolean),
+      GroupIds: isExclude ? [] : ids,
+      GroupNames: isExclude ? [] : names,
+      ExcludeGroupIds: isExclude ? ids : [],
+      ExcludeGroupNames: isExclude ? names : [],
+      assignmentDirection: formData?.assignmentDirection || 'include',
       assignmentMode: formData?.assignmentMode || 'replace',
-      excludeGroup: formData?.excludeGroup || null,
       AssignmentFilterName: formData?.assignmentFilter?.value || null,
       AssignmentFilterType: formData?.assignmentFilter?.value
         ? formData?.assignmentFilterType || 'include'
@@ -210,6 +306,7 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
     label: 'Assign to All Users',
     type: 'POST',
     url: '/api/ExecAssignPolicy',
+    allowResubmit: true,
     data: {
       AssignTo: 'allLicensedUsers',
       ID: 'id',
@@ -217,7 +314,7 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
       ...(platformType && { platformType: '!deviceAppManagement' }),
     },
     multiPost: false,
-    fields: getAssignmentFields(),
+    fields: getBroadAssignFields(),
     customDataformatter: getCustomDataFormatter('allLicensedUsers'),
     confirmText: 'Are you sure you want to assign "[displayName]" to all users?',
     icon: <UserIcon />,
@@ -229,6 +326,7 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
     label: 'Assign to All Devices',
     type: 'POST',
     url: '/api/ExecAssignPolicy',
+    allowResubmit: true,
     data: {
       AssignTo: 'AllDevices',
       ID: 'id',
@@ -236,7 +334,7 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
       ...(platformType && { platformType: '!deviceAppManagement' }),
     },
     multiPost: false,
-    fields: getAssignmentFields(),
+    fields: getBroadAssignFields(),
     customDataformatter: getCustomDataFormatter('AllDevices'),
     confirmText: 'Are you sure you want to assign "[displayName]" to all devices?',
     icon: <LaptopChromebook />,
@@ -248,6 +346,7 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
     label: 'Assign Globally (All Users / All Devices)',
     type: 'POST',
     url: '/api/ExecAssignPolicy',
+    allowResubmit: true,
     data: {
       AssignTo: 'AllDevicesAndUsers',
       ID: 'id',
@@ -255,7 +354,7 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
       ...(platformType && { platformType: '!deviceAppManagement' }),
     },
     multiPost: false,
-    fields: getAssignmentFields(),
+    fields: getBroadAssignFields(),
     customDataformatter: getCustomDataFormatter('AllDevicesAndUsers'),
     confirmText: 'Are you sure you want to assign "[displayName]" to all users and devices?',
     icon: <GlobeAltIcon />,
@@ -267,41 +366,12 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
     label: 'Assign to Custom Group',
     type: 'POST',
     url: '/api/ExecAssignPolicy',
+    allowResubmit: true,
     icon: <UserGroupIcon />,
     color: 'info',
     confirmText: 'Select the target groups for "[displayName]".',
     multiPost: false,
-    fields: [
-      {
-        type: 'autoComplete',
-        name: 'groupTargets',
-        label: 'Group(s)',
-        multiple: true,
-        creatable: false,
-        allowResubmit: true,
-        validators: { required: 'Please select at least one group' },
-        api: {
-          url: '/api/ListGraphRequest',
-          dataKey: 'Results',
-          queryKey: `ListPolicyAssignmentGroups-${tenant}`,
-          labelField: (group) =>
-            group.id ? `${group.displayName} (${group.id})` : group.displayName,
-          valueField: 'id',
-          addedField: {
-            description: 'description',
-          },
-          data: {
-            Endpoint: 'groups',
-            manualPagination: true,
-            $select: 'id,displayName,description',
-            $orderby: 'displayName',
-            $top: 999,
-            $count: true,
-          },
-        },
-      },
-      ...getAssignmentFields(),
-    ],
+    fields: getCustomGroupFields(),
     customDataformatter: getCustomDataFormatterForGroups(),
   })
 

--- a/src/pages/endpoint/MEM/list-scripts/index.jsx
+++ b/src/pages/endpoint/MEM/list-scripts/index.jsx
@@ -1,13 +1,13 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage";
+import { Layout as DashboardLayout } from '../../../../layouts/index'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage'
 import {
   TrashIcon,
   PencilIcon,
   UserIcon,
   UserGroupIcon,
   GlobeAltIcon,
-} from "@heroicons/react/24/outline";
-import { showToast } from "../../../../store/toasts";
+} from '@heroicons/react/24/outline'
+import { showToast } from '../../../../store/toasts'
 import {
   Button,
   Dialog,
@@ -16,49 +16,49 @@ import {
   IconButton,
   CircularProgress,
   DialogActions,
-} from "@mui/material";
-import { CippCodeBlock } from "../../../../components/CippComponents/CippCodeBlock";
-import { useState, useEffect, useMemo } from "react";
-import { useDispatch } from "react-redux";
-import { Close, Save, LaptopChromebook } from "@mui/icons-material";
-import { useSettings } from "../../../../hooks/use-settings";
-import { Stack } from "@mui/system";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCippReportDB } from "../../../../components/CippComponents/CippReportDBControls";
+} from '@mui/material'
+import { CippCodeBlock } from '../../../../components/CippComponents/CippCodeBlock'
+import { useState, useEffect, useMemo } from 'react'
+import { useDispatch } from 'react-redux'
+import { Close, Save, LaptopChromebook } from '@mui/icons-material'
+import { useSettings } from '../../../../hooks/use-settings'
+import { Stack } from '@mui/system'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useCippReportDB } from '../../../../components/CippComponents/CippReportDBControls'
 
 const assignmentModeOptions = [
-  { label: "Replace existing assignments", value: "replace" },
-  { label: "Append to existing assignments", value: "append" },
-];
+  { label: 'Replace existing assignments', value: 'replace' },
+  { label: 'Append to existing assignments', value: 'append' },
+]
 
 const Page = () => {
-  const pageTitle = "Scripts";
-  const [codeOpen, setCodeOpen] = useState(false);
-  const [codeContent, setCodeContent] = useState("");
-  const [scriptId, setScriptId] = useState(null);
-  const [saveScript, setSaveScript] = useState(false);
-  const [codeContentChanged, setCodeContentChanged] = useState(false);
-  const [warnOpen, setWarnOpen] = useState(false);
-  const [currentScript, setCurrentScript] = useState(null);
-  const [scriptTenant, setScriptTenant] = useState(null);
+  const pageTitle = 'Scripts'
+  const [codeOpen, setCodeOpen] = useState(false)
+  const [codeContent, setCodeContent] = useState('')
+  const [scriptId, setScriptId] = useState(null)
+  const [saveScript, setSaveScript] = useState(false)
+  const [codeContentChanged, setCodeContentChanged] = useState(false)
+  const [warnOpen, setWarnOpen] = useState(false)
+  const [currentScript, setCurrentScript] = useState(null)
+  const [scriptTenant, setScriptTenant] = useState(null)
 
-  const tenantFilter = useSettings().currentTenant;
+  const tenantFilter = useSettings().currentTenant
   const reportDB = useCippReportDB({
-    apiUrl: "/api/ListIntuneScript",
-    queryKey: "ListIntuneScript",
-    cacheName: "IntuneScripts",
-    syncTitle: "Sync Intune Scripts Report",
+    apiUrl: '/api/ListIntuneScript',
+    queryKey: 'ListIntuneScript',
+    cacheName: 'IntuneScripts',
+    syncTitle: 'Sync Intune Scripts Report',
     allowToggle: true,
     defaultCached: false,
-  });
+  })
 
-  const dispatch = useDispatch();
+  const dispatch = useDispatch()
 
   const language = useMemo(() => {
-    return currentScript?.scriptType?.toLowerCase() === ("macos" || "linux")
-      ? "shell"
-      : "powershell";
-  }, [currentScript?.scriptType]);
+    return currentScript?.scriptType?.toLowerCase() === ('macos' || 'linux')
+      ? 'shell'
+      : 'powershell'
+  }, [currentScript?.scriptType])
 
   const {
     isLoading: scriptIsLoading,
@@ -66,55 +66,55 @@ const Page = () => {
     refetch: scriptRefetch,
     data,
   } = useQuery({
-    queryKey: ["script", { scriptId, scriptTenant }],
+    queryKey: ['script', { scriptId, scriptTenant }],
     queryFn: async () => {
       const response = await fetch(
         `/api/EditIntuneScript?TenantFilter=${scriptTenant || tenantFilter}&ScriptId=${scriptId}`
-      );
-      return response.json();
+      )
+      return response.json()
     },
     refetchOnWindowFocus: false,
     enabled: false,
-  });
+  })
 
   // Refetch the script on scriptId change
   useEffect(() => {
     if (scriptId) {
       scriptRefetch().then(({ data }) => {
-        setCurrentScript(data);
-        const scriptBytes = Buffer.from(data.scriptContent, "base64");
-        setCodeContent(scriptBytes.toString("ascii"));
-      });
+        setCurrentScript(data)
+        const scriptBytes = Buffer.from(data.scriptContent, 'base64')
+        setCodeContent(scriptBytes.toString('ascii'))
+      })
     }
-  }, [scriptId, scriptRefetch]);
+  }, [scriptId, scriptRefetch])
 
   const handleScriptEdit = async (row, action) => {
-    setScriptId(row.id);
-    setScriptTenant(row?.Tenant || tenantFilter);
-    setCodeOpen(!codeOpen);
-  };
+    setScriptId(row.id)
+    setScriptTenant(row?.Tenant || tenantFilter)
+    setCodeOpen(!codeOpen)
+  }
 
   const codeChange = (newValue, evt) => {
-    setCodeContent(newValue);
-    setCodeContentChanged(true);
-  };
+    setCodeContent(newValue)
+    setCodeContentChanged(true)
+  }
 
   const codeClosed = () => {
     if (codeContentChanged) {
-      setWarnOpen(!warnOpen);
+      setWarnOpen(!warnOpen)
     } else {
-      setCodeOpen(!codeOpen);
-      setCodeContentChanged(false);
-      setScriptId(null);
-      setScriptTenant(null);
-      setCodeContent("");
+      setCodeOpen(!codeOpen)
+      setCodeContentChanged(false)
+      setScriptId(null)
+      setScriptTenant(null)
+      setCodeContent('')
     }
-  };
+  }
 
   const { refetch: saveScriptRefetch, isFetching: isSaving } = useQuery({
-    queryKey: ["saveScript"],
+    queryKey: ['saveScript'],
     queryFn: async () => {
-      const scriptBytes = Buffer.from(codeContent, "ascii");
+      const scriptBytes = Buffer.from(codeContent, 'ascii')
       const {
         runAs32Bit,
         id,
@@ -125,7 +125,7 @@ const Page = () => {
         fileName,
         roleScopeTagIds,
         scriptType,
-      } = currentScript;
+      } = currentScript
       const patchData = {
         TenantFilter: scriptTenant || tenantFilter,
         ScriptId: id,
@@ -135,247 +135,247 @@ const Page = () => {
           id,
           displayName,
           description,
-          scriptContent: scriptBytes.toString("base64"), // Convert to base64
+          scriptContent: scriptBytes.toString('base64'), // Convert to base64
           runAsAccount,
           fileName,
           roleScopeTagIds,
         }),
-      };
+      }
 
-      const response = await fetch("/api/EditIntuneScript", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+      const response = await fetch('/api/EditIntuneScript', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(patchData),
-      });
+      })
 
       if (!response.ok) {
         dispatch(
           showToast({
-            title: "Script Save Error",
-            message: "Your Intune script could not be saved.",
-            type: "error",
+            title: 'Script Save Error',
+            message: 'Your Intune script could not be saved.',
+            type: 'error',
           })
-        );
+        )
       }
 
-      return response.json();
+      return response.json()
     },
     enabled: false,
     refetchOnWindowFocus: false,
-  });
+  })
 
-  const queryClient = useQueryClient();
+  const queryClient = useQueryClient()
 
   const saveCode = async () => {
-    const { data } = await saveScriptRefetch();
-    setCodeContentChanged(false);
-    setCodeOpen(!codeOpen);
+    const { data } = await saveScriptRefetch()
+    setCodeContentChanged(false)
+    setCodeOpen(!codeOpen)
     dispatch(
       showToast({
-        title: "Script Saved",
-        message: "Your Intune script has been saved successfully.",
-        type: "update",
+        title: 'Script Saved',
+        message: 'Your Intune script has been saved successfully.',
+        type: 'update',
       })
-    );
-  };
+    )
+  }
 
   // Map script type to Graph API endpoint
   const getScriptEndpoint = (scriptType) => {
     const mapping = {
-      Windows: "deviceManagementScripts",
-      MacOS: "deviceShellScripts",
-      Remediation: "deviceHealthScripts",
-      Linux: "configurationPolicies",
-    };
-    return mapping[scriptType] || "deviceManagementScripts";
-  };
+      Windows: 'deviceManagementScripts',
+      MacOS: 'deviceShellScripts',
+      Remediation: 'deviceHealthScripts',
+      Linux: 'configurationPolicies',
+    }
+    return mapping[scriptType] || 'deviceManagementScripts'
+  }
 
   const actions = [
     {
-      label: "Assign to All Users",
-      type: "POST",
-      url: "/api/ExecAssignPolicy",
+      label: 'Assign to All Users',
+      type: 'POST',
+      url: '/api/ExecAssignPolicy',
       icon: <UserIcon />,
-      color: "info",
+      color: 'info',
       fields: [
         {
-          type: "radio",
-          name: "assignmentMode",
-          label: "Assignment mode",
+          type: 'radio',
+          name: 'assignmentMode',
+          label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: "replace",
+          defaultValue: 'replace',
           helperText:
-            "Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.",
+            'Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.',
         },
       ],
       confirmText: 'Are you sure you want to assign "[displayName]" to all users?',
       customDataformatter: (row, action, formData) => ({
-        tenantFilter: tenantFilter === "AllTenants" && row?.Tenant ? row.Tenant : tenantFilter,
+        tenantFilter: tenantFilter === 'AllTenants' && row?.Tenant ? row.Tenant : tenantFilter,
         ID: row?.id,
         Type: getScriptEndpoint(row?.scriptType),
-        AssignTo: "allLicensedUsers",
-        assignmentMode: formData?.assignmentMode || "replace",
+        AssignTo: 'allLicensedUsers',
+        assignmentMode: formData?.assignmentMode || 'replace',
       }),
     },
     {
-      label: "Assign to All Devices",
-      type: "POST",
-      url: "/api/ExecAssignPolicy",
+      label: 'Assign to All Devices',
+      type: 'POST',
+      url: '/api/ExecAssignPolicy',
       icon: <LaptopChromebook />,
-      color: "info",
+      color: 'info',
       fields: [
         {
-          type: "radio",
-          name: "assignmentMode",
-          label: "Assignment mode",
+          type: 'radio',
+          name: 'assignmentMode',
+          label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: "replace",
+          defaultValue: 'replace',
           helperText:
-            "Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.",
+            'Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.',
         },
       ],
       confirmText: 'Are you sure you want to assign "[displayName]" to all devices?',
       customDataformatter: (row, action, formData) => ({
-        tenantFilter: tenantFilter === "AllTenants" && row?.Tenant ? row.Tenant : tenantFilter,
+        tenantFilter: tenantFilter === 'AllTenants' && row?.Tenant ? row.Tenant : tenantFilter,
         ID: row?.id,
         Type: getScriptEndpoint(row?.scriptType),
-        AssignTo: "AllDevices",
-        assignmentMode: formData?.assignmentMode || "replace",
+        AssignTo: 'AllDevices',
+        assignmentMode: formData?.assignmentMode || 'replace',
       }),
     },
     {
-      label: "Assign Globally (All Users / All Devices)",
-      type: "POST",
-      url: "/api/ExecAssignPolicy",
+      label: 'Assign Globally (All Users / All Devices)',
+      type: 'POST',
+      url: '/api/ExecAssignPolicy',
       icon: <GlobeAltIcon />,
-      color: "info",
+      color: 'info',
       fields: [
         {
-          type: "radio",
-          name: "assignmentMode",
-          label: "Assignment mode",
+          type: 'radio',
+          name: 'assignmentMode',
+          label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: "replace",
+          defaultValue: 'replace',
           helperText:
-            "Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.",
+            'Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.',
         },
       ],
       confirmText: 'Are you sure you want to assign "[displayName]" to all users and devices?',
       customDataformatter: (row, action, formData) => ({
-        tenantFilter: tenantFilter === "AllTenants" && row?.Tenant ? row.Tenant : tenantFilter,
+        tenantFilter: tenantFilter === 'AllTenants' && row?.Tenant ? row.Tenant : tenantFilter,
         ID: row?.id,
         Type: getScriptEndpoint(row?.scriptType),
-        AssignTo: "AllDevicesAndUsers",
-        assignmentMode: formData?.assignmentMode || "replace",
+        AssignTo: 'AllDevicesAndUsers',
+        assignmentMode: formData?.assignmentMode || 'replace',
       }),
     },
     {
-      label: "Assign to Custom Group",
-      type: "POST",
-      url: "/api/ExecAssignPolicy",
+      label: 'Assign to Custom Group',
+      type: 'POST',
+      url: '/api/ExecAssignPolicy',
       icon: <UserGroupIcon />,
-      color: "info",
+      color: 'info',
       confirmText: 'Select the target groups for "[displayName]".',
       fields: [
         {
-          type: "autoComplete",
-          name: "groupTargets",
-          label: "Group(s)",
+          type: 'autoComplete',
+          name: 'groupTargets',
+          label: 'Group(s)',
           multiple: true,
           creatable: false,
           allowResubmit: true,
-          validators: { required: "Please select at least one group" },
+          validators: { required: 'Please select at least one group' },
           api: {
-            url: "/api/ListGraphRequest",
-            dataKey: "Results",
+            url: '/api/ListGraphRequest',
+            dataKey: 'Results',
             queryKey: `ListScriptAssignmentGroups-${tenantFilter}`,
             labelField: (group) =>
               group.id ? `${group.displayName} (${group.id})` : group.displayName,
-            valueField: "id",
+            valueField: 'id',
             addedField: {
-              description: "description",
+              description: 'description',
             },
             data: {
-              Endpoint: "groups",
+              Endpoint: 'groups',
               manualPagination: true,
-              $select: "id,displayName,description",
-              $orderby: "displayName",
+              $select: 'id,displayName,description',
+              $orderby: 'displayName',
               $top: 999,
               $count: true,
             },
           },
         },
         {
-          type: "radio",
-          name: "assignmentMode",
-          label: "Assignment mode",
+          type: 'radio',
+          name: 'assignmentMode',
+          label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: "replace",
+          defaultValue: 'replace',
           helperText:
-            "Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.",
+            'Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.',
         },
       ],
       customDataformatter: (row, action, formData) => {
-        const selectedGroups = Array.isArray(formData?.groupTargets) ? formData.groupTargets : [];
+        const selectedGroups = Array.isArray(formData?.groupTargets) ? formData.groupTargets : []
         return {
-          tenantFilter: tenantFilter === "AllTenants" && row?.Tenant ? row.Tenant : tenantFilter,
+          tenantFilter: tenantFilter === 'AllTenants' && row?.Tenant ? row.Tenant : tenantFilter,
           ID: row?.id,
           Type: getScriptEndpoint(row?.scriptType),
           GroupIds: selectedGroups.map((group) => group.value).filter(Boolean),
           GroupNames: selectedGroups.map((group) => group.label).filter(Boolean),
-          assignmentMode: formData?.assignmentMode || "replace",
-        };
+          assignmentMode: formData?.assignmentMode || 'replace',
+        }
       },
     },
     {
-      label: "Edit Script",
+      label: 'Edit Script',
       icon: <PencilIcon />,
-      color: "primary",
+      color: 'primary',
       noConfirm: true,
       customFunction: handleScriptEdit,
     },
     {
-      label: "Delete Script",
-      type: "POST",
-      url: "/api/RemoveIntuneScript",
+      label: 'Delete Script',
+      type: 'POST',
+      url: '/api/RemoveIntuneScript',
       data: {
-        ID: "id",
-        displayName: "displayName",
-        ScriptType: "scriptType",
+        ID: 'id',
+        displayName: 'displayName',
+        ScriptType: 'scriptType',
       },
-      confirmText: "Are you sure you want to delete this script?",
+      confirmText: 'Are you sure you want to delete this script?',
       icon: <TrashIcon />,
-      color: "danger",
+      color: 'danger',
     },
-  ];
+  ]
 
   const offCanvas = {
     extendedInfoFields: [
-      "scriptType",
-      "id",
-      "fileName",
-      "displayName",
-      "description",
-      "lastModifiedDateTime",
-      "runAsAccount",
-      "createdDateTime",
-      "runAs32Bit",
-      "executionFrequency",
-      "enforceSignatureCheck",
+      'scriptType',
+      'id',
+      'fileName',
+      'displayName',
+      'description',
+      'lastModifiedDateTime',
+      'runAsAccount',
+      'createdDateTime',
+      'runAs32Bit',
+      'executionFrequency',
+      'enforceSignatureCheck',
     ],
     actions: actions,
-  };
+  }
 
   const simpleColumns = [
     ...reportDB.cacheColumns,
-    "scriptType",
-    "displayName",
-    "ScriptAssignment",
-    "ScriptExclude",
-    "description",
-    "runAsAccount",
-    "lastModifiedDateTime",
-  ];
+    'scriptType',
+    'displayName',
+    'ScriptAssignment',
+    'ScriptExclude',
+    'description',
+    'runAsAccount',
+    'lastModifiedDateTime',
+  ]
 
   return (
     <>
@@ -396,7 +396,7 @@ const Page = () => {
             <IconButton
               aria-label="close"
               onClick={codeClosed}
-              sx={{ position: "absolute", right: 8, top: 8 }}
+              sx={{ position: 'absolute', right: 8, top: 8 }}
             >
               <Close />
             </IconButton>
@@ -405,13 +405,13 @@ const Page = () => {
             <IconButton
               aria-label="save"
               onClick={saveCode}
-              sx={{ position: "absolute", right: 50, top: 8 }}
+              sx={{ position: 'absolute', right: 50, top: 8 }}
             >
               <Save />
             </IconButton>
           )}
           {isSaving && (
-            <CircularProgress size={20} sx={{ position: "absolute", right: 55, top: 14 }} />
+            <CircularProgress size={20} sx={{ position: 'absolute', right: 55, top: 14 }} />
           )}
         </DialogTitle>
         <DialogContent dividers>
@@ -439,12 +439,12 @@ const Page = () => {
           <Button
             variant="contained"
             onClick={() => {
-              setCodeOpen(false);
-              setWarnOpen(false);
-              setCodeContent("");
-              setScriptId(null);
-              setScriptTenant(null);
-              setCodeContentChanged(false);
+              setCodeOpen(false)
+              setWarnOpen(false)
+              setCodeContent('')
+              setScriptId(null)
+              setScriptTenant(null)
+              setCodeContentChanged(false)
             }}
           >
             Confirm
@@ -453,8 +453,8 @@ const Page = () => {
       </Dialog>
       {reportDB.syncDialog}
     </>
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout>{page}</DashboardLayout>
+export default Page

--- a/src/pages/endpoint/MEM/list-scripts/index.jsx
+++ b/src/pages/endpoint/MEM/list-scripts/index.jsx
@@ -31,6 +31,11 @@ const assignmentModeOptions = [
   { label: 'Append to existing assignments', value: 'append' },
 ]
 
+const assignmentDirectionOptions = [
+  { label: 'Include these group(s)', value: 'include' },
+  { label: 'Exclude these group(s)', value: 'exclude' },
+]
+
 const Page = () => {
   const pageTitle = 'Scripts'
   const [codeOpen, setCodeOpen] = useState(false)
@@ -190,11 +195,41 @@ const Page = () => {
     return mapping[scriptType] || 'deviceManagementScripts'
   }
 
+  // Group picker (by ID) reused for both include and exclude selection
+  const getGroupPickerField = (name, label, required) => ({
+    type: 'autoComplete',
+    name,
+    label,
+    multiple: true,
+    creatable: false,
+    allowResubmit: true,
+    ...(required && { validators: { required: 'Please select at least one group' } }),
+    api: {
+      url: '/api/ListGraphRequest',
+      dataKey: 'Results',
+      queryKey: `ListScriptAssignmentGroups-${tenantFilter}`,
+      labelField: (group) => (group.id ? `${group.displayName} (${group.id})` : group.displayName),
+      valueField: 'id',
+      addedField: {
+        description: 'description',
+      },
+      data: {
+        Endpoint: 'groups',
+        manualPagination: true,
+        $select: 'id,displayName,description',
+        $orderby: 'displayName',
+        $top: 999,
+        $count: true,
+      },
+    },
+  })
+
   const actions = [
     {
       label: 'Assign to All Users',
       type: 'POST',
       url: '/api/ExecAssignPolicy',
+      allowResubmit: true,
       icon: <UserIcon />,
       color: 'info',
       fields: [
@@ -221,6 +256,7 @@ const Page = () => {
       label: 'Assign to All Devices',
       type: 'POST',
       url: '/api/ExecAssignPolicy',
+      allowResubmit: true,
       icon: <LaptopChromebook />,
       color: 'info',
       fields: [
@@ -247,6 +283,7 @@ const Page = () => {
       label: 'Assign Globally (All Users / All Devices)',
       type: 'POST',
       url: '/api/ExecAssignPolicy',
+      allowResubmit: true,
       icon: <GlobeAltIcon />,
       color: 'info',
       fields: [
@@ -273,56 +310,69 @@ const Page = () => {
       label: 'Assign to Custom Group',
       type: 'POST',
       url: '/api/ExecAssignPolicy',
+      allowResubmit: true,
       icon: <UserGroupIcon />,
       color: 'info',
       confirmText: 'Select the target groups for "[displayName]".',
       fields: [
+        { type: 'heading', label: 'Target groups' },
         {
-          type: 'autoComplete',
-          name: 'groupTargets',
-          label: 'Group(s)',
-          multiple: true,
-          creatable: false,
-          allowResubmit: true,
-          validators: { required: 'Please select at least one group' },
-          api: {
-            url: '/api/ListGraphRequest',
-            dataKey: 'Results',
-            queryKey: `ListScriptAssignmentGroups-${tenantFilter}`,
-            labelField: (group) =>
-              group.id ? `${group.displayName} (${group.id})` : group.displayName,
-            valueField: 'id',
-            addedField: {
-              description: 'description',
-            },
-            data: {
-              Endpoint: 'groups',
-              manualPagination: true,
-              $select: 'id,displayName,description',
-              $orderby: 'displayName',
-              $top: 999,
-              $count: true,
+          ...getGroupPickerField('groupTargets', 'Group(s)', false),
+          helperText:
+            'Leave empty with Exclude + Replace to remove all exclusions (keeps includes).',
+          validators: {
+            // Required, except Exclude + Replace where an empty selection clears all exclusions.
+            validate: (value, formValues) => {
+              if (
+                formValues?.assignmentDirection === 'exclude' &&
+                (formValues?.assignmentMode || 'replace') === 'replace'
+              ) {
+                return true
+              }
+              return (
+                (Array.isArray(value) && value.length > 0) || 'Please select at least one group'
+              )
             },
           },
         },
+        {
+          type: 'radio',
+          name: 'assignmentDirection',
+          label: 'Assignment direction',
+          options: assignmentDirectionOptions,
+          defaultValue: 'include',
+          // Re-validate the picker so the empty-allowed rule updates when direction changes.
+          validators: { deps: ['groupTargets'] },
+          helperText:
+            'Include assigns to these groups; Exclude excludes them. Replace updates only this direction and keeps the other (and All Users/All Devices) intact.',
+        },
+        { type: 'heading', label: 'Assignment options' },
         {
           type: 'radio',
           name: 'assignmentMode',
           label: 'Assignment mode',
           options: assignmentModeOptions,
           defaultValue: 'replace',
+          // Re-validate the picker so the empty-allowed rule updates when mode changes.
+          validators: { deps: ['groupTargets'] },
           helperText:
-            'Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.',
+            'Replace updates only the selected direction and keeps the other direction plus All Users/All Devices. Append adds the selected groups to existing assignments.',
         },
       ],
       customDataformatter: (row, action, formData) => {
         const selectedGroups = Array.isArray(formData?.groupTargets) ? formData.groupTargets : []
+        const isExclude = formData?.assignmentDirection === 'exclude'
+        const ids = selectedGroups.map((group) => group.value).filter(Boolean)
+        const names = selectedGroups.map((group) => group.label).filter(Boolean)
         return {
           tenantFilter: tenantFilter === 'AllTenants' && row?.Tenant ? row.Tenant : tenantFilter,
           ID: row?.id,
           Type: getScriptEndpoint(row?.scriptType),
-          GroupIds: selectedGroups.map((group) => group.value).filter(Boolean),
-          GroupNames: selectedGroups.map((group) => group.label).filter(Boolean),
+          GroupIds: isExclude ? [] : ids,
+          GroupNames: isExclude ? [] : names,
+          ExcludeGroupIds: isExclude ? ids : [],
+          ExcludeGroupNames: isExclude ? names : [],
+          assignmentDirection: formData?.assignmentDirection || 'include',
           assignmentMode: formData?.assignmentMode || 'replace',
         }
       },

--- a/src/pages/endpoint/applications/list/index.js
+++ b/src/pages/endpoint/applications/list/index.js
@@ -27,6 +27,11 @@ const assignmentFilterTypeOptions = [
   { label: 'Exclude - Apply to devices NOT matching filter', value: 'exclude' },
 ]
 
+const assignmentDirectionOptions = [
+  { label: 'Include these group(s)', value: 'include' },
+  { label: 'Exclude these group(s)', value: 'exclude' },
+]
+
 const getAppAssignmentSettingsType = (odataType) => {
   if (!odataType || typeof odataType !== 'string') {
     return undefined
@@ -79,6 +84,7 @@ const Page = () => {
       options: assignmentFilterTypeOptions,
       defaultValue: 'include',
       helperText: 'Choose whether to include or exclude devices matching the filter.',
+      condition: { field: 'assignmentFilter', compareType: 'hasValue', clearOnHide: false },
     },
   ]
 
@@ -95,13 +101,49 @@ const Page = () => {
         AssignmentFilterType: formData?.assignmentFilter?.value
           ? formData?.assignmentFilterType || 'include'
           : null,
+        ExcludeGroupIds: (formData?.excludeGroupTargets || []).map((g) => g.value).filter(Boolean),
+        ExcludeGroupNames: (formData?.excludeGroupTargets || [])
+          .map((g) => g.label)
+          .filter(Boolean),
         ...getRowData(singleRow, formData),
       }
     }
     return Array.isArray(row) ? row.map(formatRow) : formatRow(row)
   }
 
+  // Group picker (by ID) reused for both include and exclude selection
+  const getGroupPickerField = (name, label, required) => ({
+    type: 'autoComplete',
+    name,
+    label,
+    multiple: true,
+    creatable: false,
+    allowResubmit: true,
+    ...(required && { validators: { required: 'Please select at least one group' } }),
+    api: {
+      url: '/api/ListGraphRequest',
+      dataKey: 'Results',
+      queryKey: `ListAppAssignmentGroups-${tenant}`,
+      labelField: (group) => (group.id ? `${group.displayName} (${group.id})` : group.displayName),
+      valueField: 'id',
+      addedField: {
+        description: 'description',
+      },
+      data: {
+        Endpoint: 'groups',
+        manualPagination: true,
+        $select: 'id,displayName,description',
+        $orderby: 'displayName',
+        $top: 999,
+        $count: true,
+      },
+    },
+  })
+
   const assignmentFields = [
+    { type: 'heading', label: 'Exclude groups (optional)' },
+    getGroupPickerField('excludeGroupTargets', 'Exclude group(s)', false),
+    { type: 'heading', label: 'Assignment options' },
     {
       type: 'radio',
       name: 'Intent',
@@ -121,6 +163,7 @@ const Page = () => {
       helperText:
         'Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups/intents.',
     },
+    { type: 'heading', label: 'Device filter (optional)' },
     ...getAssignmentFilterFields(),
   ]
 
@@ -129,6 +172,7 @@ const Page = () => {
       label: 'Assign to All Users',
       type: 'POST',
       url: '/api/ExecAssignApp',
+      allowResubmit: true,
       fields: assignmentFields,
       customDataformatter: makeAssignFormatter((_singleRow, formData) => ({
         AssignTo: 'AllUsers',
@@ -143,6 +187,7 @@ const Page = () => {
       label: 'Assign to All Devices',
       type: 'POST',
       url: '/api/ExecAssignApp',
+      allowResubmit: true,
       fields: assignmentFields,
       customDataformatter: makeAssignFormatter((_singleRow, formData) => ({
         AssignTo: 'AllDevices',
@@ -157,6 +202,7 @@ const Page = () => {
       label: 'Assign Globally (All Users / All Devices)',
       type: 'POST',
       url: '/api/ExecAssignApp',
+      allowResubmit: true,
       fields: assignmentFields,
       customDataformatter: makeAssignFormatter((_singleRow, formData) => ({
         AssignTo: 'AllDevicesAndUsers',
@@ -171,38 +217,43 @@ const Page = () => {
       label: 'Assign to Custom Group',
       type: 'POST',
       url: '/api/ExecAssignApp',
+      allowResubmit: true,
       icon: <UserGroupIcon />,
       color: 'info',
       confirmText: 'Select the target groups and intent for "[displayName]".',
       fields: [
+        { type: 'heading', label: 'Target groups' },
         {
-          type: 'autoComplete',
-          name: 'groupTargets',
-          label: 'Group(s)',
-          multiple: true,
-          creatable: false,
-          allowResubmit: true,
-          validators: { required: 'Please select at least one group' },
-          api: {
-            url: '/api/ListGraphRequest',
-            dataKey: 'Results',
-            queryKey: `ListAppAssignmentGroups-${tenant}`,
-            labelField: (group) =>
-              group.id ? `${group.displayName} (${group.id})` : group.displayName,
-            valueField: 'id',
-            addedField: {
-              description: 'description',
-            },
-            data: {
-              Endpoint: 'groups',
-              manualPagination: true,
-              $select: 'id,displayName,description',
-              $orderby: 'displayName',
-              $top: 999,
-              $count: true,
+          ...getGroupPickerField('groupTargets', 'Group(s)', false),
+          helperText:
+            'Leave empty with Exclude + Replace to remove all exclusions (keeps includes).',
+          validators: {
+            // Required, except Exclude + Replace where an empty selection clears all exclusions.
+            validate: (value, formValues) => {
+              if (
+                formValues?.assignmentDirection === 'exclude' &&
+                (formValues?.assignmentMode || 'replace') === 'replace'
+              ) {
+                return true
+              }
+              return (
+                (Array.isArray(value) && value.length > 0) || 'Please select at least one group'
+              )
             },
           },
         },
+        {
+          type: 'radio',
+          name: 'assignmentDirection',
+          label: 'Assignment direction',
+          options: assignmentDirectionOptions,
+          defaultValue: 'include',
+          // Re-validate the picker so the empty-allowed rule updates when direction changes.
+          validators: { deps: ['groupTargets'] },
+          helperText:
+            'Include assigns to these groups; Exclude excludes them. Replace updates only this direction and keeps the other (and All Users/All Devices) intact.',
+        },
+        { type: 'heading', label: 'Assignment options' },
         {
           type: 'radio',
           name: 'assignmentIntent',
@@ -219,16 +270,25 @@ const Page = () => {
           label: 'Assignment mode',
           options: assignmentModeOptions,
           defaultValue: 'replace',
+          // Re-validate the picker so the empty-allowed rule updates when mode changes.
+          validators: { deps: ['groupTargets'] },
           helperText:
-            'Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups/intents.',
+            'Replace updates only the selected direction and keeps the other direction plus All Users/All Devices. Append adds the selected groups to existing assignments.',
         },
+        { type: 'heading', label: 'Device filter (optional)' },
         ...getAssignmentFilterFields(),
       ],
       customDataformatter: makeAssignFormatter((_singleRow, formData) => {
         const selectedGroups = Array.isArray(formData?.groupTargets) ? formData.groupTargets : []
+        const isExclude = formData?.assignmentDirection === 'exclude'
+        const ids = selectedGroups.map((group) => group.value).filter(Boolean)
+        const names = selectedGroups.map((group) => group.label).filter(Boolean)
         return {
-          GroupIds: selectedGroups.map((group) => group.value).filter(Boolean),
-          GroupNames: selectedGroups.map((group) => group.label).filter(Boolean),
+          GroupIds: isExclude ? [] : ids,
+          GroupNames: isExclude ? [] : names,
+          ExcludeGroupIds: isExclude ? ids : [],
+          ExcludeGroupNames: isExclude ? names : [],
+          assignmentDirection: formData?.assignmentDirection || 'include',
           Intent: formData?.assignmentIntent || 'Required',
           AssignmentMode: formData?.assignmentMode || 'replace',
         }

--- a/src/pages/endpoint/applications/list/index.js
+++ b/src/pages/endpoint/applications/list/index.js
@@ -1,315 +1,315 @@
-import { Layout as DashboardLayout } from "../../../../layouts/index.js";
-import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
-import { CippApiDialog } from "../../../../components/CippComponents/CippApiDialog.jsx";
-import { GlobeAltIcon, TrashIcon, UserIcon, UserGroupIcon } from "@heroicons/react/24/outline";
-import { LaptopMac, Sync, BookmarkAdd } from "@mui/icons-material";
-import { CippApplicationDeployDrawer } from "../../../../components/CippComponents/CippApplicationDeployDrawer";
-import { Button } from "@mui/material";
-import { Stack } from "@mui/system";
-import { useSettings } from "../../../../hooks/use-settings.js";
-import { useDialog } from "../../../../hooks/use-dialog.js";
-import { useCippReportDB } from "../../../../components/CippComponents/CippReportDBControls";
+import { Layout as DashboardLayout } from '../../../../layouts/index.js'
+import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import { CippApiDialog } from '../../../../components/CippComponents/CippApiDialog.jsx'
+import { GlobeAltIcon, TrashIcon, UserIcon, UserGroupIcon } from '@heroicons/react/24/outline'
+import { LaptopMac, Sync, BookmarkAdd } from '@mui/icons-material'
+import { CippApplicationDeployDrawer } from '../../../../components/CippComponents/CippApplicationDeployDrawer'
+import { Button } from '@mui/material'
+import { Stack } from '@mui/system'
+import { useSettings } from '../../../../hooks/use-settings.js'
+import { useDialog } from '../../../../hooks/use-dialog.js'
+import { useCippReportDB } from '../../../../components/CippComponents/CippReportDBControls'
 
 const assignmentIntentOptions = [
-  { label: "Required", value: "Required" },
-  { label: "Available", value: "Available" },
-  { label: "Available without enrollment", value: "AvailableWithoutEnrollment" },
-  { label: "Uninstall", value: "Uninstall" },
-];
+  { label: 'Required', value: 'Required' },
+  { label: 'Available', value: 'Available' },
+  { label: 'Available without enrollment', value: 'AvailableWithoutEnrollment' },
+  { label: 'Uninstall', value: 'Uninstall' },
+]
 
 const assignmentModeOptions = [
-  { label: "Replace existing assignments", value: "replace" },
-  { label: "Append to existing assignments", value: "append" },
-];
+  { label: 'Replace existing assignments', value: 'replace' },
+  { label: 'Append to existing assignments', value: 'append' },
+]
 
 const assignmentFilterTypeOptions = [
-  { label: "Include - Apply to devices matching filter", value: "include" },
-  { label: "Exclude - Apply to devices NOT matching filter", value: "exclude" },
-];
+  { label: 'Include - Apply to devices matching filter', value: 'include' },
+  { label: 'Exclude - Apply to devices NOT matching filter', value: 'exclude' },
+]
 
 const getAppAssignmentSettingsType = (odataType) => {
-  if (!odataType || typeof odataType !== "string") {
-    return undefined;
+  if (!odataType || typeof odataType !== 'string') {
+    return undefined
   }
 
-  return odataType.replace("#microsoft.graph.", "").replace(/App$/i, "");
-};
+  return odataType.replace('#microsoft.graph.', '').replace(/App$/i, '')
+}
 
 const mapOdataToAppType = (odataType) => {
-  if (!odataType) return "win32ScriptApp";
-  const type = odataType.toLowerCase();
-  if (type.includes("wingetapp")) return "StoreApp";
-  if (type.includes("win32lobapp")) return "chocolateyApp";
-  if (type.includes("officesuiteapp")) return "officeApp";
-  return "win32ScriptApp";
-};
+  if (!odataType) return 'win32ScriptApp'
+  const type = odataType.toLowerCase()
+  if (type.includes('wingetapp')) return 'StoreApp'
+  if (type.includes('win32lobapp')) return 'chocolateyApp'
+  if (type.includes('officesuiteapp')) return 'officeApp'
+  return 'win32ScriptApp'
+}
 
 const Page = () => {
-  const pageTitle = "Applications";
-  const vppSyncDialog = useDialog();
-  const tenant = useSettings().currentTenant;
+  const pageTitle = 'Applications'
+  const vppSyncDialog = useDialog()
+  const tenant = useSettings().currentTenant
 
   const reportDB = useCippReportDB({
-    apiUrl: "/api/ListApps",
-    queryKey: "ListApps",
-    cacheName: "IntuneApplications",
-    syncTitle: "Sync Intune Applications Report",
+    apiUrl: '/api/ListApps',
+    queryKey: 'ListApps',
+    cacheName: 'IntuneApplications',
+    syncTitle: 'Sync Intune Applications Report',
     allowToggle: true,
     defaultCached: false,
-  });
+  })
 
   const getAssignmentFilterFields = () => [
     {
-      type: "autoComplete",
-      name: "assignmentFilter",
-      label: "Assignment Filter (Optional)",
+      type: 'autoComplete',
+      name: 'assignmentFilter',
+      label: 'Assignment Filter (Optional)',
       multiple: false,
       creatable: false,
       api: {
-        url: "/api/ListAssignmentFilters",
+        url: '/api/ListAssignmentFilters',
         queryKey: `ListAssignmentFilters-${tenant}`,
         labelField: (filter) => filter.displayName,
-        valueField: "displayName",
+        valueField: 'displayName',
       },
     },
     {
-      type: "radio",
-      name: "assignmentFilterType",
-      label: "Assignment Filter Mode",
+      type: 'radio',
+      name: 'assignmentFilterType',
+      label: 'Assignment Filter Mode',
       options: assignmentFilterTypeOptions,
-      defaultValue: "include",
-      helperText: "Choose whether to include or exclude devices matching the filter.",
+      defaultValue: 'include',
+      helperText: 'Choose whether to include or exclude devices matching the filter.',
     },
-  ];
+  ]
 
   // Builds a customDataformatter that handles both single-row and bulk (array) inputs.
   const makeAssignFormatter = (getRowData) => (row, action, formData) => {
     const formatRow = (singleRow) => {
       const tenantFilterValue =
-        tenant === "AllTenants" && singleRow?.Tenant ? singleRow.Tenant : tenant;
+        tenant === 'AllTenants' && singleRow?.Tenant ? singleRow.Tenant : tenant
       return {
         tenantFilter: tenantFilterValue,
         ID: singleRow?.id,
-        AppType: getAppAssignmentSettingsType(singleRow?.["@odata.type"]),
+        AppType: getAppAssignmentSettingsType(singleRow?.['@odata.type']),
         AssignmentFilterName: formData?.assignmentFilter?.value || null,
         AssignmentFilterType: formData?.assignmentFilter?.value
-          ? formData?.assignmentFilterType || "include"
+          ? formData?.assignmentFilterType || 'include'
           : null,
         ...getRowData(singleRow, formData),
-      };
-    };
-    return Array.isArray(row) ? row.map(formatRow) : formatRow(row);
-  };
+      }
+    }
+    return Array.isArray(row) ? row.map(formatRow) : formatRow(row)
+  }
 
   const assignmentFields = [
     {
-      type: "radio",
-      name: "Intent",
-      label: "Assignment intent",
+      type: 'radio',
+      name: 'Intent',
+      label: 'Assignment intent',
       options: assignmentIntentOptions,
-      defaultValue: "Required",
-      validators: { required: "Select an assignment intent" },
+      defaultValue: 'Required',
+      validators: { required: 'Select an assignment intent' },
       helperText:
-        "Available assigns to Company Portal, Required installs automatically, Uninstall removes the app, Available without enrollment exposes it without device enrollment.",
+        'Available assigns to Company Portal, Required installs automatically, Uninstall removes the app, Available without enrollment exposes it without device enrollment.',
     },
     {
-      type: "radio",
-      name: "assignmentMode",
-      label: "Assignment mode",
+      type: 'radio',
+      name: 'assignmentMode',
+      label: 'Assignment mode',
       options: assignmentModeOptions,
-      defaultValue: "replace",
+      defaultValue: 'replace',
       helperText:
-        "Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups/intents.",
+        'Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups/intents.',
     },
     ...getAssignmentFilterFields(),
-  ];
+  ]
 
   const actions = [
     {
-      label: "Assign to All Users",
-      type: "POST",
-      url: "/api/ExecAssignApp",
+      label: 'Assign to All Users',
+      type: 'POST',
+      url: '/api/ExecAssignApp',
       fields: assignmentFields,
       customDataformatter: makeAssignFormatter((_singleRow, formData) => ({
-        AssignTo: "AllUsers",
-        Intent: formData?.Intent || "Required",
-        assignmentMode: formData?.assignmentMode || "replace",
+        AssignTo: 'AllUsers',
+        Intent: formData?.Intent || 'Required',
+        assignmentMode: formData?.assignmentMode || 'replace',
       })),
       confirmText: 'Are you sure you want to assign "[displayName]" to all users?',
       icon: <UserIcon />,
-      color: "info",
+      color: 'info',
     },
     {
-      label: "Assign to All Devices",
-      type: "POST",
-      url: "/api/ExecAssignApp",
+      label: 'Assign to All Devices',
+      type: 'POST',
+      url: '/api/ExecAssignApp',
       fields: assignmentFields,
       customDataformatter: makeAssignFormatter((_singleRow, formData) => ({
-        AssignTo: "AllDevices",
-        Intent: formData?.Intent || "Required",
-        assignmentMode: formData?.assignmentMode || "replace",
+        AssignTo: 'AllDevices',
+        Intent: formData?.Intent || 'Required',
+        assignmentMode: formData?.assignmentMode || 'replace',
       })),
       confirmText: 'Are you sure you want to assign "[displayName]" to all devices?',
       icon: <LaptopMac />,
-      color: "info",
+      color: 'info',
     },
     {
-      label: "Assign Globally (All Users / All Devices)",
-      type: "POST",
-      url: "/api/ExecAssignApp",
+      label: 'Assign Globally (All Users / All Devices)',
+      type: 'POST',
+      url: '/api/ExecAssignApp',
       fields: assignmentFields,
       customDataformatter: makeAssignFormatter((_singleRow, formData) => ({
-        AssignTo: "AllDevicesAndUsers",
-        Intent: formData?.Intent || "Required",
-        assignmentMode: formData?.assignmentMode || "replace",
+        AssignTo: 'AllDevicesAndUsers',
+        Intent: formData?.Intent || 'Required',
+        assignmentMode: formData?.assignmentMode || 'replace',
       })),
       confirmText: 'Are you sure you want to assign "[displayName]" to all users and devices?',
       icon: <GlobeAltIcon />,
-      color: "info",
+      color: 'info',
     },
     {
-      label: "Assign to Custom Group",
-      type: "POST",
-      url: "/api/ExecAssignApp",
+      label: 'Assign to Custom Group',
+      type: 'POST',
+      url: '/api/ExecAssignApp',
       icon: <UserGroupIcon />,
-      color: "info",
+      color: 'info',
       confirmText: 'Select the target groups and intent for "[displayName]".',
       fields: [
         {
-          type: "autoComplete",
-          name: "groupTargets",
-          label: "Group(s)",
+          type: 'autoComplete',
+          name: 'groupTargets',
+          label: 'Group(s)',
           multiple: true,
           creatable: false,
           allowResubmit: true,
-          validators: { required: "Please select at least one group" },
+          validators: { required: 'Please select at least one group' },
           api: {
-            url: "/api/ListGraphRequest",
-            dataKey: "Results",
+            url: '/api/ListGraphRequest',
+            dataKey: 'Results',
             queryKey: `ListAppAssignmentGroups-${tenant}`,
             labelField: (group) =>
               group.id ? `${group.displayName} (${group.id})` : group.displayName,
-            valueField: "id",
+            valueField: 'id',
             addedField: {
-              description: "description",
+              description: 'description',
             },
             data: {
-              Endpoint: "groups",
+              Endpoint: 'groups',
               manualPagination: true,
-              $select: "id,displayName,description",
-              $orderby: "displayName",
+              $select: 'id,displayName,description',
+              $orderby: 'displayName',
               $top: 999,
               $count: true,
             },
           },
         },
         {
-          type: "radio",
-          name: "assignmentIntent",
-          label: "Assignment intent",
+          type: 'radio',
+          name: 'assignmentIntent',
+          label: 'Assignment intent',
           options: assignmentIntentOptions,
-          defaultValue: "Required",
-          validators: { required: "Select an assignment intent" },
+          defaultValue: 'Required',
+          validators: { required: 'Select an assignment intent' },
           helperText:
-            "Available assigns to Company Portal, Required installs automatically, Uninstall removes the app, Available without enrollment exposes it without device enrollment.",
+            'Available assigns to Company Portal, Required installs automatically, Uninstall removes the app, Available without enrollment exposes it without device enrollment.',
         },
         {
-          type: "radio",
-          name: "assignmentMode",
-          label: "Assignment mode",
+          type: 'radio',
+          name: 'assignmentMode',
+          label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: "replace",
+          defaultValue: 'replace',
           helperText:
-            "Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups/intents.",
+            'Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups/intents.',
         },
         ...getAssignmentFilterFields(),
       ],
       customDataformatter: makeAssignFormatter((_singleRow, formData) => {
-        const selectedGroups = Array.isArray(formData?.groupTargets) ? formData.groupTargets : [];
+        const selectedGroups = Array.isArray(formData?.groupTargets) ? formData.groupTargets : []
         return {
           GroupIds: selectedGroups.map((group) => group.value).filter(Boolean),
           GroupNames: selectedGroups.map((group) => group.label).filter(Boolean),
-          Intent: formData?.assignmentIntent || "Required",
-          AssignmentMode: formData?.assignmentMode || "replace",
-        };
+          Intent: formData?.assignmentIntent || 'Required',
+          AssignmentMode: formData?.assignmentMode || 'replace',
+        }
       }),
     },
     {
-      label: "Save as Template",
-      type: "POST",
-      url: "/api/AddAppTemplate",
+      label: 'Save as Template',
+      type: 'POST',
+      url: '/api/AddAppTemplate',
       icon: <BookmarkAdd />,
-      color: "info",
+      color: 'info',
       fields: [
         {
-          type: "textField",
-          name: "displayName",
-          label: "Template Name",
-          validators: { required: "Template name is required" },
+          type: 'textField',
+          name: 'displayName',
+          label: 'Template Name',
+          validators: { required: 'Template name is required' },
         },
         {
-          type: "textField",
-          name: "description",
-          label: "Description",
+          type: 'textField',
+          name: 'description',
+          label: 'Description',
         },
       ],
       customDataformatter: (row, action, formData) => {
-        const rows = Array.isArray(row) ? row : [row];
+        const rows = Array.isArray(row) ? row : [row]
         return {
           displayName: formData?.displayName,
-          description: formData?.description || "",
+          description: formData?.description || '',
           apps: rows.map((r) => ({
-            appType: mapOdataToAppType(r["@odata.type"]),
+            appType: mapOdataToAppType(r['@odata.type']),
             appName: r.displayName,
             config: JSON.stringify({
               ApplicationName: r.displayName,
               IntuneBody: r,
-              assignTo: "On",
+              assignTo: 'On',
             }),
           })),
-        };
+        }
       },
       confirmText: 'Save selected application(s) as a reusable template?',
     },
     {
-      label: "Delete Application",
-      type: "POST",
-      url: "/api/RemoveApp",
+      label: 'Delete Application',
+      type: 'POST',
+      url: '/api/RemoveApp',
       data: {
-        ID: "id",
+        ID: 'id',
       },
       confirmText: 'Are you sure you want to delete "[displayName]"?',
       icon: <TrashIcon />,
-      color: "danger",
+      color: 'danger',
     },
-  ];
+  ]
 
   const offCanvas = {
     extendedInfoFields: [
-      "installExperience.runAsAccount",
-      "installExperience.deviceRestartBehavior",
-      "isAssigned",
-      "createdDateTime",
-      "lastModifiedDateTime",
-      "isFeatured",
-      "publishingState",
-      "dependentAppCount",
-      "rules.0.ruleType",
-      "rules.0.fileOrFolderName",
-      "rules.0.path",
+      'installExperience.runAsAccount',
+      'installExperience.deviceRestartBehavior',
+      'isAssigned',
+      'createdDateTime',
+      'lastModifiedDateTime',
+      'isFeatured',
+      'publishingState',
+      'dependentAppCount',
+      'rules.0.ruleType',
+      'rules.0.fileOrFolderName',
+      'rules.0.path',
     ],
     actions: actions,
-  };
+  }
 
   const simpleColumns = [
     ...reportDB.cacheColumns,
-    "displayName",
-    "AppAssignment",
-    "AppExclude",
-    "publishingState",
-    "lastModifiedDateTime",
-    "createdDateTime",
-  ];
+    'displayName',
+    'AppAssignment',
+    'AppExclude',
+    'publishingState',
+    'lastModifiedDateTime',
+    'createdDateTime',
+  ]
 
   return (
     <>
@@ -334,16 +334,16 @@ const Page = () => {
         title="Sync VPP Tokens"
         createDialog={vppSyncDialog}
         api={{
-          type: "POST",
-          url: "/api/ExecSyncVPP",
+          type: 'POST',
+          url: '/api/ExecSyncVPP',
           data: {},
           confirmText: `Are you sure you want to sync Apple Volume Purchase Program (VPP) tokens? This will sync all VPP tokens for ${tenant}.`,
         }}
       />
       {reportDB.syncDialog}
     </>
-  );
-};
+  )
+}
 
-Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>;
-export default Page;
+Page.getLayout = (page) => <DashboardLayout allTenantsSupport={true}>{page}</DashboardLayout>
+export default Page


### PR DESCRIPTION
Refactor the Intune assignment interface to include group pickers for inclusion and exclusion, allowing for more flexible policy assignments.


API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/2115