### PR TITLE
feat: bulk remove mailbox permissions

### DIFF
--- a/src/pages/email/reports/mailbox-permissions/index.js
+++ b/src/pages/email/reports/mailbox-permissions/index.js
@@ -6,123 +6,6 @@ import { Stack } from '@mui/system'
 import { Person, Inbox, Delete } from '@mui/icons-material'
 import { useCippReportDB } from '../../../../components/CippComponents/CippReportDBControls'
 
-const byMailboxActions = [
-  {
-    label: 'Bulk Remove Mailbox Permissions',
-    type: 'POST',
-    url: '/api/ExecModifyMBPerms',
-    icon: <Delete />,
-    confirmText: 'Remove the selected permissions from the selected mailboxes?',
-    multiPost: false,
-    fields: [
-      {
-        type: 'autoComplete',
-        name: 'permissionsToRemove',
-        label: 'Permissions to remove',
-        multiple: true,
-        creatable: false,
-        required: true,
-        options: (rows) => {
-          const rowArray = Array.isArray(rows) ? rows : [rows]
-          const seen = new Set()
-          const options = []
-          rowArray.forEach((row) =>
-            (row?.Permissions ?? []).forEach((p) => {
-              const key = `${p.User}|${p.AccessRights}`
-              if (!seen.has(key)) {
-                seen.add(key)
-                options.push({ label: `${p.User} — ${p.AccessRights}`, value: key })
-              }
-            })
-          )
-          return options
-        },
-      },
-    ],
-    customDataformatter: (rows, action, formData) => {
-      const rowArray = Array.isArray(rows) ? rows : [rows]
-      const selected = new Set((formData.permissionsToRemove ?? []).map((o) => o.value))
-      // Group per tenant; only remove grants each mailbox actually has
-      const byTenant = {}
-      rowArray.forEach((mailbox) => {
-        const permissions = (mailbox.Permissions ?? [])
-          .filter((p) => selected.has(`${p.User}|${p.AccessRights}`))
-          .map((p) => ({
-            UserID: p.User,
-            PermissionLevel: p.AccessRights,
-            Modification: 'Remove',
-          }))
-        if (!permissions.length) return
-        ;(byTenant[mailbox.Tenant] ??= []).push({ userID: mailbox.MailboxUPN, permissions })
-      })
-      // Array return => one POST per tenant, so AllTenants selections work
-      return Object.entries(byTenant).map(([tenantFilter, mailboxRequests]) => ({
-        mailboxRequests,
-        tenantFilter,
-      }))
-    },
-  },
-]
-
-const byUserActions = [
-  {
-    label: 'Bulk Remove Mailbox Permissions',
-    type: 'POST',
-    url: '/api/ExecModifyMBPerms',
-    icon: <Delete />,
-    confirmText: "Remove the selected users' permissions from the selected mailboxes?",
-    multiPost: false,
-    fields: [
-      {
-        type: 'autoComplete',
-        name: 'permissionsToRemove',
-        label: 'Mailbox permissions to remove',
-        multiple: true,
-        creatable: false,
-        required: true,
-        options: (rows) => {
-          const rowArray = Array.isArray(rows) ? rows : [rows]
-          const seen = new Set()
-          const options = []
-          rowArray.forEach((row) =>
-            (row?.Permissions ?? []).forEach((p) => {
-              const key = `${p.MailboxUPN}|${p.AccessRights}`
-              if (!seen.has(key)) {
-                seen.add(key)
-                options.push({ label: `${p.MailboxUPN} — ${p.AccessRights}`, value: key })
-              }
-            })
-          )
-          return options
-        },
-      },
-    ],
-    customDataformatter: (rows, action, formData) => {
-      const rowArray = Array.isArray(rows) ? rows : [rows]
-      const selected = new Set((formData.permissionsToRemove ?? []).map((o) => o.value))
-      // Group per tenant; strip each selected user from the chosen mailboxes only
-      const byTenant = {}
-      rowArray.forEach((user) => {
-        ;(user.Permissions ?? [])
-          .filter((p) => selected.has(`${p.MailboxUPN}|${p.AccessRights}`))
-          .forEach((p) => {
-            ;(byTenant[user.Tenant] ??= []).push({
-              userID: p.MailboxUPN,
-              permissions: [
-                { UserID: user.User, PermissionLevel: p.AccessRights, Modification: 'Remove' },
-              ],
-            })
-          })
-      })
-      // Array return => one POST per tenant, so AllTenants selections work
-      return Object.entries(byTenant).map(([tenantFilter, mailboxRequests]) => ({
-        mailboxRequests,
-        tenantFilter,
-      }))
-    },
-  },
-]
-
 const Page = () => {
   const [byUser, setByUser] = useState(true)
 
@@ -136,6 +19,131 @@ const Page = () => {
     defaultCached: true,
     cacheColumns: ['MailboxCacheTimestamp', 'PermissionCacheTimestamp'],
   })
