### PR TITLE
Feat: Add mailbox types selection for Mailbox quota alert

### DIFF
--- a/src/data/alerts.json
+++ b/src/data/alerts.json
@@ -176,6 +176,17 @@
         "inputType": "textField",
         "inputLabel": "Excluded mailbox UPNs (comma-separated). Supports custom variables like %excludefrommailboxalert% defined under CIPP > Settings > Custom Variables at tenant or AllTenants scope.",
         "inputName": "QuotaUsedExcludedMailboxes"
+      },
+      {
+        "inputType": "autoComplete",
+        "inputLabel": "Mailbox types to alert on (default: all)",
+        "inputName": "QuotaUsedMailboxTypes",
+        "creatable": false,
+        "multiple": true,
+        "options": [
+          { "label": "User mailboxes", "value": "User" },
+          { "label": "Shared mailboxes", "value": "Shared" }
+        ]
       }
     ],
     "recommendedRunInterval": "1d"


### PR DESCRIPTION
Introduce the ability to filter mailbox types for quota alerts, allowing users to exclude shared mailboxes from notifications. Fully backwards compatible.
Fixes #6361

API PR: https://github.com/KelvinTegelaar/CIPP-API/pull/2146