### PR TITLE
feat(alerts): resolve button on dashboard alerts card

### DIFF
--- a/src/components/CippComponents/AlertsOverviewCard.jsx
+++ b/src/components/CippComponents/AlertsOverviewCard.jsx
@@ -14,6 +14,7 @@ import {
   Typography,
 } from '@mui/material'
 import {
+  CheckCircleOutline as ResolveIcon,
   DeleteOutline as DeleteIcon,
   NotificationsActive as AlertIcon,
   Settings as SettingsIcon,
@@ -23,6 +24,7 @@ import Link from 'next/link'
 import { ApiGetCall } from '../../api/ApiCall'
 import { getCippError } from '../../utils/get-cipp-error'
 import { useDialog } from '../../hooks/use-dialog'
+import { usePermissions } from '../../hooks/use-permissions'
 import { CippAlertSnoozeDialog } from './CippAlertSnoozeDialog'
 import { CippApiDialog } from './CippApiDialog'
 import { describeAlertItem, humanizeCmdlet } from '../../utils/format-alert-item'
@@ -73,6 +75,13 @@ const SnoozeStatusChip = ({ snooze }) => {
 export const AlertsOverviewCard = ({ tenantFilter, sx }) => {
   const [snoozeTarget, setSnoozeTarget] = useState(null)
   const removeDialog = useDialog()
+  const resolveDialog = useDialog()
+
+  // Viewing only needs CIPP.Alert.Read / CIPP.AlertSnooze.Read - hide the write
+  // actions from users whose submission the API would reject anyway.
+  const { checkPermissions } = usePermissions()
+  const canResolve = checkPermissions(['CIPP.Alert.ReadWrite'])
+  const canSnooze = checkPermissions(['CIPP.AlertSnooze.ReadWrite'])
 
   const resultsQueryKey = `ListAlertResults-${tenantFilter}`
   // Dedicated key — must NOT be "ListSnoozedAlerts": that key is owned by the Snoozed
@@ -189,11 +198,22 @@ export const AlertsOverviewCard = ({ tenantFilter, sx }) => {
                         {secondary}
                       </Typography>
                     </Box>
-                    <Tooltip title="Snooze this alert">
-                      <IconButton size="small" onClick={() => setSnoozeTarget(item)}>
-                        <SnoozeIcon fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
+                    <Stack direction="row" spacing={0.5} alignItems="center" sx={{ flexShrink: 0 }}>
+                      {canResolve && (
+                        <Tooltip title="Resolve this alert">
+                          <IconButton size="small" onClick={() => resolveDialog.handleOpen(item)}>
+                            <ResolveIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                      {canSnooze && (
+                        <Tooltip title="Snooze this alert">
+                          <IconButton size="small" onClick={() => setSnoozeTarget(item)}>
+                            <SnoozeIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                    </Stack>
                   </Box>
                 )
               })}
@@ -240,11 +260,16 @@ export const AlertsOverviewCard = ({ tenantFilter, sx }) => {
                         sx={{ flexShrink: 0 }}
                       >
                         <SnoozeStatusChip snooze={snooze} />
-                        <Tooltip title="Remove snooze">
-                          <IconButton size="small" onClick={() => removeDialog.handleOpen(snooze)}>
-                            <DeleteIcon fontSize="small" />
-                          </IconButton>
-                        </Tooltip>
+                        {canSnooze && (
+                          <Tooltip title="Remove snooze">
+                            <IconButton
+                              size="small"
+                              onClick={() => removeDialog.handleOpen(snooze)}
+                            >
+                              <DeleteIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        )}
                       </Stack>
                     </Box>
                   )
@@ -288,6 +313,22 @@ export const AlertsOverviewCard = ({ tenantFilter, sx }) => {
         cmdletName={snoozeTarget?.CmdletName}
         tenantFilter={tenantFilter}
         relatedQueryKeys={relatedQueryKeys}
+      />
+
+      <CippApiDialog
+        createDialog={resolveDialog}
+        title="Resolve alert"
+        fields={[]}
+        row={resolveDialog.data ?? {}}
+        api={{
+          type: 'POST',
+          url: '/api/ExecResolveAlert',
+          confirmText:
+            'Mark this alert as resolved? It is removed immediately, but unlike a snooze it will return on the next scheduled run if the underlying condition still exists.',
+          data: { CmdletName: 'CmdletName', TenantFilter: 'Tenant', AlertItem: 'AlertItem' },
+          relatedQueryKeys,
+          multiPost: false,
+        }}
       />
 
       <CippApiDialog


### PR DESCRIPTION
Backend PR: KelvinTegelaar/CIPP-API#2145 — full context for both PRs lives here.

## Problem

Dashboard alerts never resolve. Fired scripted alerts (`Get-CIPPAlert*`) are written to the `AlertLastRun` table and surfaced on the dashboard via `ListAlertResults`, but nothing ever removes them when the underlying condition clears — a clean run simply never calls `Write-AlertTrace`, so the last fired row stays the "latest" forever and the alert sits on the dashboard indefinitely. The only way to get rid of one is snoozing it, which is the wrong semantic for a resolved condition: it suppresses future occurrences instead of acknowledging the current one, and the alert comes back when the snooze expires.

## Solution (both PRs together)

**1. Auto-resolve on clean runs** (backend). Alert output can't signal "cleared" because output only carries *changed* data — it drives notifications, which must not repeat for unchanged conditions (alerts can recur every 30 minutes, and `BreachAlert`/`SecureScore` rely on unchanged-data silence across days via their fixed PartitionKeys). Instead:

- `Write-AlertTrace` now writes the row on **every** run with active items, stamping a `LastSeen` unix timestamp (new column, additive). Output semantics are unchanged: data is returned only when it differs, so notification behavior is byte-for-byte identical.
- After a successful `Get-CIPPAlert*` task run, `Push-ExecScheduledCommand` checks whether any trace row was stamped during the run. If none was, the condition no longer holds (or every item is snoozed) and the new `Clear-AlertTrace` helper deletes the stored state — the alert disappears from the dashboard on its next scheduled run after resolving.
- `Clear-AlertTrace` only deletes rows carrying `LogData`: `Get-CIPPAlertCheckExtension` keeps its last-run watermark in the same table under the same RowKey format and must survive.
- Existing stale alerts self-heal on each alert's next scheduled run; no migration needed.

**2. Manual resolve** (backend endpoint + this PR's button). New `Invoke-ExecResolveAlert` endpoint (role `CIPP.Alert.ReadWrite`). Resolve differs from snooze: it removes the fired item immediately but does **not** suppress it — if the condition still exists, the item legitimately re-fires on the next run. It removes the item by content hash from every `AlertLastRun` partition (so older rows can't resurface it), deletes rows that empty out, preserves the `LastSeen` stamp on rewrites so the scheduler doesn't misread surviving items as stale, and escapes caller input via `ConvertTo-CIPPODataFilterValue` before filter interpolation.

**3. This PR — the UI.** Each active alert row in `AlertsOverviewCard` gets a **Resolve** action (check icon) next to Snooze. It opens a confirm dialog posting `{ CmdletName, TenantFilter, AlertItem }` to `ExecResolveAlert` and invalidates the same query keys the snooze flow uses. The confirm text spells out the distinction: the alert is removed immediately, but unlike a snooze it returns on the next scheduled run if the condition still exists.

Additionally, the card's write actions are now permission-gated with the existing `usePermissions` hook: Resolve requires `CIPP.Alert.ReadWrite`, Snooze/Remove-snooze require `CIPP.AlertSnooze.ReadWrite`. Read-only operators (`CIPP.Alert.Read`) previously saw buttons whose submission the API would reject; those are now hidden.

## Known trade-offs

- An alert cmdlet that swallows a dependency failure internally (catch → log → return) reads as a clean run and clears the alert; it returns with a fresh notification on the next successful firing run. The proper fix is rethrowing from those catch blocks so the task lands in `Failed` state (which already guards the clear) — happy to do that as a follow-up, it touches every alert cmdlet.
- The resolve endpoint's read-modify-write is not ETag-guarded. The race window is milliseconds against 30m+ run cadences, and the damage self-corrects on the next run (changed data rewrites and re-notifies).

## Testing

Backend: 12 new Pester tests, full suite green —
- `Tests/Private/Write-AlertTrace.Tests.ps1` — new/changed/unchanged (LastSeen refresh, silent output)/all-snoozed branches
- `Tests/Private/Clear-AlertTrace.Tests.ps1` — trace-row deletion, CheckExtension watermark survival
- `Tests/Endpoint/Invoke-ExecResolveAlert.Tests.ps1` — item removal with rewrite, last-item row deletion, multi-partition cleanup, idempotent already-resolved path, LastSeen preservation, OData injection escaping, 400/500 paths

Frontend: Prettier-clean; verified against the local stack.

## Dependency

Requires KelvinTegelaar/CIPP-API#2145. Without it, the Resolve button posts to a non-existent endpoint (error toast); the permission gating is independent and safe either way.
