### PR TITLE
fix: Change default assignment mode to 'append'

### DIFF
--- a/src/components/CippComponents/CippIntunePolicyActions.jsx
+++ b/src/components/CippComponents/CippIntunePolicyActions.jsx
@@ -88,7 +88,7 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
       name: 'assignmentMode',
       label: 'Assignment mode',
       options: assignmentModeOptions,
-      defaultValue: 'replace',
+      defaultValue: 'append',
       // Re-validate the Custom Group picker (no-op for broad actions, which have no groupTargets).
       validators: { deps: ['groupTargets'] },
       helperText:
@@ -147,7 +147,7 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
         validate: (value, formValues) => {
           if (
             formValues?.assignmentDirection === 'exclude' &&
-            (formValues?.assignmentMode || 'replace') === 'replace'
+            (formValues?.assignmentMode || 'append') === 'replace'
           ) {
             return true
           }
@@ -179,7 +179,7 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
       type: item?.URLName || policyType,
       ...(platformType && { platformType }),
       AssignTo: assignTo,
-      assignmentMode: formData?.assignmentMode || 'replace',
+      assignmentMode: formData?.assignmentMode || 'append',
       ExcludeGroupIds: (formData?.excludeGroupTargets || []).map((g) => g.value).filter(Boolean),
       ExcludeGroupNames: (formData?.excludeGroupTargets || []).map((g) => g.label).filter(Boolean),
       AssignmentFilterName: formData?.assignmentFilter?.value || null,
@@ -205,7 +205,7 @@ export const useCippIntunePolicyActions = (tenant, policyType, options = {}) => 
       ExcludeGroupIds: isExclude ? ids : [],
       ExcludeGroupNames: isExclude ? names : [],
       assignmentDirection: formData?.assignmentDirection || 'include',
-      assignmentMode: formData?.assignmentMode || 'replace',
+      assignmentMode: formData?.assignmentMode || 'append',
       AssignmentFilterName: formData?.assignmentFilter?.value || null,
       AssignmentFilterType: formData?.assignmentFilter?.value
         ? formData?.assignmentFilterType || 'include'

--- a/src/pages/endpoint/MEM/list-scripts/index.jsx
+++ b/src/pages/endpoint/MEM/list-scripts/index.jsx
@@ -238,7 +238,7 @@ const Page = () => {
           name: 'assignmentMode',
           label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: 'replace',
+          defaultValue: 'append',
           helperText:
             'Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.',
         },
@@ -249,7 +249,7 @@ const Page = () => {
         ID: row?.id,
         Type: getScriptEndpoint(row?.scriptType),
         AssignTo: 'allLicensedUsers',
-        assignmentMode: formData?.assignmentMode || 'replace',
+        assignmentMode: formData?.assignmentMode || 'append',
       }),
     },
     {
@@ -265,7 +265,7 @@ const Page = () => {
           name: 'assignmentMode',
           label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: 'replace',
+          defaultValue: 'append',
           helperText:
             'Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.',
         },
@@ -276,7 +276,7 @@ const Page = () => {
         ID: row?.id,
         Type: getScriptEndpoint(row?.scriptType),
         AssignTo: 'AllDevices',
-        assignmentMode: formData?.assignmentMode || 'replace',
+        assignmentMode: formData?.assignmentMode || 'append',
       }),
     },
     {
@@ -292,7 +292,7 @@ const Page = () => {
           name: 'assignmentMode',
           label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: 'replace',
+          defaultValue: 'append',
           helperText:
             'Replace will overwrite existing assignments. Append keeps current assignments and adds the new ones.',
         },
@@ -303,7 +303,7 @@ const Page = () => {
         ID: row?.id,
         Type: getScriptEndpoint(row?.scriptType),
         AssignTo: 'AllDevicesAndUsers',
-        assignmentMode: formData?.assignmentMode || 'replace',
+        assignmentMode: formData?.assignmentMode || 'append',
       }),
     },
     {
@@ -325,7 +325,7 @@ const Page = () => {
             validate: (value, formValues) => {
               if (
                 formValues?.assignmentDirection === 'exclude' &&
-                (formValues?.assignmentMode || 'replace') === 'replace'
+                (formValues?.assignmentMode || 'append') === 'replace'
               ) {
                 return true
               }
@@ -352,7 +352,7 @@ const Page = () => {
           name: 'assignmentMode',
           label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: 'replace',
+          defaultValue: 'append',
           // Re-validate the picker so the empty-allowed rule updates when mode changes.
           validators: { deps: ['groupTargets'] },
           helperText:
@@ -373,7 +373,7 @@ const Page = () => {
           ExcludeGroupIds: isExclude ? ids : [],
           ExcludeGroupNames: isExclude ? names : [],
           assignmentDirection: formData?.assignmentDirection || 'include',
-          assignmentMode: formData?.assignmentMode || 'replace',
+          assignmentMode: formData?.assignmentMode || 'append',
         }
       },
     },

--- a/src/pages/endpoint/applications/list/index.js
+++ b/src/pages/endpoint/applications/list/index.js
@@ -159,7 +159,7 @@ const Page = () => {
       name: 'assignmentMode',
       label: 'Assignment mode',
       options: assignmentModeOptions,
-      defaultValue: 'replace',
+      defaultValue: 'append',
       helperText:
         'Replace will overwrite existing assignments. Append keeps current assignments and adds/overwrites only for the selected groups/intents.',
     },
@@ -177,7 +177,7 @@ const Page = () => {
       customDataformatter: makeAssignFormatter((_singleRow, formData) => ({
         AssignTo: 'AllUsers',
         Intent: formData?.Intent || 'Required',
-        assignmentMode: formData?.assignmentMode || 'replace',
+        assignmentMode: formData?.assignmentMode || 'append',
       })),
       confirmText: 'Are you sure you want to assign "[displayName]" to all users?',
       icon: <UserIcon />,
@@ -192,7 +192,7 @@ const Page = () => {
       customDataformatter: makeAssignFormatter((_singleRow, formData) => ({
         AssignTo: 'AllDevices',
         Intent: formData?.Intent || 'Required',
-        assignmentMode: formData?.assignmentMode || 'replace',
+        assignmentMode: formData?.assignmentMode || 'append',
       })),
       confirmText: 'Are you sure you want to assign "[displayName]" to all devices?',
       icon: <LaptopMac />,
@@ -207,7 +207,7 @@ const Page = () => {
       customDataformatter: makeAssignFormatter((_singleRow, formData) => ({
         AssignTo: 'AllDevicesAndUsers',
         Intent: formData?.Intent || 'Required',
-        assignmentMode: formData?.assignmentMode || 'replace',
+        assignmentMode: formData?.assignmentMode || 'append',
       })),
       confirmText: 'Are you sure you want to assign "[displayName]" to all users and devices?',
       icon: <GlobeAltIcon />,
@@ -232,7 +232,7 @@ const Page = () => {
             validate: (value, formValues) => {
               if (
                 formValues?.assignmentDirection === 'exclude' &&
-                (formValues?.assignmentMode || 'replace') === 'replace'
+                (formValues?.assignmentMode || 'append') === 'replace'
               ) {
                 return true
               }
@@ -269,7 +269,7 @@ const Page = () => {
           name: 'assignmentMode',
           label: 'Assignment mode',
           options: assignmentModeOptions,
-          defaultValue: 'replace',
+          defaultValue: 'append',
           // Re-validate the picker so the empty-allowed rule updates when mode changes.
           validators: { deps: ['groupTargets'] },
           helperText:
@@ -290,7 +290,7 @@ const Page = () => {
           ExcludeGroupNames: isExclude ? names : [],
           assignmentDirection: formData?.assignmentDirection || 'include',
           Intent: formData?.assignmentIntent || 'Required',
-          AssignmentMode: formData?.assignmentMode || 'replace',
+          AssignmentMode: formData?.assignmentMode || 'append',
         }
       }),
     },


### PR DESCRIPTION
Update the default assignment mode from 'replace' to 'append' to ensure that existing assignments are retained while new ones are added. This change enhances the user experience by preventing unintentional overwrites.

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/2137