### PR TITLE
fix: decouple JIT admin roles from GDAP and modernize Entra role names

### DIFF
--- a/src/data/GDAPRoles.json
+++ b/src/data/GDAPRoles.json
@@ -809,14 +809,6 @@
   },
   {
     "ExtensionData": {},
-    "Description": "Assign the Customer Delegated Admin Relationship Administrator role to users who need to accept, view, or terminate GDAP relationships with partners.",
-    "IsEnabled": true,
-    "IsSystem": true,
-    "Name": "Customer Delegated Admin Relationship Administrator",
-    "ObjectId": "fc8ad4e2-40e4-4724-8317-bcda7503ecbf"
-  },
-  {
-    "ExtensionData": {},
     "Description": "Assign the AI Administrator role to users who need to manage all aspects of Microsoft 365 Copilot, AI-related enterprise services, copilot agents, and view usage reports and service health dashboards.",
     "IsEnabled": true,
     "IsSystem": true,

--- a/src/data/GDAPRoles.json
+++ b/src/data/GDAPRoles.json
@@ -33,7 +33,7 @@
   },
   {
     "ExtensionData": {},
-    "Description": "Assign custom security attribute keys and values to supported Azure AD objects.",
+    "Description": "Assign custom security attribute keys and values to supported Microsoft Entra objects.",
     "IsEnabled": true,
     "IsSystem": true,
     "Name": "Attribute Assignment Administrator",
@@ -41,7 +41,7 @@
   },
   {
     "ExtensionData": {},
-    "Description": "Read custom security attribute keys and values for supported Azure AD objects.",
+    "Description": "Read custom security attribute keys and values for supported Microsoft Entra objects.",
     "IsEnabled": true,
     "IsSystem": true,
     "Name": "Attribute Assignment Reader",
@@ -169,7 +169,7 @@
   },
   {
     "ExtensionData": {},
-    "Description": "Full access to manage devices in Azure AD.",
+    "Description": "Full access to manage devices in Microsoft Entra ID.",
     "IsEnabled": true,
     "IsSystem": true,
     "Name": "Cloud Device Administrator",
@@ -185,7 +185,7 @@
   },
   {
     "ExtensionData": {},
-    "Description": "Can read and manage compliance configuration and reports in Azure AD and Microsoft 365.",
+    "Description": "Can read and manage compliance configuration and reports in Microsoft Entra ID and Microsoft 365.",
     "IsEnabled": true,
     "IsSystem": true,
     "Name": "Compliance Administrator",
@@ -249,7 +249,7 @@
   },
   {
     "ExtensionData": {},
-    "Description": "Only used by Azure AD Connect service.",
+    "Description": "Only used by Microsoft Entra Connect service.",
     "IsEnabled": true,
     "IsSystem": true,
     "Name": "Directory Synchronization Accounts",
@@ -377,7 +377,7 @@
   },
   {
     "ExtensionData": {},
-    "Description": "Can manage AD to Azure AD cloud provisioning, Azure AD Connect, and federation settings.",
+    "Description": "Can manage AD to Microsoft Entra cloud provisioning, Microsoft Entra Connect, and federation settings.",
     "IsEnabled": true,
     "IsSystem": true,
     "Name": "Hybrid Identity Administrator",
@@ -385,7 +385,7 @@
   },
   {
     "ExtensionData": {},
-    "Description": "Manage access using Azure AD for identity governance scenarios.",
+    "Description": "Manage access using Microsoft Entra ID for identity governance scenarios.",
     "IsEnabled": true,
     "IsSystem": true,
     "Name": "Identity Governance Administrator",
@@ -457,7 +457,7 @@
   },
   {
     "ExtensionData": {},
-    "Description": "Create and manage all aspects of workflows and tasks associated with Lifecycle Workflows in Azure AD.",
+    "Description": "Create and manage all aspects of workflows and tasks associated with Lifecycle Workflows in Microsoft Entra ID.",
     "IsEnabled": true,
     "IsSystem": true,
     "Name": "Lifecycle Workflows Administrator",
@@ -585,7 +585,7 @@
   },
   {
     "ExtensionData": {},
-    "Description": "Can manage role assignments in Azure AD, and all aspects of Privileged Identity Management.",
+    "Description": "Can manage role assignments in Microsoft Entra ID, and all aspects of Privileged Identity Management.",
     "IsEnabled": true,
     "IsSystem": true,
     "Name": "Privileged Role Administrator",
@@ -633,7 +633,7 @@
   },
   {
     "ExtensionData": {},
-    "Description": "Can read security information and reports in Azure AD and Office 365.",
+    "Description": "Can read security information and reports in Microsoft Entra ID and Office 365.",
     "IsEnabled": true,
     "IsSystem": true,
     "Name": "Security Reader",

--- a/src/data/GDAPRoles.json
+++ b/src/data/GDAPRoles.json
@@ -105,10 +105,10 @@
   },
   {
     "ExtensionData": {},
-    "Description": "Users assigned to this role are added to the local administrators group on Azure AD-joined devices.",
+    "Description": "Users assigned to this role are added to the local administrators group on Microsoft Entra joined devices.",
     "IsEnabled": true,
     "IsSystem": true,
-    "Name": "Azure AD Joined Device Local Administrator",
+    "Name": "Microsoft Entra Joined Device Local Administrator",
     "ObjectId": "9f06204d-73c1-4d4c-880a-6edb90606fd8"
   },
   {
@@ -177,10 +177,10 @@
   },
   {
     "ExtensionData": {},
-    "Description": "Can manage all aspects of Azure AD and Microsoft services that use Azure AD identities. This role was formerly known as Global Administrator.",
+    "Description": "Can manage all aspects of Microsoft Entra ID and Microsoft services that use Microsoft Entra identities.",
     "IsEnabled": true,
     "IsSystem": true,
-    "Name": "Company Administrator",
+    "Name": "Global Administrator",
     "ObjectId": "62e90394-69f5-4237-9190-012177145e10"
   },
   {
@@ -212,7 +212,7 @@
     "Description": "Can approve Microsoft support requests to access customer organizational data.",
     "IsEnabled": true,
     "IsSystem": true,
-    "Name": "Customer LockBox Access Approver",
+    "Name": "Customer Lockbox Access Approver",
     "ObjectId": "5c4f9dcd-47dc-4cf7-8c9a-9e4207cbfc91"
   },
   {
@@ -545,10 +545,10 @@
   },
   {
     "ExtensionData": {},
-    "Description": "Can manage all aspects of the Power BI product.",
+    "Description": "Manage all aspects of the Fabric and Power BI products.",
     "IsEnabled": true,
     "IsSystem": true,
-    "Name": "Power BI Administrator",
+    "Name": "Fabric Administrator",
     "ObjectId": "a9ea8996-122f-4c74-9520-8edcd192826c"
   },
   {

--- a/src/data/JitAdminRoles.json
+++ b/src/data/JitAdminRoles.json
@@ -180,9 +180,24 @@
     "Description": "Manage all aspects of Microsoft Edge."
   },
   {
+    "Name": "Entra Backup Administrator",
+    "ObjectId": "b6a27b2b-f905-4b2e-81b5-0d90e0ef1fdb",
+    "Description": "Manage all aspects of Microsoft Entra Backup, such as create recovery jobs and manage backup snapshots."
+  },
+  {
+    "Name": "Entra Backup Reader",
+    "ObjectId": "f42252d9-5400-4d7b-b9ef-cc582dbb8577",
+    "Description": "Read all aspects of Microsoft Entra Backup, such as list all preview jobs, recovery jobs, backup snapshots, and create preview jobs."
+  },
+  {
     "Name": "Exchange Administrator",
     "ObjectId": "29232cdf-9323-42fd-ade2-1d097af3e4de",
     "Description": "Can manage all aspects of the Exchange product."
+  },
+  {
+    "Name": "Exchange Backup Administrator",
+    "ObjectId": "49eb8f75-97e9-4e37-9b2b-6c3ebfcffa31",
+    "Description": "Back up and restore content (including granular restore) for Exchange in Microsoft 365 Backup."
   },
   {
     "Name": "Exchange Recipient Administrator",
@@ -295,6 +310,11 @@
     "Description": "Can read messages and updates for their organization in Office 365 Message Center only."
   },
   {
+    "Name": "Microsoft 365 Backup Administrator",
+    "ObjectId": "1707125e-0aa2-4d4d-8655-a7c786c76a25",
+    "Description": "Back up and restore content across supported services (SharePoint, OneDrive, and Exchange Online) in Microsoft 365 Backup."
+  },
+  {
     "Name": "Microsoft 365 Migration Administrator",
     "ObjectId": "8c8b803f-96e1-4129-9349-20738d9f9652",
     "Description": "Perform all migration functionality to migrate content to Microsoft 365 using Migration Manager."
@@ -403,6 +423,11 @@
     "Name": "SharePoint Administrator",
     "ObjectId": "f28a1f50-f6e7-4571-818b-6a12f2af6b6c",
     "Description": "Can manage all aspects of the SharePoint service."
+  },
+  {
+    "Name": "SharePoint Backup Administrator",
+    "ObjectId": "9d3e04ba-3ee4-4d1b-a3a7-9aef423a09be",
+    "Description": "Back up and restore content (including granular restore) for SharePoint and OneDrive in Microsoft 365 Backup."
   },
   {
     "Name": "SharePoint Embedded Administrator",

--- a/src/data/JitAdminRoles.json
+++ b/src/data/JitAdminRoles.json
@@ -70,11 +70,6 @@
     "Description": "Can create and manage the authentication methods policy, tenant-wide MFA settings, password protection policy, and verifiable credentials."
   },
   {
-    "Name": "Azure AD Joined Device Local Administrator",
-    "ObjectId": "9f06204d-73c1-4d4c-880a-6edb90606fd8",
-    "Description": "Users assigned to this role are added to the local administrators group on Azure AD-joined devices."
-  },
-  {
     "Name": "Azure DevOps Administrator",
     "ObjectId": "e3973bdf-4987-49ae-837a-ba8e231c7286",
     "Description": "Can manage Azure DevOps organization policy and settings."
@@ -115,11 +110,6 @@
     "Description": "Full access to manage devices in Azure AD."
   },
   {
-    "Name": "Company Administrator",
-    "ObjectId": "62e90394-69f5-4237-9190-012177145e10",
-    "Description": "Can manage all aspects of Azure AD and Microsoft services that use Azure AD identities. This role was formerly known as Global Administrator."
-  },
-  {
     "Name": "Compliance Administrator",
     "ObjectId": "17315797-102d-40b4-93e0-432062caca18",
     "Description": "Can read and manage compliance configuration and reports in Azure AD and Microsoft 365."
@@ -140,7 +130,7 @@
     "Description": "Assign the Customer Delegated Admin Relationship Administrator role to users who need to accept, view, or terminate GDAP relationships with partners."
   },
   {
-    "Name": "Customer LockBox Access Approver",
+    "Name": "Customer Lockbox Access Approver",
     "ObjectId": "5c4f9dcd-47dc-4cf7-8c9a-9e4207cbfc91",
     "Description": "Can approve Microsoft support requests to access customer organizational data."
   },
