### PR TITLE
Feat: Add anonymization alert for report pages

### DIFF
--- a/src/components/CippComponents/CippAnonymizedReportAlert.jsx
+++ b/src/components/CippComponents/CippAnonymizedReportAlert.jsx
@@ -1,0 +1,84 @@
+import { Alert, Link } from '@mui/material'
+import { ApiGetCallWithPagination } from '../../api/ApiCall'
+import { useSettings } from '../../hooks/use-settings'
+
+// When M365 "conceal user/site names in reports" is enabled, Graph usage reports return
+// 32-char hex hashes (e.g. 85926F73B5A9FA60D166E6057BA76F4A) instead of names/UPNs.
+const HASHED_NAME = /^[0-9A-F]{32}$/i
+const DEFAULT_FIELDS = [
+  'userPrincipalName',
+  'displayName',
+  'ownerPrincipalName',
+  'ownerDisplayName',
+  'UPN',
+  'userId',
+  'UserId',
+  'siteUrl',
+]
+
+/**
+ * True when report rows look anonymized: for at least one of the given fields, every
+ * populated value across all rows is a 32-char hex hash.
+ */
+export const isReportAnonymized = (rows, fields = DEFAULT_FIELDS) => {
+  if (!Array.isArray(rows) || rows.length === 0) return false
+  return fields.some((field) => {
+    const values = rows
+      .map((row) => row?.[field])
+      .filter((value) => typeof value === 'string' && value !== '')
+    return values.length > 0 && values.every((value) => HASHED_NAME.test(value))
+  })
+}
+
+/**
+ * Hook for CippTablePage-based report pages. Subscribes to the same React Query cache entry
+ * as the page's table (same url/data/queryKey → one shared request) and returns whether the
+ * loaded rows look anonymized.
+ *
+ * @param {string} url        - Same apiUrl the table uses.
+ * @param {Object} [data]     - Same extra apiData the table uses (tenantFilter is added here).
+ * @param {string} queryKey   - Same queryKey the table uses (must match exactly).
+ * @param {string} [dataKey]  - Same apiDataKey the table uses (e.g. "Results").
+ * @param {string[]} [fields] - Name fields to test for hashes.
+ * @param {Function} [check]  - Optional custom predicate (rows) => bool, replaces the hash test.
+ */
+export const useReportAnonymized = ({ url, data, queryKey, dataKey, fields, check }) => {
+  const tenant = useSettings().currentTenant
+  const query = ApiGetCallWithPagination({
+    url,
+    data: { tenantFilter: tenant, ...data },
+    queryKey,
+  })
+  if (!query.isSuccess || query.isFetching) return false
+  const rows = (query.data?.pages ?? []).flatMap((page) => {
+    const pageData = dataKey ? page?.[dataKey] : page
+    return Array.isArray(pageData) ? pageData : []
+  })
+  if (check) return rows.length > 0 && check(rows)
+  return isReportAnonymized(rows, fields)
+}
+
+/**
+ * Warning banner shown when report data is anonymized. Renders nothing unless `show`.
+ * Pass `children` to override only the lead-in sentence (e.g. the all-zero-storage variant);
+ * the standard link and guidance are always appended.
+ */
+export const CippAnonymizedReportAlert = ({ show, children }) => {
+  if (!show) return null
+  return (
+    <Alert severity="warning">
+      {children ??
+        'Names in this report appear pseudo-anonymised because Microsoft 365 report anonymization is enabled for this tenant.'}{' '}
+      The{' '}
+      <Link
+        href="https://standards.cipp.app/standards/anonreportdisable"
+        target="_blank"
+        rel="noopener"
+      >
+        Enable Usernames instead of pseudo anonymised names in reports
+      </Link>{' '}
+      standard might need to be enabled to have the data populate correctly. Re-run the report sync
+      after changing the setting.
+    </Alert>
+  )
+}

--- a/src/pages/copilot/reports/copilot-usage/index.js
+++ b/src/pages/copilot/reports/copilot-usage/index.js
@@ -1,12 +1,29 @@
 import { Layout as DashboardLayout } from '../../../../layouts/index.js'
 import { CippTablePage } from '../../../../components/CippComponents/CippTablePage.jsx'
