### PR TITLE
Fix: Add 'description' to extended info fields

### DIFF
--- a/src/pages/endpoint/MEM/list-appprotection-policies/index.js
+++ b/src/pages/endpoint/MEM/list-appprotection-policies/index.js
@@ -34,6 +34,7 @@ const Page = () => {
     extendedInfoFields: [
       'createdDateTime',
       'displayName',
+      'description',
       'lastModifiedDateTime',
       'PolicyTypeName',
       'PolicySource',

--- a/src/pages/endpoint/MEM/list-policies/index.js
+++ b/src/pages/endpoint/MEM/list-policies/index.js
@@ -34,6 +34,7 @@ const Page = () => {
     extendedInfoFields: [
       'createdDateTime',
       'displayName',
+      'description',
       'lastModifiedDateTime',
       'PolicyTypeName',
     ],
@@ -51,7 +52,6 @@ const Page = () => {
     'description',
     'lastModifiedDateTime',
   ]
-
 
   return (
     <>


### PR DESCRIPTION
Add 'description' to the list of extended info fields