+
+  // Refetch both views after a removal — the endpoint now syncs the cached report
+  const relatedQueryKeys = [
+    `${reportDB.resolvedQueryKey}-true`,
+    `${reportDB.resolvedQueryKey}-false`,
+  ]
+
+  const byMailboxActions = [
+    {
+      label: 'Bulk Remove Mailbox Permissions',
+      type: 'POST',
+      url: '/api/ExecModifyMBPerms',
+      icon: <Delete />,
+      confirmText: 'Remove the selected permissions from the selected mailboxes?',
+      multiPost: false,
+      relatedQueryKeys,
+      fields: [
+        {
+          type: 'autoComplete',
+          name: 'permissionsToRemove',
+          label: 'Permissions to remove',
+          multiple: true,
+          creatable: false,
+          required: true,
+          options: (rows) => {
+            const rowArray = Array.isArray(rows) ? rows : [rows]
+            const seen = new Set()
+            const options = []
+            rowArray.forEach((row) =>
+              (row?.Permissions ?? []).forEach((p) => {
+                const key = `${p.User}|${p.AccessRights}`
+                if (!seen.has(key)) {
+                  seen.add(key)
+                  options.push({ label: `${p.User} — ${p.AccessRights}`, value: key })
+                }
+              })
+            )
+            return options
+          },
+        },
+      ],
+      customDataformatter: (rows, action, formData) => {
+        const rowArray = Array.isArray(rows) ? rows : [rows]
+        const selected = new Set((formData.permissionsToRemove ?? []).map((o) => o.value))
+        // Group per tenant; only remove grants each mailbox actually has
+        const byTenant = {}
+        rowArray.forEach((mailbox) => {
+          const permissions = (mailbox.Permissions ?? [])
+            .filter((p) => selected.has(`${p.User}|${p.AccessRights}`))
+            .map((p) => ({
+              UserID: p.User,
+              PermissionLevel: p.AccessRights,
+              Modification: 'Remove',
+            }))
+          if (!permissions.length) return
+          ;(byTenant[mailbox.Tenant] ??= []).push({ userID: mailbox.MailboxUPN, permissions })
+        })
+        // Array return => one POST per tenant, so AllTenants selections work
+        return Object.entries(byTenant).map(([tenantFilter, mailboxRequests]) => ({
+          mailboxRequests,
+          tenantFilter,
+        }))
+      },
+    },
+  ]
+
+  const byUserActions = [
+    {
+      label: 'Bulk Remove Mailbox Permissions',
+      type: 'POST',
+      url: '/api/ExecModifyMBPerms',
+      icon: <Delete />,
+      confirmText: "Remove the selected users' permissions from the selected mailboxes?",
+      multiPost: false,
+      relatedQueryKeys,
+      fields: [
+        {
+          type: 'autoComplete',
+          name: 'permissionsToRemove',
+          label: 'Mailbox permissions to remove',
+          multiple: true,
+          creatable: false,
+          required: true,
+          options: (rows) => {
+            const rowArray = Array.isArray(rows) ? rows : [rows]
+            const seen = new Set()
+            const options = []
+            rowArray.forEach((row) =>
+              (row?.Permissions ?? []).forEach((p) => {
+                const key = `${p.MailboxUPN}|${p.AccessRights}`
+                if (!seen.has(key)) {
+                  seen.add(key)
+                  options.push({ label: `${p.MailboxUPN} — ${p.AccessRights}`, value: key })
+                }
+              })
+            )
+            return options
+          },
+        },
+      ],
+      customDataformatter: (rows, action, formData) => {
+        const rowArray = Array.isArray(rows) ? rows : [rows]
+        const selected = new Set((formData.permissionsToRemove ?? []).map((o) => o.value))
+        // Group per tenant; strip each selected user from the chosen mailboxes only
+        const byTenant = {}
+        rowArray.forEach((user) => {
+          ;(user.Permissions ?? [])
+            .filter((p) => selected.has(`${p.MailboxUPN}|${p.AccessRights}`))
+            .forEach((p) => {
+              ;(byTenant[user.Tenant] ??= []).push({
+                userID: p.MailboxUPN,
+                permissions: [
+                  { UserID: user.User, PermissionLevel: p.AccessRights, Modification: 'Remove' },
+                ],
+              })
+            })
+        })
+        // Array return => one POST per tenant, so AllTenants selections work
+        return Object.entries(byTenant).map(([tenantFilter, mailboxRequests]) => ({
+          mailboxRequests,
+          tenantFilter,
+        }))
+      },
+    },
+  ]
 
   const columns = byUser
     ? [

--- a/src/pages/email/reports/mailbox-permissions/index.js
+++ b/src/pages/email/reports/mailbox-permissions/index.js
@@ -3,8 +3,125 @@ import { CippTablePage } from '../../../../components/CippComponents/CippTablePa
 import { useState } from 'react'
 import { Tooltip, Chip } from '@mui/material'
 import { Stack } from '@mui/system'
-import { Person, Inbox } from '@mui/icons-material'
+import { Person, Inbox, Delete } from '@mui/icons-material'
 import { useCippReportDB } from '../../../../components/CippComponents/CippReportDBControls'
+
+const byMailboxActions = [
+  {
+    label: 'Bulk Remove Mailbox Permissions',
+    type: 'POST',
+    url: '/api/ExecModifyMBPerms',
+    icon: <Delete />,
+    confirmText: 'Remove the selected permissions from the selected mailboxes?',
+    multiPost: false,
+    fields: [
+      {
+        type: 'autoComplete',
+        name: 'permissionsToRemove',
+        label: 'Permissions to remove',
+        multiple: true,
+        creatable: false,
+        required: true,
+        options: (rows) => {
+          const rowArray = Array.isArray(rows) ? rows : [rows]
+          const seen = new Set()
+          const options = []
+          rowArray.forEach((row) =>
+            (row?.Permissions ?? []).forEach((p) => {
+              const key = `${p.User}|${p.AccessRights}`
+              if (!seen.has(key)) {
+                seen.add(key)
+                options.push({ label: `${p.User} — ${p.AccessRights}`, value: key })
+              }
+            })
+          )
+          return options
+        },
+      },
+    ],
+    customDataformatter: (rows, action, formData) => {
+      const rowArray = Array.isArray(rows) ? rows : [rows]
+      const selected = new Set((formData.permissionsToRemove ?? []).map((o) => o.value))
+      // Group per tenant; only remove grants each mailbox actually has
+      const byTenant = {}
+      rowArray.forEach((mailbox) => {
+        const permissions = (mailbox.Permissions ?? [])
+          .filter((p) => selected.has(`${p.User}|${p.AccessRights}`))
+          .map((p) => ({
+            UserID: p.User,
+            PermissionLevel: p.AccessRights,
+            Modification: 'Remove',
+          }))
+        if (!permissions.length) return
+        ;(byTenant[mailbox.Tenant] ??= []).push({ userID: mailbox.MailboxUPN, permissions })
+      })
+      // Array return => one POST per tenant, so AllTenants selections work
+      return Object.entries(byTenant).map(([tenantFilter, mailboxRequests]) => ({
+        mailboxRequests,
+        tenantFilter,
+      }))
+    },
+  },
+]
+
+const byUserActions = [
+  {
+    label: 'Bulk Remove Mailbox Permissions',
+    type: 'POST',
+    url: '/api/ExecModifyMBPerms',
+    icon: <Delete />,
+    confirmText: "Remove the selected users' permissions from the selected mailboxes?",
+    multiPost: false,
+    fields: [
+      {
+        type: 'autoComplete',
+        name: 'permissionsToRemove',
+        label: 'Mailbox permissions to remove',
+        multiple: true,
+        creatable: false,
+        required: true,
+        options: (rows) => {
+          const rowArray = Array.isArray(rows) ? rows : [rows]
+          const seen = new Set()
+          const options = []
+          rowArray.forEach((row) =>
+            (row?.Permissions ?? []).forEach((p) => {
+              const key = `${p.MailboxUPN}|${p.AccessRights}`
+              if (!seen.has(key)) {
+                seen.add(key)
+                options.push({ label: `${p.MailboxUPN} — ${p.AccessRights}`, value: key })
+              }
+            })
+          )
+          return options
+        },
+      },
+    ],
+    customDataformatter: (rows, action, formData) => {
+      const rowArray = Array.isArray(rows) ? rows : [rows]
+      const selected = new Set((formData.permissionsToRemove ?? []).map((o) => o.value))
+      // Group per tenant; strip each selected user from the chosen mailboxes only
+      const byTenant = {}
+      rowArray.forEach((user) => {
+        ;(user.Permissions ?? [])
+          .filter((p) => selected.has(`${p.MailboxUPN}|${p.AccessRights}`))
+          .forEach((p) => {
+            ;(byTenant[user.Tenant] ??= []).push({
+              userID: p.MailboxUPN,
+              permissions: [
+                { UserID: user.User, PermissionLevel: p.AccessRights, Modification: 'Remove' },
+              ],
+            })
+          })
+      })
+      // Array return => one POST per tenant, so AllTenants selections work
+      return Object.entries(byTenant).map(([tenantFilter, mailboxRequests]) => ({
+        mailboxRequests,
+        tenantFilter,
+      }))
+    },
+  },
+]
 
 const Page = () => {
   const [byUser, setByUser] = useState(true)
@@ -69,6 +186,7 @@ const Page = () => {
         queryKey={`${reportDB.resolvedQueryKey}-${byUser}`}
         apiData={{ ...reportDB.resolvedApiData, ByUser: byUser }}
         simpleColumns={columns}
+        actions={byUser ? byUserActions : byMailboxActions}
         cardButton={pageActions}
         offCanvas={null}
       />

--- a/src/pages/identity/administration/users/user/exchange.jsx
+++ b/src/pages/identity/administration/users/user/exchange.jsx
@@ -73,7 +73,10 @@ const Page = () => {
   });
 
   const mailboxAccessRequest = ApiGetCall({
-    url: `/api/ListMailboxPermissions?tenantFilter=${userSettingsDefaults.currentTenant}&UseReportDB=true&ByUser=true&User=${graphUserRequest.data?.[0]?.userPrincipalName}`,
+    // Encode the UPN - guest UPNs contain #EXT#, which would truncate the query string
+    url: `/api/ListMailboxPermissions?tenantFilter=${userSettingsDefaults.currentTenant}&UseReportDB=true&ByUser=true&User=${encodeURIComponent(
+      graphUserRequest.data?.[0]?.userPrincipalName ?? "",
+    )}`,
     queryKey: `MailboxAccess-${userId}`,
     waiting: waiting && !!graphUserRequest.data?.[0]?.userPrincipalName,
   });
@@ -702,8 +705,9 @@ const Page = () => {
         ),
       },
       text: "Mailbox Access",
-      subtext:
-        mailboxAccessData.length !== 0
+      subtext: mailboxAccessRequest.isError
+        ? "Could not load the cached permission report - sync the mailbox permissions cache and try again"
+        : mailboxAccessData.length !== 0
           ? "This user has access to other mailboxes (from the cached permission report)"
           : "This user has no access to other mailboxes (from the cached permission report)",
       statusColor: "green.main",

--- a/src/pages/identity/administration/users/user/exchange.jsx
+++ b/src/pages/identity/administration/users/user/exchange.jsx
@@ -72,6 +72,12 @@ const Page = () => {
     waiting: waiting && !!graphUserRequest.data?.[0]?.userPrincipalName,
   });
 
