### PR TITLE
Fix: Deprecate SPDirectSharing standard

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -5070,6 +5070,7 @@
   },
   {
     "name": "standards.SPDirectSharing",
+    "deprecated": true,
     "cat": "SharePoint Standards",
     "tag": [],
     "helpText": "This standard has been deprecated in favor of the Default Sharing Link standard. ",


### PR DESCRIPTION
Mark the SPDirectSharing standard as deprecated in favor of the Default Sharing Link standard.