### PR TITLE
fix(ui): rename Compliance Portal labels to Microsoft Purview

### DIFF
--- a/src/components/CippComponents/CippDeployCompliancePolicyDrawer.jsx
+++ b/src/components/CippComponents/CippDeployCompliancePolicyDrawer.jsx
@@ -290,7 +290,7 @@ export const CippDeployCompliancePolicyDrawer = ({
                 label="Label Color (optional)"
                 name="labelColor"
                 formControl={formControl}
-                helperText="Custom label color, applied via the 'color' advanced setting. The compliance portal only offers preset colors; this supports any hex color. Leave empty to keep the color from the JSON below."
+                helperText="Custom label color, applied via the 'color' advanced setting. The Purview portal only offers preset colors; this supports any hex color. Leave empty to keep the color from the JSON below."
               />
             </Grid>
           )}

--- a/src/components/CippComponents/CippTenantSelector.jsx
+++ b/src/components/CippComponents/CippTenantSelector.jsx
@@ -97,7 +97,7 @@ export const CippTenantSelector = React.forwardRef((props, ref) => {
       },
       {
         key: "Compliance_Portal",
-        label: "Compliance Portal",
+        label: "Purview Portal",
         link: `https://purview.microsoft.com/?tid=${currentTenant?.addedFields?.customerId}`,
         icon: "ShieldMoon",
       },

--- a/src/components/CippComponents/CippTranslations.jsx
+++ b/src/components/CippComponents/CippTranslations.jsx
@@ -47,7 +47,7 @@ export const CippTranslations = {
   portal_azure: 'Azure',
   portal_intune: 'Intune',
   portal_security: 'Security',
-  portal_compliance: 'Compliance',
+  portal_compliance: 'Purview',
   portal_sharepoint: 'SharePoint',
   portal_platform: 'Power Platform',
   portal_bi: 'Power BI',

--- a/src/data/portals.json
+++ b/src/data/portals.json
@@ -72,7 +72,7 @@
     "icon": "Shield"
   },
   {
-    "label": "Compliance",
+    "label": "Purview",
     "name": "Compliance_Portal",
     "url": "https://purview.microsoft.com/?tid=customerId",
     "variable": "customerId",

--- a/src/pages/cipp/preferences.js
+++ b/src/pages/cipp/preferences.js
@@ -215,7 +215,7 @@ const Page = () => {
     },
     {
       name: "portalLinks.Compliance_Portal",
-      label: "Compliance",
+      label: "Purview",
     },
     {
       name: "portalLinks.Power_Platform_Portal",

--- a/src/pages/security/compliance/labels/index.js
+++ b/src/pages/security/compliance/labels/index.js
@@ -43,7 +43,7 @@ const Page = () => {
         },
       ],
       confirmText:
-        'Pick a custom color for this sensitivity label. This supports any hex color, beyond the preset palette available in the compliance portal. Leave empty to clear the custom color.',
+        'Pick a custom color for this sensitivity label. This supports any hex color, beyond the preset palette available in the Purview portal. Leave empty to clear the custom color.',
       hideBulk: true,
     },
     {


### PR DESCRIPTION
## Summary

Microsoft renamed the compliance portal to the **Microsoft Purview portal**, and CIPP's links already point to `purview.microsoft.com` — but the UI labels still said "Compliance Portal". This PR updates the user-facing labels to match the current product name.

## Changes (labels only, 6 files / 6 lines)

- **Tenant Extended Info drawer** (`CippTenantSelector.jsx`): "Compliance Portal" → "Purview Portal"
- **Portals sidebar** (`portals.json`): "Compliance" → "Purview"
- **Preferences page** (`preferences.js`): portal link toggle label "Compliance" → "Purview"
- **Translations** (`CippTranslations.jsx`): `portal_compliance` display name → "Purview"
- **Two helper texts** (sensitivity label color pickers): "compliance portal" → "Purview portal"

## Deliberately unchanged

- Internal keys `Compliance_Portal` / `portal_compliance` — kept so stored user preferences and bookmarks keep working.
- The Hudu extension setting "Include link to Compliance Portal (compliance.microsoft.com)" — CIPP-API's `Invoke-HuduExtensionSync.ps1` still generates `compliance.microsoft.com` links, so that label is accurate until the backend is updated (happy to do a follow-up CIPP-API PR).

## Screenshot context

The Extended Info drawer currently shows "Compliance Portal" while the link opens Microsoft Purview.