+  const mailboxAccessRequest = ApiGetCall({
+    url: `/api/ListMailboxPermissions?tenantFilter=${userSettingsDefaults.currentTenant}&UseReportDB=true&ByUser=true&User=${graphUserRequest.data?.[0]?.userPrincipalName}`,
+    queryKey: `MailboxAccess-${userId}`,
+    waiting: waiting && !!graphUserRequest.data?.[0]?.userPrincipalName,
+  });
+
   const usersList = ApiGetCall({
     url: "/api/ListGraphRequest",
     data: {
@@ -649,6 +655,66 @@ const Page = () => {
             );
           },
         },
+      },
+    },
+  ];
+
+  const mailboxAccessActions = [
+    {
+      label: "Remove Permission",
+      type: "POST",
+      icon: <Delete />,
+      url: "/api/ExecModifyMBPerms",
+      customDataformatter: (row, action, formData) => {
+        const rowArray = Array.isArray(row) ? row : [row];
+        return {
+          mailboxRequests: rowArray.map((r) => ({
+            userID: r.MailboxUPN,
+            permissions: [
+              {
+                UserID: graphUserRequest.data?.[0]?.userPrincipalName,
+                PermissionLevel: r.AccessRights,
+                Modification: "Remove",
+              },
+            ],
+          })),
+          tenantFilter: userSettingsDefaults.currentTenant,
+        };
+      },
+      confirmText: "Are you sure you want to remove this user's access to the selected mailboxes?",
+      multiPost: false,
+      relatedQueryKeys: [`MailboxAccess-${userId}`],
+    },
+  ];
+
+  const mailboxAccessData = mailboxAccessRequest.data?.[0]?.Permissions ?? [];
+
+  const mailboxAccessCard = [
+    {
+      id: 1,
+      cardLabelBox: {
+        cardLabelBoxHeader: mailboxAccessRequest.isFetching ? (
+          <CircularProgress size="25px" color="inherit" />
+        ) : mailboxAccessData.length !== 0 ? (
+          <Check />
+        ) : (
+          <Error />
+        ),
+      },
+      text: "Mailbox Access",
+      subtext:
+        mailboxAccessData.length !== 0
+          ? "This user has access to other mailboxes (from the cached permission report)"
+          : "This user has no access to other mailboxes (from the cached permission report)",
+      statusColor: "green.main",
+      table: {
+        title: "Mailbox Access",
+        hideTitle: true,
+        data: mailboxAccessData,
+        refreshFunction: () => mailboxAccessRequest.refetch(),
+        isFetching: mailboxAccessRequest.isFetching,
+        simpleColumns: ["Mailbox", "MailboxUPN", "AccessRights"],
+        actions: mailboxAccessActions,
       },
     },
   ];
