### PR TITLE
fix(ui): modernize Azure AD -> Microsoft Entra wording in UI labels

### DIFF
--- a/src/components/CippComponents/CippAutopilotProfileDrawer.jsx
+++ b/src/components/CippComponents/CippAutopilotProfileDrawer.jsx
@@ -225,7 +225,7 @@ export const CippAutopilotProfileDrawer = ({
               name="HideChangeAccount"
               formControl={formControl}
               disabled={true}
-              helperText="This setting requires Hybrid Azure AD Join which is not supported in CIPP"
+              helperText="This setting requires Hybrid Microsoft Entra Join which is not supported in CIPP"
             />
             <CippFormComponent
               type="switch"

--- a/src/components/CippComponents/CippSchedulerDrawer.jsx
+++ b/src/components/CippComponents/CippSchedulerDrawer.jsx
@@ -80,7 +80,7 @@ export const CippSchedulerDrawer = ({
               ? "Clone this task with the same configuration. Modify the settings as needed and save to create a new task."
               : taskId
               ? "Edit the task configuration. Changes will be applied when you save."
-              : "Create a scheduled task or event-triggered task. Scheduled tasks run PowerShell commands at specified times, while triggered tasks respond to events like Azure AD changes."}
+              : "Create a scheduled task or event-triggered task. Scheduled tasks run PowerShell commands at specified times, while triggered tasks respond to events like Microsoft Entra changes."}
           </Alert>
 
           <CippSchedulerForm

--- a/src/components/CippComponents/CippTemplateFieldRenderer.jsx
+++ b/src/components/CippComponents/CippTemplateFieldRenderer.jsx
@@ -175,9 +175,9 @@ const CippTemplateFieldRenderer = ({
           options: [
             { label: "Not Configured", value: "notConfigured" },
             { label: "Disabled", value: "disabled" },
-            { label: "Enabled for Azure AD Joined", value: "enabledForAzureAd" },
+            { label: "Enabled for Microsoft Entra Joined", value: "enabledForAzureAd" },
             {
-              label: "Enabled for Azure AD and Hybrid Joined",
+              label: "Enabled for Microsoft Entra and Hybrid Joined",
               value: "enabledForAzureAdAndHybrid",
             },
           ],

--- a/src/layouts/config.js
+++ b/src/layouts/config.js
@@ -124,7 +124,7 @@ export const nativeMenuItems = [
             permissions: ['Identity.User.*'],
           },
           {
-            title: 'AAD Connect Report',
+            title: 'Microsoft Entra Connect Report',
             path: '/identity/reports/azure-ad-connect-report',
             permissions: ['Identity.User.*'],
           },

--- a/src/pages/identity/reports/azure-ad-connect-report/index.js
+++ b/src/pages/identity/reports/azure-ad-connect-report/index.js
@@ -13,7 +13,7 @@ const apiUrl = "/api/ListAzureADConnectStatus";
 const Page = () => {
   return (
     <CippTablePage
-      title="Azure AD Connect Report"
+      title="Microsoft Entra Connect Report"
       apiUrl={apiUrl}
       apiData={{
         DataToReturn: "AzureADObjectsInError",


### PR DESCRIPTION
## Summary

Pure **UI / display-text** change to keep user-facing labels in line with current Microsoft naming ("Azure AD" → "Microsoft Entra"). No logic, option values, API parameters, routes, or comparison logic are changed — only the text a user reads.

## Changes

| Where | Route(s) | Before → After |
| --- | --- | --- |
| Nav item + breadcrumb + page header (now consistent) | `/identity/reports/azure-ad-connect-report` | "AAD Connect Report" / "Azure AD Connect Report" → **"Microsoft Entra Connect Report"** |
| Autopilot profile helper text | `/endpoint/autopilot/list-profiles` | "Hybrid Azure AD Join" → **"Hybrid Microsoft Entra Join"** |
| Scheduler helper text | `/cipp/scheduler`, `/identity/administration/offboarding-wizard` | "…events like Azure AD changes" → **"…Microsoft Entra changes"** |
| Template field option labels | `/endpoint/MEM/list-templates/edit`, `/tenant/conditional/list-template/edit` | "Enabled for Azure AD (and Hybrid) Joined" → **"…Microsoft Entra…"** |

The sidebar label previously came from `src/layouts/config.js` while the page header came from the page's `title` prop, so they were updated together to stay consistent.

## Intentionally left as-is
- **Auto-generated table column labels** (e.g. "Azure AD Registered", "Azure Active Directory Device Id") — these are derived from raw Graph API property names by `util-columnsFromAPI.js`, not hardcoded UI text.
- **Audit-log workload labels** (e.g. `Audit.AzureActiveDirectory` → "Azure AD") — these mirror the Microsoft 365 Management Activity API vocabulary, so keeping "Azure AD" there is more accurate.

No `value`s, routes or API params changed — safe display-only update.
