### PR TITLE
fix(ui): modernize Azure AD device columns + trust/join type values to Microsoft Entra

### DIFF
--- a/src/components/CippComponents/CippTranslations.jsx
+++ b/src/components/CippComponents/CippTranslations.jsx
@@ -1,5 +1,9 @@
 export const CippTranslations = {
   userPrincipalName: 'User Principal Name',
+  aadRegistered: 'Microsoft Entra Registered',
+  azureADRegistered: 'Microsoft Entra Registered',
+  azureActiveDirectoryDeviceId: 'Microsoft Entra Device ID',
+  azureADDeviceId: 'Microsoft Entra Device ID',
   aiTool: 'AI Tool',
   applicationId: 'Application ID',
   signInsLast7Days: 'Sign-ins (7 Days)',

--- a/src/utils/get-cipp-formatting.js
+++ b/src/utils/get-cipp-formatting.js
@@ -139,6 +139,27 @@ export const getCippFormatting = (data, cellName, type, canReceive, flatten = tr
     return <Chip variant="outlined" label={label} size="small" color={color} />
   }
 
+  // Microsoft Entra device trust type (Graph device.trustType)
+  if (cellName === 'trustType' && typeof data === 'string' && data) {
+    const trustTypeMap = {
+      workplace: 'Microsoft Entra registered',
+      azuread: 'Microsoft Entra joined',
+      serverad: 'Microsoft Entra hybrid joined',
+    }
+    return trustTypeMap[data.toLowerCase()] ?? data
+  }
+
+  // Microsoft Entra device join type (Intune managedDevice.joinType)
+  if (cellName === 'joinType' && typeof data === 'string' && data) {
+    const joinTypeMap = {
+      azureadregistered: 'Microsoft Entra registered',
+      azureadjoined: 'Microsoft Entra joined',
+      hybridazureadjoined: 'Microsoft Entra hybrid joined',
+      unknown: 'Unknown',
+    }
+    return joinTypeMap[data.toLowerCase()] ?? data
+  }
+
   //if the cellName starts with portal_, return text, or a link with an icon
   if (cellName.startsWith('portal_')) {
     const IconComponent = portalIcons[cellName]


### PR DESCRIPTION
## Summary

Device tables surfaced Microsoft Entra device identity in **legacy "Azure AD" wording** in two ways — the column *headers* and the raw cell *values*. This modernizes both to Microsoft's current device-state naming. Display-only: no property names, values in the API, routes, filtering or comparison logic change.

## 1. Column header labels (`CippTranslations`)

Auto-humanized headers (e.g. "Aad Registered", "Azure AD Registered", "Azure Active Directory Device Id") get friendly overrides via the existing `getCippTranslation` map:

| Graph property | Column label |
| --- | --- |
| `aadRegistered` / `azureADRegistered` | Microsoft Entra Registered |
| `azureActiveDirectoryDeviceId` / `azureADDeviceId` | Microsoft Entra Device ID |

## 2. Cell value formatting (`getCippFormatting`)

The raw `trustType` / `joinType` values rendered as cryptic codes (`AzureAd`, `ServerAd`, `Workplace`, `hybridAzureADJoined`, …). They now render as Microsoft's device-state names — verified against the Microsoft Graph **device** resource and the Intune **joinType** enum docs (note the two properties use different casing):

| `trustType` | `joinType` | → Displayed |
| --- | --- | --- |
| `Workplace` | `azureADRegistered` | **Microsoft Entra registered** |
| `AzureAd` | `azureADJoined` | **Microsoft Entra joined** |
| `ServerAd` | `hybridAzureADJoined` | **Microsoft Entra hybrid joined** |

Implemented with the same field-keyed pattern the file already uses (`complianceState`, `DMARCPolicy`, …). Unmapped/unknown values fall through to the raw value, so future Graph values still display.

## Not touched
- Audit-log workload labels that mirror the Management Activity API (`Audit.AzureActiveDirectory`) — left as-is for accuracy.
