### PR TITLE
Fix: Fix unnecessary re-renders and crash in secure score table overview

### DIFF
--- a/src/components/CippTable/CippDataTable.js
+++ b/src/components/CippTable/CippDataTable.js
@@ -81,6 +81,10 @@ const compareNullable = (aVal, bVal) => {
 // These never change between renders, so extracting them avoids creating new
 // object references on every render cycle.
 
+// Stable ref so an undefined `data` prop doesn't create a fresh [] each render
+// and loop the static-data sync effect.
+const EMPTY_ARRAY = []
+
 const SORTING_FNS = {
   dateTimeNullsLast: (a, b, id) => {
     const aRaw = getRowValueByColumnId(a, id)
@@ -328,7 +332,7 @@ function renderColumnFilterModeMenuItemsFn({ internalFilterOptions, onSelectFilt
 export const CippDataTable = (props) => {
   const {
     queryKey,
-    data = [],
+    data = EMPTY_ARRAY,
     columns = [],
     api = {},
     isFetching = false,


### PR DESCRIPTION
Prevent unnecessary re-renders by using a stable reference for the `data` prop, which also fixes a crash that occurred when switching to the secure score table overview page before data finished loading.

Probably fixes a few more things across CIPP, but idk