+import {
+  CippAnonymizedReportAlert,
+  useReportAnonymized,
+} from '../../../../components/CippComponents/CippAnonymizedReportAlert'
+import { useSettings } from '../../../../hooks/use-settings'
 
 const Page = () => {
+  const tenant = useSettings().currentTenant
+  const queryKey = `CopilotUserActivity-${tenant}`
+
+  const anonymized = useReportAnonymized({
+    url: '/api/ListCopilotUsage',
+    data: { Type: 'UserDetail' },
+    queryKey: queryKey,
+    fields: ['userPrincipalName', 'displayName'],
+  })
+
   return (
     <CippTablePage
       title="Copilot User Activity"
       apiUrl="/api/ListCopilotUsage"
       apiData={{ Type: 'UserDetail' }}
+      queryKey={queryKey}
+      tableFilter={<CippAnonymizedReportAlert show={anonymized} />}
       simpleColumns={[
         'userPrincipalName',
         'displayName',

--- a/src/pages/email/administration/mailboxes/index.js
+++ b/src/pages/email/administration/mailboxes/index.js
@@ -3,6 +3,10 @@ import { CippTablePage } from '../../../../components/CippComponents/CippTablePa
 import CippExchangeActions from '../../../../components/CippComponents/CippExchangeActions'
 import { CippSharedMailboxDrawer } from '../../../../components/CippComponents/CippSharedMailboxDrawer.jsx'
 import { useCippReportDB } from '../../../../components/CippComponents/CippReportDBControls'
+import {
+  CippAnonymizedReportAlert,
+  useReportAnonymized,
+} from '../../../../components/CippComponents/CippAnonymizedReportAlert'
 import { Stack } from '@mui/system'
 
 const Page = () => {
@@ -15,6 +19,14 @@ const Page = () => {
     syncTitle: 'Sync Mailboxes',
     allowToggle: true,
     defaultCached: true,
+  })
+
+  // Anonymized report names break the usage merge in the Mailboxes cache sync, leaving
+  // storageUsedInBytes at 0 for every mailbox (cached mode only — live mode has no usage data).
+  const allZeroStorage = useReportAnonymized({
+    url: reportDB.resolvedApiUrl,
+    queryKey: reportDB.resolvedQueryKey,
+    check: (rows) => rows.every((mailbox) => !Number(mailbox?.storageUsedInBytes)),
   })
 
   // Define off-canvas details
@@ -75,6 +87,12 @@ const Page = () => {
         offCanvas={offCanvas}
         simpleColumns={simpleColumns}
         filters={filterList}
+        tableFilter={
+          <CippAnonymizedReportAlert show={reportDB.useReportDB && allZeroStorage}>
+            All mailboxes report 0 storage used, which usually means Microsoft 365 report
+            anonymization is enabled for this tenant.
+          </CippAnonymizedReportAlert>
+        }
         cardButton={
           <Stack direction="row" spacing={1} alignItems="center">
             <CippSharedMailboxDrawer />

--- a/src/pages/email/reports/mailbox-activity/index.js
+++ b/src/pages/email/reports/mailbox-activity/index.js
@@ -15,6 +15,10 @@ import { ExpandMore, Sort } from "@mui/icons-material";
 import { FunnelIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { useForm } from "react-hook-form";
 import CippFormComponent from "../../../../components/CippComponents/CippFormComponent";
+import {
+  CippAnonymizedReportAlert,
+  useReportAnonymized,
+} from "../../../../components/CippComponents/CippAnonymizedReportAlert";
 
 const Page = () => {
   const formControl = useForm({
@@ -53,6 +57,18 @@ const Page = () => {
     setSelectedPeriodLabel("30 days");
     setExpanded(false);
   };
+
+  const anonymized = useReportAnonymized({
+    url: "/api/ListGraphRequest",
+    data: {
+      Endpoint: `reports/getEmailActivityUserDetail(period='${selectedPeriod}')`,
+      $format: "application/json",
+      Sort: "userPrincipalName",
+    },
+    queryKey: `MailboxActivity-${selectedPeriod}`,
+    dataKey: "Results",
+    fields: ["userPrincipalName", "displayName"],
+  });
 
   const tableFilter = (
     <Accordion expanded={expanded} onChange={() => setExpanded(!expanded)}>
@@ -120,7 +136,12 @@ const Page = () => {
 
   return (
     <CippTablePage
-      tableFilter={tableFilter}
+      tableFilter={
+        <>
+          <CippAnonymizedReportAlert show={anonymized} />
+          {tableFilter}
+        </>
+      }
       title="Mailbox Activity"
       apiUrl="/api/ListGraphRequest"
       apiData={{

--- a/src/pages/email/reports/mailbox-statistics/index.js
+++ b/src/pages/email/reports/mailbox-statistics/index.js
@@ -1,16 +1,35 @@
 import { Layout as DashboardLayout } from "../../../../layouts/index.js";
 import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
+import {
+  CippAnonymizedReportAlert,
+  useReportAnonymized,
+} from "../../../../components/CippComponents/CippAnonymizedReportAlert";
+import { useSettings } from "../../../../hooks/use-settings";
 
 const Page = () => {
+  const tenant = useSettings().currentTenant;
+  const apiData = {
+    Endpoint: "reports/getMailboxUsageDetail(period='D7')",
+    $format: "application/json",
+  };
+  const queryKey = `MailboxStatistics-${tenant}`;
+
+  const anonymized = useReportAnonymized({
+    url: "/api/ListGraphRequest",
+    data: apiData,
+    queryKey: queryKey,
+    dataKey: "Results",
+    fields: ["userPrincipalName", "displayName"],
+  });
+
   return (
     <CippTablePage
       title="Mailbox Statistics"
       apiUrl="/api/ListGraphRequest"
-      apiData={{
-        Endpoint: "reports/getMailboxUsageDetail(period='D7')",
-        $format: "application/json",
-      }}
+      apiData={apiData}
       apiDataKey="Results"
+      queryKey={queryKey}
+      tableFilter={<CippAnonymizedReportAlert show={anonymized} />}
       simpleColumns={[
         /* Columns from the original component translated to simpleColumns */
         "tenant", // Original conditional column, included directly here as per simplified requirements

--- a/src/pages/teams-share/teams/teams-activity/index.js
+++ b/src/pages/teams-share/teams/teams-activity/index.js
@@ -1,6 +1,10 @@
 import { Layout as DashboardLayout } from "../../../../layouts/index.js";
 import { CippTablePage } from "../../../../components/CippComponents/CippTablePage.jsx";
 import { useCippReportDB } from "../../../../components/CippComponents/CippReportDBControls";
+import {
+  CippAnonymizedReportAlert,
+  useReportAnonymized,
+} from "../../../../components/CippComponents/CippAnonymizedReportAlert";
 
 const Page = () => {
   const pageTitle = "Teams Activity List";
@@ -14,12 +18,19 @@ const Page = () => {
     defaultCached: false,
   });
 
+  const anonymized = useReportAnonymized({
+    url: reportDB.resolvedApiUrl,
+    queryKey: reportDB.resolvedQueryKey,
+    fields: ["UPN"],
+  });
+
   return (
     <>
       <CippTablePage
         title={pageTitle}
         apiUrl={reportDB.resolvedApiUrl}
         queryKey={reportDB.resolvedQueryKey}
+        tableFilter={<CippAnonymizedReportAlert show={anonymized} />}
         simpleColumns={[
           ...reportDB.cacheColumns,
           "UPN",

--- a/src/pages/tenant/reports/graph-office-reports/index.js
+++ b/src/pages/tenant/reports/graph-office-reports/index.js
@@ -8,6 +8,10 @@ import { Box, Container, Stack } from '@mui/system'
 import { CippHead } from '../../../../components/CippComponents/CippHead.jsx'
 import { CippDataTable } from '../../../../components/CippTable/CippDataTable.js'
 import CippFormComponent from '../../../../components/CippComponents/CippFormComponent'
+import {
+  CippAnonymizedReportAlert,
+  isReportAnonymized,
+} from '../../../../components/CippComponents/CippAnonymizedReportAlert'
 
 // Convert camelCase report names like "getMailboxUsageDetail" → "Mailbox Usage Detail"
 // Uses the same acronym-aware splitting as getCippTranslation
@@ -146,6 +150,14 @@ const Page = () => {
             )}
             {currentTenant && !report && (
               <Alert severity="info">Select a report above to load data.</Alert>
+            )}
+            {currentTenant && report && (
+              <CippAnonymizedReportAlert
+                show={
+                  !reportDataApi.isFetching &&
+                  isReportAnonymized(Array.isArray(reportDataApi.data) ? reportDataApi.data : [])
+                }
+              />
             )}
             {currentTenant && report && (
               <Card>


### PR DESCRIPTION
Introduce an alert to notify users when report data appears anonymized due to Microsoft 365 settings. Should reduce the amount of users asking why the mailbox page has no storage shown and such