### PR TITLE
feat(bec): show recent inbox rule changes

### DIFF
--- a/src/components/BECRemediationReportButton.js
+++ b/src/components/BECRemediationReportButton.js
@@ -437,6 +437,7 @@ const BECRemediationReportDocument = ({
   // Calculate statistics
   const stats = {
     newRules: becData?.NewRules?.length || 0,
+    ruleChanges: becData?.InboxRuleChanges?.length || 0,
     newUsers: becData?.NewUsers?.length || 0,
     newApps: becData?.AddedApps?.length || 0,
     permissionChanges: becData?.MailboxPermissionChanges?.length || 0,
@@ -448,6 +449,7 @@ const BECRemediationReportDocument = ({
   const calculateThreatLevel = () => {
     let threatScore = 0
     if (stats.newRules > 0) threatScore += 3
+    if (stats.ruleChanges > 0) threatScore += 3
     if (stats.permissionChanges > 0) threatScore += 2
     if (stats.newApps > 0) threatScore += 2
     if (stats.newUsers > 5) threatScore += 1
@@ -738,7 +740,7 @@ const BECRemediationReportDocument = ({
             </Text>
           </View>
 
-          {stats.newRules > 0 ? (
+          {stats.newRules > 0 && (
             <>
               <View style={styles.alertBox}>
                 <Text style={styles.alertTitle}>⚠ {stats.newRules} Mailbox Rule(s) Found</Text>
@@ -758,6 +760,7 @@ const BECRemediationReportDocument = ({
                     {rule.MoveToFolder && `Moves to: ${rule.MoveToFolder}`}
                     {rule.ForwardTo && `\nForwards to: ${rule.ForwardTo}`}
                     {rule.DeleteMessage && '\nDeletes messages'}
+                    {rule.RecentlyChanged && '\nCreated or changed in the last 7 days'}
                   </Text>
                 </View>
               ))}
@@ -767,7 +770,42 @@ const BECRemediationReportDocument = ({
                 </Text>
               )}
             </>
-          ) : (
+          )}
+          {stats.ruleChanges > 0 && (
+            <>
+              <View style={styles.alertBox}>
+                <Text style={styles.alertTitle}>
+                  ⚠ {stats.ruleChanges} Rule Change(s) in the Last 7 Days
+                </Text>
+                <Text style={styles.alertText}>
+                  The audit log recorded inbox rules being created, changed or removed on this
+                  mailbox. Rules that were removed after use are a common way for attackers to cover
+                  their tracks.
+                </Text>
+              </View>
+
+              {becData.InboxRuleChanges.slice(0, 10).map((change, index) => (
+                <View key={index} style={styles.infoBox}>
+                  <Text style={styles.infoTitle}>
+                    {change.Operation || 'Rule Change'}: {change.RuleName || 'Unnamed Rule'}
+                  </Text>
+                  <Text style={styles.infoText}>
+                    Date: {change.Date || 'Unknown'}
+                    {'\n'}
+                    By: {change.UserKey || 'Unknown'}
+                    {change.Parameters && `\nParameters: ${change.Parameters}`}
+                  </Text>
+                </View>
+              ))}
+              {becData.InboxRuleChanges.length > 10 && (
+                <Text style={[styles.infoText, { marginLeft: 12, fontStyle: 'italic' }]}>
+                  ... and {becData.InboxRuleChanges.length - 10} more changes (see JSON export for
+                  full list)
+                </Text>
+              )}
+            </>
+          )}
+          {stats.newRules === 0 && stats.ruleChanges === 0 && (
             <View style={[styles.infoBox, { backgroundColor: '#F0FDF4' }]}>
               <Text style={[styles.infoTitle, { color: '#22543D' }]}>
                 ✓ No Suspicious Rules Found
@@ -1343,6 +1381,8 @@ const BECRemediationReportDocument = ({
               Threat Level: {threatLevel.level}
               {'\n'}
               Mailbox Rules Found: {stats.newRules}
+              {'\n'}
+              Rule Changes: {stats.ruleChanges}
               {'\n'}
               Permission Changes: {stats.permissionChanges}
               {'\n'}

--- a/src/pages/identity/administration/users/user/bec.jsx
+++ b/src/pages/identity/administration/users/user/bec.jsx
@@ -108,7 +108,14 @@ const Page = () => {
       if (hasPotentialBreach) {
         return "Potential Breach found. The rules for this user contain classic signs of a breach.";
       }
+      const recentCount = becPollingCall.data.NewRules.filter((rule) => rule.RecentlyChanged).length;
+      if (recentCount > 0) {
+        return `Rules have been found, ${recentCount} of which were created or changed in the last 7 days. Please review the list below and take action as needed.`;
+      }
       return "Rules have been found. Please review the list below and take action as needed.";
+    }
+    if (becPollingCall.data.InboxRuleChanges && becPollingCall.data.InboxRuleChanges.length > 0) {
+      return "No rules currently exist on the mailbox, but rules were created, changed or removed in the last 7 days. Please review the changes below.";
     }
     return "No new rules found.";
   };
@@ -300,8 +307,8 @@ const Page = () => {
                       <Box>Check 1: Mailbox Rules</Box>
                       <Stack direction="row" spacing={2}>
                         {becPollingCall.data &&
-                        becPollingCall.data.NewRules &&
-                        becPollingCall.data.NewRules.length > 0 ? (
+                        (becPollingCall.data.NewRules?.length > 0 ||
+                          becPollingCall.data.InboxRuleChanges?.length > 0) ? (
                           <SvgIcon color="success">
                             <CheckCircle />
                           </SvgIcon>
@@ -323,11 +330,40 @@ const Page = () => {
                     becPollingCall.data.NewRules.length > 0 && (
                       <Box mt={2}>
                         <PropertyList>
-                          {becPollingCall.data.NewRules.map((rule, index) => (
+                          {[...becPollingCall.data.NewRules]
+                            .sort(
+                              (a, b) =>
+                                (b?.RecentlyChanged === true) - (a?.RecentlyChanged === true),
+                            )
+                            .map((rule, index) => (
+                              <PropertyListItem
+                                key={index}
+                                label={
+                                  rule?.RecentlyChanged
+                                    ? `${rule?.Name} - changed in last 7 days`
+                                    : rule?.Name
+                                }
+                                value={rule?.Description}
+                              />
+                            ))}
+                        </PropertyList>
+                      </Box>
+                    )}
+                  {becPollingCall.data &&
+                    becPollingCall.data.InboxRuleChanges &&
+                    becPollingCall.data.InboxRuleChanges.length > 0 && (
+                      <Box mt={2}>
+                        <Typography variant="subtitle2" gutterBottom>
+                          Rule changes in the last 7 days
+                        </Typography>
+                        <PropertyList>
+                          {becPollingCall.data.InboxRuleChanges.map((change, index) => (
                             <PropertyListItem
                               key={index}
-                              label={rule?.Name}
-                              value={rule?.Description}
+                              label={`${change?.Operation} - ${change?.RuleName}`}
+                              value={`${change?.Date} by ${change?.UserKey}${
+                                change?.Parameters ? ` | ${change.Parameters}` : ""
+                              }`}
                             />
                           ))}
                         </PropertyList>


### PR DESCRIPTION
## Problem

The BEC page and PDF report only show inbox rules that **still exist** on the mailbox. Attackers commonly create a rule, use it, and delete it to cover their tracks — those rules were invisible in the investigation.

## Changes

Displays the new data from companion backend PR KelvinTegelaar/CIPP-API#2127:

**BEC page (`identity/administration/users/user/bec`)**
- New "Rule changes in the last 7 days" section listing `InboxRuleChanges` audit events (operation, rule name, date, actor, parameters).
- Rules flagged `RecentlyChanged` are sorted first and labelled "changed in last 7 days"; the check-1 summary message calls out how many.
- Check 1 now completes/warns correctly when no rules currently exist but rules were created/changed/removed recently.

**PDF remediation report (`BECRemediationReportButton`)**
- New alert section for rule changes (first 10, with overflow note pointing to the JSON export).
- `RecentlyChanged` note per surviving rule; rule changes add +3 to the threat score and appear in the summary stats.

## Notes

- Degrades gracefully against an older backend: without `InboxRuleChanges` the new sections simply don't render, so this is a soft dependency on the backend PR, not a merge blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)