@@ -218,6 +208,16 @@
     "Name": "External Identity Provider Administrator",
     "ObjectId": "be2f45a1-457d-42af-a067-6ec1fa63bc45",
     "Description": "Can configure identity providers for use in direct federation."
+  },
+  {
+    "Name": "Fabric Administrator",
+    "ObjectId": "a9ea8996-122f-4c74-9520-8edcd192826c",
+    "Description": "Manage all aspects of the Fabric and Power BI products."
+  },
+  {
+    "Name": "Global Administrator",
+    "ObjectId": "62e90394-69f5-4237-9190-012177145e10",
+    "Description": "Can manage all aspects of Microsoft Entra ID and Microsoft services that use Microsoft Entra identities."
   },
   {
     "Name": "Global Reader",
@@ -320,6 +320,11 @@
     "Description": "Perform all migration functionality to migrate content to Microsoft 365 using Migration Manager."
   },
   {
+    "Name": "Microsoft Entra Joined Device Local Administrator",
+    "ObjectId": "9f06204d-73c1-4d4c-880a-6edb90606fd8",
+    "Description": "Users assigned to this role are added to the local administrators group on Microsoft Entra joined devices."
+  },
+  {
     "Name": "Microsoft Hardware Warranty Administrator",
     "ObjectId": "1501b917-7653-4ff9-a4b5-203eaf33784f",
     "Description": "Create and manage all aspects warranty claims and entitlements for Microsoft manufactured hardware, like Surface and HoloLens."
@@ -353,11 +358,6 @@
     "Name": "Permissions Management Administrator",
     "ObjectId": "af78dc32-cf4d-46f9-ba4e-4428526346b5",
     "Description": "Manage all aspects of Entra Permissions Management."
-  },
-  {
-    "Name": "Power BI Administrator",
-    "ObjectId": "a9ea8996-122f-4c74-9520-8edcd192826c",
-    "Description": "Can manage all aspects of the Power BI product."
   },
   {
     "Name": "Power Platform Administrator",

--- a/src/data/JitAdminRoles.json
+++ b/src/data/JitAdminRoles.json
@@ -1,0 +1,497 @@
+[
+  {
+    "Name": "AI Administrator",
+    "ObjectId": "d2562ede-74db-457e-a7b6-544e236ebb61",
+    "Description": "Assign the AI Administrator role to users who need to manage all aspects of Microsoft 365 Copilot, AI-related enterprise services, copilot agents, and view usage reports and service health dashboards."
+  },
+  {
+    "Name": "Application Administrator",
+    "ObjectId": "9b895d92-2cd3-44c7-9d02-a6ac2d5ea5c3",
+    "Description": "Can create and manage all aspects of app registrations and enterprise apps."
+  },
+  {
+    "Name": "Application Developer",
+    "ObjectId": "cf1c38e5-3621-4004-a7cb-879624dced7c",
+    "Description": "Can create application registrations independent of the 'Users can register applications' setting."
+  },
+  {
+    "Name": "Attack Payload Author",
+    "ObjectId": "9c6df0f2-1e7c-4dc3-b195-66dfbd24aa8f",
+    "Description": "Can create attack payloads that an administrator can initiate later."
+  },
+  {
+    "Name": "Attack Simulation Administrator",
+    "ObjectId": "c430b396-e693-46cc-96f3-db01bf8bb62a",
+    "Description": "Can create and manage all aspects of attack simulation campaigns."
+  },
+  {
+    "Name": "Attribute Assignment Administrator",
+    "ObjectId": "58a13ea3-c632-46ae-9ee0-9c0d43cd7f3d",
+    "Description": "Assign custom security attribute keys and values to supported Azure AD objects."
+  },
+  {
+    "Name": "Attribute Assignment Reader",
+    "ObjectId": "ffd52fa5-98dc-465c-991d-fc073eb59f8f",
+    "Description": "Read custom security attribute keys and values for supported Azure AD objects."
+  },
+  {
+    "Name": "Attribute Definition Administrator",
+    "ObjectId": "8424c6f0-a189-499e-bbd0-26c1753c96d4",
+    "Description": "Define and manage the definition of custom security attributes."
+  },
+  {
+    "Name": "Attribute Definition Reader",
+    "ObjectId": "1d336d2c-4ae8-42ef-9711-b3604ce3fc2c",
+    "Description": "Read the definition of custom security attributes."
+  },
+  {
+    "Name": "Attribute Log Administrator",
+    "ObjectId": "5b784334-f94b-471a-a387-e7219fc49ca2",
+    "Description": "Read audit logs and configure diagnostic settings for events related to custom security attributes."
+  },
+  {
+    "Name": "Attribute Log Reader",
+    "ObjectId": "9c99539d-8186-4804-835f-fd51ef9e2dcd",
+    "Description": "Read audit logs related to custom security attributes."
+  },
+  {
+    "Name": "Authentication Administrator",
+    "ObjectId": "c4e39bd9-1100-46d3-8c65-fb160da0071f",
+    "Description": "Allowed to view, set and reset authentication method information for any non-admin user."
+  },
+  {
+    "Name": "Authentication Extensibility Administrator",
+    "ObjectId": "25a516ed-2fa0-40ea-a2d0-12923a21473a",
+    "Description": "Customize sign in and sign up experiences for users by creating and managing custom authentication extensions."
+  },
+  {
+    "Name": "Authentication Policy Administrator",
+    "ObjectId": "0526716b-113d-4c15-b2c8-68e3c22b9f80",
+    "Description": "Can create and manage the authentication methods policy, tenant-wide MFA settings, password protection policy, and verifiable credentials."
+  },
+  {
+    "Name": "Azure AD Joined Device Local Administrator",
+    "ObjectId": "9f06204d-73c1-4d4c-880a-6edb90606fd8",
+    "Description": "Users assigned to this role are added to the local administrators group on Azure AD-joined devices."
+  },
+  {
+    "Name": "Azure DevOps Administrator",
+    "ObjectId": "e3973bdf-4987-49ae-837a-ba8e231c7286",
+    "Description": "Can manage Azure DevOps organization policy and settings."
+  },
+  {
+    "Name": "Azure Information Protection Administrator",
+    "ObjectId": "7495fdc4-34c4-4d15-a289-98788ce399fd",
+    "Description": "Can manage all aspects of the Azure Information Protection product."
+  },
+  {
+    "Name": "B2C IEF Keyset Administrator",
+    "ObjectId": "aaf43236-0c0d-4d5f-883a-6955382ac081",
+    "Description": "Can manage secrets for federation and encryption in the Identity Experience Framework (IEF)."
+  },
+  {
+    "Name": "B2C IEF Policy Administrator",
+    "ObjectId": "3edaf663-341e-4475-9f94-5c398ef6c070",
+    "Description": "Can create and manage trust framework policies in the Identity Experience Framework (IEF)."
+  },
+  {
+    "Name": "Billing Administrator",
+    "ObjectId": "b0f54661-2d74-4c50-afa3-1ec803f12efe",
+    "Description": "Can perform common billing related tasks like updating payment information."
+  },
+  {
+    "Name": "Cloud App Security Administrator",
+    "ObjectId": "892c5842-a9a6-463a-8041-72aa08ca3cf6",
+    "Description": "Can manage all aspects of the Cloud App Security product."
+  },
+  {
+    "Name": "Cloud Application Administrator",
+    "ObjectId": "158c047a-c907-4556-b7ef-446551a6b5f7",
+    "Description": "Can create and manage all aspects of app registrations and enterprise apps except App Proxy."
+  },
+  {
+    "Name": "Cloud Device Administrator",
+    "ObjectId": "7698a772-787b-4ac8-901f-60d6b08affd2",
+    "Description": "Full access to manage devices in Azure AD."
+  },
+  {
+    "Name": "Company Administrator",
+    "ObjectId": "62e90394-69f5-4237-9190-012177145e10",
+    "Description": "Can manage all aspects of Azure AD and Microsoft services that use Azure AD identities. This role was formerly known as Global Administrator."
+  },
+  {
+    "Name": "Compliance Administrator",
+    "ObjectId": "17315797-102d-40b4-93e0-432062caca18",
+    "Description": "Can read and manage compliance configuration and reports in Azure AD and Microsoft 365."
+  },
+  {
+    "Name": "Compliance Data Administrator",
+    "ObjectId": "e6d1a23a-da11-4be4-9570-befc86d067a7",
+    "Description": "Creates and manages compliance content."
+  },
+  {
+    "Name": "Conditional Access Administrator",
+    "ObjectId": "b1be1c3e-b65d-4f19-8427-f6fa0d97feb9",
+    "Description": "Can manage Conditional Access capabilities."
+  },
+  {
+    "Name": "Customer Delegated Admin Relationship Administrator",
+    "ObjectId": "fc8ad4e2-40e4-4724-8317-bcda7503ecbf",
+    "Description": "Assign the Customer Delegated Admin Relationship Administrator role to users who need to accept, view, or terminate GDAP relationships with partners."
+  },
+  {
+    "Name": "Customer LockBox Access Approver",
+    "ObjectId": "5c4f9dcd-47dc-4cf7-8c9a-9e4207cbfc91",
+    "Description": "Can approve Microsoft support requests to access customer organizational data."
+  },
+  {
+    "Name": "Desktop Analytics Administrator",
+    "ObjectId": "38a96431-2bdf-4b4c-8b6e-5d3d8abac1a4",
+    "Description": "Can access and manage Desktop management tools and services."
+  },
+  {
+    "Name": "Directory Readers",
+    "ObjectId": "88d8e3e3-8f55-4a1e-953a-9b9898b8876b",
+    "Description": "Can read basic directory information. Commonly used to grant directory read access to applications and guests."
+  },
+  {
+    "Name": "Directory Writers",
+    "ObjectId": "9360feb5-f418-4baa-8175-e2a00bac4301",
+    "Description": "Can read and write basic directory information. For granting access to applications, not intended for users."
+  },
+  {
+    "Name": "Domain Name Administrator",
+    "ObjectId": "8329153b-31d0-4727-b945-745eb3bc5f31",
+    "Description": "Can manage domain names in cloud and on-premises."
+  },
+  {
+    "Name": "Dynamics 365 Administrator",
+    "ObjectId": "44367163-eba1-44c3-98af-f5787879f96a",
+    "Description": "Can manage all aspects of the Dynamics 365 product."
+  },
+  {
+    "Name": "Dynamics 365 Business Central Administrator",
+    "ObjectId": "963797fb-eb3b-4cde-8ce3-5878b3f32a3f",
+    "Description": "Access and perform all administrative tasks on Dynamics 365 Business Central environments."
+  },
+  {
+    "Name": "Edge Administrator",
+    "ObjectId": "3f1acade-1e04-4fbc-9b69-f0302cd84aef",
+    "Description": "Manage all aspects of Microsoft Edge."
+  },
+  {
+    "Name": "Exchange Administrator",
+    "ObjectId": "29232cdf-9323-42fd-ade2-1d097af3e4de",
+    "Description": "Can manage all aspects of the Exchange product."
+  },
+  {
+    "Name": "Exchange Recipient Administrator",
+    "ObjectId": "31392ffb-586c-42d1-9346-e59415a2cc4e",
+    "Description": "Can create or update Exchange Online recipients within the Exchange Online organization."
+  },
+  {
+    "Name": "External ID User Flow Administrator",
+    "ObjectId": "6e591065-9bad-43ed-90f3-e9424366d2f0",
+    "Description": "Can create and manage all aspects of user flows."
+  },
+  {
+    "Name": "External ID User Flow Attribute Administrator",
+    "ObjectId": "0f971eea-41eb-4569-a71e-57bb8a3eff1e",
+    "Description": "Can create and manage the attribute schema available to all user flows."
+  },
+  {
+    "Name": "External Identity Provider Administrator",
+    "ObjectId": "be2f45a1-457d-42af-a067-6ec1fa63bc45",
+    "Description": "Can configure identity providers for use in direct federation."
+  },
+  {
+    "Name": "Global Reader",
+    "ObjectId": "f2ef992c-3afb-46b9-b7cf-a126ee74c451",
+    "Description": "Can read everything that a Global Administrator can, but not update anything."
+  },
+  {
+    "Name": "Global Secure Access Administrator",
+    "ObjectId": "ac434307-12b9-4fa1-a708-88bf58caabc1",
+    "Description": "Create and manage all aspects of Microsoft Entra Internet Access and Microsoft Entra Private Access, including managing access to public and private endpoints."
+  },
+  {
+    "Name": "Groups Administrator",
+    "ObjectId": "fdd7a751-b60b-444a-984c-02652fe8fa1c",
+    "Description": "Members of this role can create/manage groups, create/manage groups settings like naming and expiration policies, and view groups activity and audit reports."
+  },
+  {
+    "Name": "Guest Inviter",
+    "ObjectId": "95e79109-95c0-4d8e-aee3-d01accf2d47b",
+    "Description": "Can invite guest users independent of the 'members can invite guests' setting."
+  },
+  {
+    "Name": "Helpdesk Administrator",
+    "ObjectId": "729827e3-9c14-49f7-bb1b-9608f156bbb8",
+    "Description": "Can reset passwords for non-administrators and Helpdesk Administrators."
+  },
+  {
+    "Name": "Hybrid Identity Administrator",
+    "ObjectId": "8ac3fc64-6eca-42ea-9e69-59f4c7b60eb2",
+    "Description": "Can manage AD to Azure AD cloud provisioning, Azure AD Connect, and federation settings."
+  },
+  {
+    "Name": "Identity Governance Administrator",
+    "ObjectId": "45d8d3c5-c802-45c6-b32a-1d70b5e1e86e",
+    "Description": "Manage access using Azure AD for identity governance scenarios."
+  },
+  {
+    "Name": "Insights Administrator",
+    "ObjectId": "eb1f4a8d-243a-41f0-9fbd-c7cdf6c5ef7c",
+    "Description": "Has administrative access in the Microsoft 365 Insights app."
+  },
+  {
+    "Name": "Insights Analyst",
+    "ObjectId": "25df335f-86eb-4119-b717-0ff02de207e9",
+    "Description": "Access the analytical capabilities in Microsoft Viva Insights and run custom queries."
+  },
+  {
+    "Name": "Insights Business Leader",
+    "ObjectId": "31e939ad-9672-4796-9c2e-873181342d2d",
+    "Description": "Can view and share dashboards and insights via the M365 Insights app."
+  },
+  {
+    "Name": "Intune Administrator",
+    "ObjectId": "3a2c62db-5318-420d-8d74-23affee5d9d5",
+    "Description": "Can manage all aspects of the Intune product."
+  },
+  {
+    "Name": "Kaizala Administrator",
+    "ObjectId": "74ef975b-6605-40af-a5d2-b9539d836353",
+    "Description": "Can manage settings for Microsoft Kaizala."
+  },
+  {
+    "Name": "Knowledge Administrator",
+    "ObjectId": "b5a8dcf3-09d5-43a9-a639-8e29ef291470",
+    "Description": "Can configure knowledge, learning, and other intelligent features."
+  },
+  {
+    "Name": "Knowledge Manager",
+    "ObjectId": "744ec460-397e-42ad-a462-8b3f9747a02c",
+    "Description": "Has access to topic management dashboard and can manage content."
+  },
+  {
+    "Name": "License Administrator",
+    "ObjectId": "4d6ac14f-3453-41d0-bef9-a3e0c569773a",
+    "Description": "Can manage product licenses on users and groups."
+  },
+  {
+    "Name": "Lifecycle Workflows Administrator",
+    "ObjectId": "59d46f88-662b-457b-bceb-5c3809e5908f",
+    "Description": "Create and manage all aspects of workflows and tasks associated with Lifecycle Workflows in Azure AD."
+  },
+  {
+    "Name": "Message Center Privacy Reader",
+    "ObjectId": "ac16e43d-7b2d-40e0-ac05-243ff356ab5b",
+    "Description": "Can read security messages and updates in Office 365 Message Center only."
+  },
+  {
+    "Name": "Message Center Reader",
+    "ObjectId": "790c1fb9-7f7d-4f88-86a1-ef1f95c05c1b",
+    "Description": "Can read messages and updates for their organization in Office 365 Message Center only."
+  },
+  {
+    "Name": "Microsoft 365 Migration Administrator",
+    "ObjectId": "8c8b803f-96e1-4129-9349-20738d9f9652",
+    "Description": "Perform all migration functionality to migrate content to Microsoft 365 using Migration Manager."
+  },
+  {
+    "Name": "Microsoft Hardware Warranty Administrator",
+    "ObjectId": "1501b917-7653-4ff9-a4b5-203eaf33784f",
+    "Description": "Create and manage all aspects warranty claims and entitlements for Microsoft manufactured hardware, like Surface and HoloLens."
+  },
+  {
+    "Name": "Microsoft Hardware Warranty Specialist",
+    "ObjectId": "281fe777-fb20-4fbb-b7a3-ccebce5b0d96",
+    "Description": "Create and read warranty claims for Microsoft manufactured hardware, like Surface and HoloLens."
+  },
+  {
+    "Name": "Network Administrator",
+    "ObjectId": "d37c8bed-0711-4417-ba38-b4abe66ce4c2",
+    "Description": "Can manage network locations and review enterprise network design insights for Microsoft 365 Software as a Service applications."
+  },
+  {
+    "Name": "Office Apps Administrator",
+    "ObjectId": "2b745bdf-0803-4d80-aa65-822c4493daac",
+    "Description": "Can manage Office apps cloud services, including policy and settings management, and manage the ability to select, unselect and publish 'what's new' feature content to end-user's devices."
+  },
+  {
+    "Name": "Organizational Messages Writer",
+    "ObjectId": "507f53e4-4e52-4077-abd3-d2e1558b6ea2",
+    "Description": "Write, publish, manage, and review the organizational messages for end-users through Microsoft product surfaces."
+  },
+  {
+    "Name": "Password Administrator",
+    "ObjectId": "966707d0-3269-4727-9be2-8c3a10f19b9d",
+    "Description": "Can reset passwords for non-administrators and Password Administrators."
+  },
+  {
+    "Name": "Permissions Management Administrator",
+    "ObjectId": "af78dc32-cf4d-46f9-ba4e-4428526346b5",
+    "Description": "Manage all aspects of Entra Permissions Management."
+  },
+  {
+    "Name": "Power BI Administrator",
+    "ObjectId": "a9ea8996-122f-4c74-9520-8edcd192826c",
+    "Description": "Can manage all aspects of the Power BI product."
+  },
+  {
+    "Name": "Power Platform Administrator",
+    "ObjectId": "11648597-926c-4cf3-9c36-bcebb0ba8dcc",
+    "Description": "Can create and manage all aspects of Microsoft Dynamics 365, PowerApps and Microsoft Flow."
+  },
+  {
+    "Name": "Printer Administrator",
+    "ObjectId": "644ef478-e28f-4e28-b9dc-3fdde9aa0b1f",
+    "Description": "Can manage all aspects of printers and printer connectors."
+  },
+  {
+    "Name": "Printer Technician",
+    "ObjectId": "e8cef6f1-e4bd-4ea8-bc07-4b8d950f4477",
+    "Description": "Can manage all aspects of printers and printer connectors."
+  },
+  {
+    "Name": "Privileged Authentication Administrator",
+    "ObjectId": "7be44c8a-adaf-4e2a-84d6-ab2649e08a13",
+    "Description": "Allowed to view, set and reset authentication method information for any user (admin or non-admin)."
+  },
+  {
+    "Name": "Privileged Role Administrator",
+    "ObjectId": "e8611ab8-c189-46e8-94e1-60213ab1f814",
+    "Description": "Can manage role assignments in Azure AD, and all aspects of Privileged Identity Management."
+  },
+  {
+    "Name": "Reports Reader",
+    "ObjectId": "4a5d8f65-41da-4de4-8968-e035b65339cf",
+    "Description": "Can read sign-in and audit reports."
+  },
+  {
+    "Name": "Search Administrator",
+    "ObjectId": "0964bb5e-9bdb-4d7b-ac29-58e794862a40",
+    "Description": "Can create and manage all aspects of Microsoft Search settings."
+  },
+  {
+    "Name": "Search Editor",
+    "ObjectId": "8835291a-918c-4fd7-a9ce-faa49f0cf7d9",
+    "Description": "Can create and manage the editorial content such as bookmarks, Q and As, locations, floorplan."
+  },
+  {
+    "Name": "Security Administrator",
+    "ObjectId": "194ae4cb-b126-40b2-bd5b-6091b380977d",
+    "Description": "Security Administrator allows ability to read and manage security configuration and reports."
+  },
+  {
+    "Name": "Security Operator",
+    "ObjectId": "5f2222b1-57c3-48ba-8ad5-d4759f1fde6f",
+    "Description": "Creates and manages security events."
+  },
+  {
+    "Name": "Security Reader",
+    "ObjectId": "5d6b6bb7-de71-4623-b4af-96380a352509",
+    "Description": "Can read security information and reports in Azure AD and Office 365."
+  },
+  {
+    "Name": "Service Support Administrator",
+    "ObjectId": "f023fd81-a637-4b56-95fd-791ac0226033",
+    "Description": "Can read service health information and manage support tickets."
+  },
+  {
+    "Name": "SharePoint Administrator",
+    "ObjectId": "f28a1f50-f6e7-4571-818b-6a12f2af6b6c",
+    "Description": "Can manage all aspects of the SharePoint service."
+  },
+  {
+    "Name": "SharePoint Embedded Administrator",
+    "ObjectId": "1a7d78b6-429f-476b-8eb-35fb715fffd4",
+    "Description": "Manage all aspects of SharePoint Embedded containers."
+  },
+  {
+    "Name": "Skype for Business Administrator",
+    "ObjectId": "75941009-915a-4869-abe7-691bff18279e",
+    "Description": "Can manage all aspects of the Skype for Business product."
+  },
+  {
+    "Name": "Teams Administrator",
+    "ObjectId": "69091246-20e8-4a56-aa4d-066075b2a7a8",
+    "Description": "Can manage the Microsoft Teams service."
+  },
+  {
+    "Name": "Teams Communications Administrator",
+    "ObjectId": "baf37b3a-610e-45da-9e62-d9d1e5e8914b",
+    "Description": "Can manage calling and meetings features within the Microsoft Teams service."
+  },
+  {
+    "Name": "Teams Communications Support Engineer",
+    "ObjectId": "f70938a0-fc10-4177-9e90-2178f8765737",
+    "Description": "Can troubleshoot communications issues within Teams using advanced tools."
+  },
+  {
+    "Name": "Teams Communications Support Specialist",
+    "ObjectId": "fcf91098-03e3-41a9-b5ba-6f0ec8188a12",
+    "Description": "Can troubleshoot communications issues within Teams using basic tools."
+  },
+  {
+    "Name": "Teams Devices Administrator",
+    "ObjectId": "3d762c5a-1b6c-493f-843e-55a3b42923d4",
+    "Description": "Can perform management related tasks on Teams certified devices."
+  },
+  {
+    "Name": "Teams Telephony Administrator",
+    "ObjectId": "aa38014f-0993-46e9-9b45-30501a20909d",
+    "Description": "Manage voice and telephony features and troubleshoot communication issues within the Microsoft Teams service."
+  },
+  {
+    "Name": "Tenant Creator",
+    "ObjectId": "112ca1a2-15ad-4102-995e-45b0bc479a6a",
+    "Description": "Create new Microsoft Entra or Azure AD B2C tenants."
+  },
+  {
+    "Name": "Usage Summary Reports Reader",
+    "ObjectId": "75934031-6c7e-415a-99d7-48dbd49e875e",
+    "Description": "Can see only tenant level aggregates in Microsoft 365 Usage Analytics and Productivity Score."
+  },
+  {
+    "Name": "User Administrator",
+    "ObjectId": "fe930be7-5e62-47db-91af-98c3a49a38b1",
+    "Description": "Can manage all aspects of users and groups, including resetting passwords for limited admins."
+  },
+  {
+    "Name": "User Experience Success Manager",
+    "ObjectId": "27460883-1df1-4691-b032-3b79643e5e63",
+    "Description": "View product feedback, survey results, and reports to find training and communication opportunities."
+  },
+  {
+    "Name": "Virtual Visits Administrator",
+    "ObjectId": "e300d9e7-4a2b-4295-9eff-f1c78b36cc98",
+    "Description": "Manage and share Virtual Visits information and metrics from admin centers or the Virtual Visits app."
+  },
+  {
+    "Name": "Viva Goals Administrator",
+    "ObjectId": "92b086b3-e367-4ef2-b869-1de128fb986e",
+    "Description": "Manage and configure all aspects of Microsoft Viva Goals."
+  },
+  {
+    "Name": "Viva Pulse Administrator",
+    "ObjectId": "87761b17-1ed2-4af3-9acd-92a150038160",
+    "Description": "Can manage all settings for Microsoft Viva Pulse app."
+  },
+  {
+    "Name": "Windows 365 Administrator",
+    "ObjectId": "11451d60-acb2-45eb-a7d6-43d0f0125c13",
+    "Description": "Can provision and manage all aspects of Cloud PCs."
+  },
+  {
+    "Name": "Windows Update Deployment Administrator",
+    "ObjectId": "32696413-001a-46ae-978c-ce0f6b3620d2",
+    "Description": "Can create and manage all aspects of Windows Update deployments through the Windows Update for Business deployment service."
+  },
+  {
+    "Name": "Yammer Administrator",
+    "ObjectId": "810a2642-a034-447f-a5e8-41beaa378541",
+    "Description": "Manage all aspects of Yammer."
+  }
+]

--- a/src/data/JitAdminRoles.json
+++ b/src/data/JitAdminRoles.json
@@ -27,12 +27,12 @@
   {
     "Name": "Attribute Assignment Administrator",
     "ObjectId": "58a13ea3-c632-46ae-9ee0-9c0d43cd7f3d",
-    "Description": "Assign custom security attribute keys and values to supported Azure AD objects."
+    "Description": "Assign custom security attribute keys and values to supported Microsoft Entra objects."
   },
   {
     "Name": "Attribute Assignment Reader",
     "ObjectId": "ffd52fa5-98dc-465c-991d-fc073eb59f8f",
-    "Description": "Read custom security attribute keys and values for supported Azure AD objects."
+    "Description": "Read custom security attribute keys and values for supported Microsoft Entra objects."
   },
   {
     "Name": "Attribute Definition Administrator",
@@ -107,12 +107,12 @@
   {
     "Name": "Cloud Device Administrator",
     "ObjectId": "7698a772-787b-4ac8-901f-60d6b08affd2",
-    "Description": "Full access to manage devices in Azure AD."
+    "Description": "Full access to manage devices in Microsoft Entra ID."
   },
   {
     "Name": "Compliance Administrator",
     "ObjectId": "17315797-102d-40b4-93e0-432062caca18",
-    "Description": "Can read and manage compliance configuration and reports in Azure AD and Microsoft 365."
+    "Description": "Can read and manage compliance configuration and reports in Microsoft Entra ID and Microsoft 365."
   },
   {
     "Name": "Compliance Data Administrator",
@@ -247,12 +247,12 @@
   {
     "Name": "Hybrid Identity Administrator",
     "ObjectId": "8ac3fc64-6eca-42ea-9e69-59f4c7b60eb2",
-    "Description": "Can manage AD to Azure AD cloud provisioning, Azure AD Connect, and federation settings."
+    "Description": "Can manage AD to Microsoft Entra cloud provisioning, Microsoft Entra Connect, and federation settings."
   },
   {
     "Name": "Identity Governance Administrator",
     "ObjectId": "45d8d3c5-c802-45c6-b32a-1d70b5e1e86e",
-    "Description": "Manage access using Azure AD for identity governance scenarios."
+    "Description": "Manage access using Microsoft Entra ID for identity governance scenarios."
   },
   {
     "Name": "Insights Administrator",
@@ -297,7 +297,7 @@
   {
     "Name": "Lifecycle Workflows Administrator",
     "ObjectId": "59d46f88-662b-457b-bceb-5c3809e5908f",
-    "Description": "Create and manage all aspects of workflows and tasks associated with Lifecycle Workflows in Azure AD."
+    "Description": "Create and manage all aspects of workflows and tasks associated with Lifecycle Workflows in Microsoft Entra ID."
   },
   {
     "Name": "Message Center Privacy Reader",
@@ -382,7 +382,7 @@
   {
     "Name": "Privileged Role Administrator",
     "ObjectId": "e8611ab8-c189-46e8-94e1-60213ab1f814",
-    "Description": "Can manage role assignments in Azure AD, and all aspects of Privileged Identity Management."
+    "Description": "Can manage role assignments in Microsoft Entra ID, and all aspects of Privileged Identity Management."
   },
   {
     "Name": "Reports Reader",
@@ -412,7 +412,7 @@
   {
     "Name": "Security Reader",
     "ObjectId": "5d6b6bb7-de71-4623-b4af-96380a352509",
-    "Description": "Can read security information and reports in Azure AD and Office 365."
+    "Description": "Can read security information and reports in Microsoft Entra ID and Office 365."
   },
   {
     "Name": "Service Support Administrator",

--- a/src/pages/identity/administration/jit-admin-templates/add.jsx
+++ b/src/pages/identity/administration/jit-admin-templates/add.jsx
@@ -8,7 +8,7 @@ import { CippFormCondition } from "../../../../components/CippComponents/CippFor
 import { CippFormDomainSelector } from "../../../../components/CippComponents/CippFormDomainSelector";
 import { CippFormUserSelector } from "../../../../components/CippComponents/CippFormUserSelector";
 import { CippFormGroupSelector } from "../../../../components/CippComponents/CippFormGroupSelector";
-import gdaproles from "../../../../data/GDAPRoles.json";
+import jitAdminRoles from "../../../../data/JitAdminRoles.json";
 import countryList from "../../../../data/countryList.json";
 import { useSettings } from "../../../../hooks/use-settings";
 import { useEffect } from "react";
@@ -133,7 +133,7 @@ const Page = () => {
                   label="Default Roles"
                   name="defaultRoles"
                   creatable={false}
-                  options={gdaproles.map((role) => ({ label: role.Name, value: role.ObjectId }))}
+                  options={jitAdminRoles.map((role) => ({ label: role.Name, value: role.ObjectId }))}
                   formControl={formControl}
                   required={true}
                   validators={{

--- a/src/pages/identity/administration/jit-admin-templates/edit.jsx
+++ b/src/pages/identity/administration/jit-admin-templates/edit.jsx
@@ -8,7 +8,7 @@ import { CippFormCondition } from "../../../../components/CippComponents/CippFor
 import { CippFormDomainSelector } from "../../../../components/CippComponents/CippFormDomainSelector";
 import { CippFormUserSelector } from "../../../../components/CippComponents/CippFormUserSelector";
 import { CippFormGroupSelector } from "../../../../components/CippComponents/CippFormGroupSelector";
-import gdaproles from "../../../../data/GDAPRoles.json";
+import jitAdminRoles from "../../../../data/JitAdminRoles.json";
 import countryList from "../../../../data/countryList.json";
 import { useSettings } from "../../../../hooks/use-settings";
 import { useRouter } from "next/router";
@@ -156,7 +156,7 @@ const Page = () => {
                   label="Default Roles"
                   name="defaultRoles"
                   creatable={false}
-                  options={gdaproles.map((role) => ({ label: role.Name, value: role.ObjectId }))}
+                  options={jitAdminRoles.map((role) => ({ label: role.Name, value: role.ObjectId }))}
                   formControl={formControl}
                   required={true}
                   validators={{

--- a/src/pages/identity/administration/jit-admin/add.jsx
+++ b/src/pages/identity/administration/jit-admin/add.jsx
@@ -6,7 +6,7 @@ import { CippFormTenantSelector } from '../../../../components/CippComponents/Ci
 import { useForm, useWatch } from 'react-hook-form'
 import CippFormComponent from '../../../../components/CippComponents/CippFormComponent'
 import { CippFormCondition } from '../../../../components/CippComponents/CippFormCondition'
-import gdaproles from '../../../../data/GDAPRoles.json'
+import jitAdminRoles from '../../../../data/JitAdminRoles.json'
 import countryList from '../../../../data/countryList.json'
 import { CippFormDomainSelector } from '../../../../components/CippComponents/CippFormDomainSelector'
 import { CippFormUserSelector } from '../../../../components/CippComponents/CippFormUserSelector'
@@ -469,7 +469,7 @@ const Page = () => {
                   fullWidth
                   label="Roles"
                   name="adminRoles"
-                  options={gdaproles.map((role) => ({ label: role.Name, value: role.ObjectId }))}
+                  options={jitAdminRoles.map((role) => ({ label: role.Name, value: role.ObjectId }))}
                   formControl={formControl}
                   required={true}
                   validators={{

--- a/src/pages/tenant/gdap-management/onboarding/start.js
+++ b/src/pages/tenant/gdap-management/onboarding/start.js
@@ -418,7 +418,7 @@ const Page = () => {
                       (role) => role.roleDefinitionId === "62e90394-69f5-4237-9190-012177145e10"
                     ) && (
                       <Alert severity="warning">
-                        The Company Administrator role is a highly privileged role that should be
+                        The Global Administrator role is a highly privileged role that should be
                         used with caution. GDAP Relationships with this role will not be eligible
                         for auto-extend.
                       </Alert>

--- a/src/pages/tenant/gdap-management/roles/add.js
+++ b/src/pages/tenant/gdap-management/roles/add.js
@@ -205,7 +205,7 @@ const Page = () => {
               compareValue="62e90394-69f5-4237-9190-012177145e10"
             >
               <Alert severity="warning">
-                The Company Administrator role is a highly privileged role that should be used with
+                The Global Administrator role is a highly privileged role that should be used with
                 caution. GDAP Relationships with this role will not be eligible for auto-extend.
               </Alert>
             </CippFormCondition>


### PR DESCRIPTION
## Summary

JIT Admin and GDAP are two different things, but the UI treated them as one — the JIT role picker was populated from `src/data/GDAPRoles.json`. This PR decouples them, then modernizes the role data on both sides.

- **JIT Admin** assigns Microsoft Entra **directory roles directly** to a user in the tenant (`POST /directoryRoles(roleTemplateId=…)/members/$ref`). It has nothing to do with GDAP.
- **GDAP** delegates a *different* set of roles to a partner via the CSP relationship.

Sharing one list meant JIT offered roles that don't belong there, and the GDAP flow offered roles that GDAP can't actually delegate — role creep in both directions.

## Changes

### 1. Decouple JIT from the GDAP catalog
- Add a dedicated **`src/data/JitAdminRoles.json`** and point the three JIT pages (`jit-admin/add`, `jit-admin-templates/add`, `jit-admin-templates/edit`) at it.
- It's the assignable directory-role catalog **minus** the non-assignable/deprecated pseudo-roles: Device Join, Device Users, Workplace Device Join, Directory Synchronization Accounts.

### 2. Remove a non-delegatable role from the GDAP catalog
- Remove **Customer Delegated Admin Relationship Administrator** (`fc8ad4e2-40e4-4724-8317-bcda7503ecbf`) from `GDAPRoles.json`.
- **Why:** it's a *customer-side* role for accepting/viewing/terminating GDAP relationships with partners. It is **not GDAP-delegatable** and does not appear in the Partner Center "create GDAP relationship" role picker. Because CIPP's GDAP selector is served from `GDAPRoles.json`, leaving it there offered an option GDAP can never grant. It **is** a valid JIT assignment, so it now lives in `JitAdminRoles.json` — the concrete example of why the two lists must be separate.

### 3. Add the Microsoft 365 / Entra Backup roles to JIT
- Add **Microsoft 365 Backup Administrator**, **SharePoint Backup Administrator**, **Exchange Backup Administrator**, **Entra Backup Administrator**, **Entra Backup Reader**.
- **Why:** M365 Backup (GA Sept 2024) must be managed by an admin assigned at tenant level in the customer directory — a textbook JIT need — and these roles were missing from CIPP's static catalog.
- **Intentionally NOT added:** the three *Purview Workload Content* roles (Administrator/Reader/Writer). Microsoft advises against assigning those Entra roles directly (they auto-sync from Purview role groups), so offering them in a JIT picker would be misleading.

### 4. Use current Microsoft Entra role names + terminology (both lists)
CIPP's catalog carried legacy/GDAP-framework labels and "Azure AD" wording. Aligned the display names and descriptions with the current `permissions-reference` in **both** `JitAdminRoles.json` and `GDAPRoles.json` (the `roleTemplateId`/`ObjectId` is unchanged, so existing GDAP mappings and JIT templates are unaffected):

| Legacy label | Current Entra name |
| --- | --- |
| Company Administrator | **Global Administrator** |
| Azure AD Joined Device Local Administrator | **Microsoft Entra Joined Device Local Administrator** |
| Power BI Administrator | **Fabric Administrator** |
| Customer LockBox Access Approver | **Customer Lockbox Access Approver** |

- Also modernized the remaining role **descriptions** that still said "Azure AD" → "Microsoft Entra" / "Microsoft Entra ID" (and "Azure AD Connect" → "Microsoft Entra Connect"). *"Azure AD B2C"* is left as-is — it's still the current product name.
- Updated the two GDAP warning alerts (`gdap-management/roles/add.js`, `gdap-management/onboarding/start.js`) that referenced "Company Administrator" by name, so the UI matches the renamed option.

## Notes / decisions
- **`GDAPRoles.json` stays the full catalog.** It's also the app-wide role-name translation source (`get-cipp-role-translation.js`), so only the one truly non-delegatable role was removed; everything else is a rename/description update, not a deletion.
- **Static list, on purpose.** This keeps the change minimal. If we later want the JIT list to always reflect a tenant's live roles, it can be upgraded to fetch directory roles dynamically from Graph (`directoryRoleTemplates` / a tenant-scoped `ListRoles`-style endpoint) behind the same picker — no consumer changes required.
