### PR TITLE
Add audit log alert presets: external mailbox forwarding & Exchange admin elevation

### DIFF
--- a/src/data/AuditLogTemplates.json
+++ b/src/data/AuditLogTemplates.json
@@ -446,5 +446,52 @@
         }
       ]
     }
+  },
+  {
+    "value": "Set-MailboxForwardingExternal",
+    "name": "External email forwarding has been configured on a mailbox",
+    "template": {
+      "preset": {
+        "value": "Set-MailboxForwardingExternal",
+        "label": "External email forwarding has been configured on a mailbox"
+      },
+      "logbook": { "value": "Audit.Exchange", "label": "Exchange" },
+      "conditions": [
+        {
+          "Property": { "value": "List:Operation", "label": "Operation" },
+          "Operator": { "value": "EQ", "label": "Equals to" },
+          "Input": {
+            "value": "Set-Mailbox",
+            "label": "mailbox settings were changed"
+          }
+        },
+        {
+          "Property": { "value": "String", "label": "ForwardingSmtpAddress" },
+          "Operator": { "value": "like", "label": "Like" },
+          "Input": { "value": "*@*" }
+        }
+      ]
+    }
+  },
+  {
+    "value": "Add-RoleGroupMember",
+    "name": "A user has been granted Exchange admin privileges",
+    "template": {
+      "preset": {
+        "value": "Add-RoleGroupMember",
+        "label": "A user has been granted Exchange admin privileges"
+      },
+      "logbook": { "value": "Audit.Exchange", "label": "Exchange" },
+      "conditions": [
+        {
+          "Property": { "value": "List:Operation", "label": "Operation" },
+          "Operator": { "value": "EQ", "label": "Equals to" },
+          "Input": {
+            "value": "Add-RoleGroupMember",
+            "label": "added a member to an Exchange role group"
+          }
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
# Add audit-log alert presets: external mailbox forwarding and Exchange admin elevation

Partially addresses KelvinTegelaar/CIPP#6228.

That request asks for five alert types. This PR adds the two that map cleanly onto audit sources CIPP already ingests (`Audit.Exchange`). They are pure additions to the alert-preset list, with no engine changes.

1. **External email forwarding has been configured on a mailbox.** `Set-Mailbox` where `ForwardingSmtpAddress` is set. `ForwardingSmtpAddress` is the external (SMTP) forwarding field, so this targets forwarding to external accounts specifically (internal `ForwardingAddress`-only changes won't match). It is distinct from the existing inbox-rule forwarding presets, because it catches mailbox-level forwarding set by an admin or attacker.

2. **A user has been granted Exchange admin privileges.** `Add-RoleGroupMember`, i.e. someone added to an Exchange role group such as Organization Management. This is the Exchange-side complement to the existing Azure AD "added to an admin role" preset (`Add member to role.`), which does not cover Exchange role groups.

## What's not in this PR

The other three requested alerts (tenant restricted from sending, suspicious sending patterns, sending limit exceeded) are outbound-spam (Defender for Office 365) alerts that are not carried in `Audit.AzureActiveDirectory` or `Audit.Exchange`, the only two content types the audit-log webhook ingestion requests (`Get-CIPPAuditLogContentBundles.ps1`, `[ValidateSet('Audit.AzureActiveDirectory','Audit.Exchange')]`). Those need a separate decision (opening up `Audit.General`, or surfacing them another way), so I have kept them out of this PR. Happy to follow up on the right approach for them separately.

## Testing

No live tenant required. I verified it locally with a logic harness that dot-sources the real `Test-CIPPConditionFilter` and rebuilds the where-block the same way `Test-CIPPAuditLogRules` does, then runs representative flattened audit records through both presets:

- external SMTP forward (`Set-Mailbox` with `ForwardingSmtpAddress`): matches
- `Set-Mailbox` with no forwarding, or internal-only `ForwardingAddress`: no match
- inbox-rule forward (a different operation): no match
- `Add-RoleGroupMember`: matches; an unrelated operation and the Azure AD directory-role add: no match

Generated where-clauses:
- `$($_.Operation) -eq 'Set-Mailbox' -and $($_.ForwardingSmtpAddress) -like '*@*'`
- `$($_.Operation) -eq 'Add-RoleGroupMember'`

I also confirmed it against a real M365 tenant's unified audit log: an actual role-group membership add is recorded with `Operation = "Add-RoleGroupMember"`, which matches preset 2. One note for maintainers: a cmdlet add logs `Add-RoleGroupMember` and a cmdlet remove logs `Remove-RoleGroupMember`, but the EAC GUI appears to log `Update-RoleGroupMember` (it does a set-based replace), so a GUI-driven grant would not match preset 2 as written. Happy to broaden the preset to also match `Update-RoleGroupMember` if you would prefer, though that would also fire on GUI-driven removals, so I left it out pending your call.