@@ -1341,6 +1407,11 @@ const Page = () => {
                     <CippBannerListCard
                       isFetching={userRequest.isLoading}
                       items={permissions}
+                      isCollapsible={true}
+                    />
+                    <CippBannerListCard
+                      isFetching={mailboxAccessRequest.isLoading}
+                      items={mailboxAccessCard}
                       isCollapsible={true}
                     />
                     <CippBannerListCard


### PR DESCRIPTION
## Summary

- **Mailbox Permissions report page**: bulk "Remove Mailbox Permissions" action on both views. The dialog autocomplete is data-driven from the selected rows (unique user/mailbox + AccessRights pairs), so you can only remove grants that actually exist. By User view makes stripping a user out of every mailbox in the tenant a two-click job. Requests are grouped per tenant (one POST each), so AllTenants selections work.
- **User Exchange page**: new "Mailbox Access" card showing the mailboxes the user has access to (inverse of the existing Mailbox Permissions card), loaded from the cached permission report with a per-row/bulk Remove Permission action. The card refetches after removal and reflects the change immediately thanks to the companion API PR (KelvinTegelaar/CIPP-API#2125), which keeps the cached report in sync.

Guest UPNs (`#EXT#`) are URL-encoded in the report query, and a failed/unsynced report shows an error hint instead of "no access".

## Companion PR

Requires KelvinTegelaar/CIPP-API#2125 (`User` filter on `ListMailboxPermissions` + cache sync in `ExecModifyMBPerms`). Without it the card falls back to showing an empty/error state and the report stays stale until the next cache sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)