### PR TITLE
feat: show MCP API URL (/api/ExecMcp) on CIPP-API integration page

### DIFF
--- a/src/components/CippIntegrations/CippApiClientManagement.jsx
+++ b/src/components/CippIntegrations/CippApiClientManagement.jsx
@@ -1,4 +1,4 @@
-import { Button, Stack, SvgIcon, Menu, MenuItem, ListItemText, Alert } from "@mui/material";
+import { Button, Stack, SvgIcon, Menu, MenuItem, ListItemText, Alert, Tooltip } from "@mui/material";
 import { useState, useEffect, useMemo } from "react";
 import isEqual from "lodash/isEqual";
 import { useRouter } from "next/router";
@@ -14,7 +14,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { CippApiResults } from "../CippComponents/CippApiResults";
 import { CippApiDialog } from "../CippComponents/CippApiDialog";
-import { Create, Key, Save, Sync } from "@mui/icons-material";
+import { Create, InfoOutlined, Key, Save, Sync } from "@mui/icons-material";
 import { CippPropertyListCard } from "../CippCards/CippPropertyListCard";
 import { CippCopyToClipBoard } from "../CippComponents/CippCopyToClipboard";
 import { Box } from "@mui/system";
@@ -315,6 +315,22 @@ const CippApiClientManagement = () => {
               label: "API Url",
               value: azureConfig.data?.Results?.ApiUrl ? (
                 <CippCopyToClipBoard type="chip" text={azureConfig.data?.Results?.ApiUrl} />
+              ) : (
+                "Not Available"
+              ),
+            },
+            {
+              label: "MCP API URL",
+              value: azureConfig.data?.Results?.ApiUrl ? (
+                <>
+                  <CippCopyToClipBoard
+                    type="chip"
+                    text={`${azureConfig.data.Results.ApiUrl.replace(/\/+$/, "")}/api/ExecMcp`}
+                  />
+                  <Tooltip title="Use this full URL when adding CIPP as an MCP connector in an AI client (e.g. Claude custom connectors).">
+                    <InfoOutlined color="action" sx={{ fontSize: 16, verticalAlign: "middle" }} />
+                  </Tooltip>
+                </>
               ) : (
                 "Not Available"
               ),


### PR DESCRIPTION
### **Body**
Users setting up MCP clients currently see only the bare function app URL on the API integrations page.
Entering that bare URL in an MCP client fails OAuth discovery.
Showing the complete /api/ExecMcp endpoint with a copy button prevents misconfiguration.
The correct URL is in the MCP setup docs, but who reads the docs ;)

### **What changed**

- Added a read-only "MCP API URL" field to the Function Authentication card on the CIPP-API integration page, directly beneath the existing "API Url" field.
- The value is derived from the same source as "API Url" (the function app hostname) with /api/ExecMcp appended. Trailing slashes are stripped from the base first so a double slash can never be produced.
- Rendered with the same copy-to-clipboard chip as "API Url" and the same visibility conditions (shows "Not Available" when the API URL is not configured).
- Added an info tooltip: "Use this full URL when adding CIPP as an MCP connector in an AI client (e.g. Claude custom connectors)."
- Display-only change, no backend/API changes.