### PR TITLE
Feat: Add applicationTemplateId to service principal query

### DIFF
--- a/src/pages/tenant/administration/applications/enterprise-apps.js
+++ b/src/pages/tenant/administration/applications/enterprise-apps.js
@@ -48,7 +48,7 @@ const Page = () => {
   const apiParams = {
     Endpoint: 'servicePrincipals',
     $select:
-      'id,appId,displayName,createdDateTime,accountEnabled,homepage,publisherName,signInAudience,replyUrls,verifiedPublisher,info,api,appOwnerOrganizationId,tags,passwordCredentials,keyCredentials',
+      'id,appId,displayName,createdDateTime,accountEnabled,homepage,publisherName,signInAudience,replyUrls,verifiedPublisher,info,api,applicationTemplateId,appOwnerOrganizationId,tags,passwordCredentials,keyCredentials',
     $count: true,
     $top: 999,
   }


### PR DESCRIPTION
Include applicationTemplateId in the API parameters for retrieving service principals to enhance the ability to locate the cloud sync service principal.