### PR TITLE
Fix: login 401 flash

### DIFF
--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -49,10 +49,12 @@ export const PrivateRoute = ({ children, routeType }) => {
   }
 
   // Check if the session is still loading before determining authentication status
+  // return loading page here when roles are loading to avoid showing 401
   if (
     session.isLoading ||
     apiRoles.isLoading ||
-    (apiRoles.isFetching && (apiRoles.data === null || apiRoles.data === undefined))
+    (hasAuthenticatedSession(session.data) && apiRoles.isPending) ||
+    (apiRoles.isFetching && !apiRoles.data?.clientPrincipal)
   ) {
     return <LoadingPage />;
   }

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -148,7 +148,9 @@ const App = (props) => {
     setDateLocale(resolvedLocale)
   }, [])
 
-  const excludeQueryKeys = ['authmeswa', 'alertsDashboard']
+  // authmecipp excluded: /api/me returns 200 with clientPrincipal null when logged out,
+  // persisting that flashes the 401 page on the post-login reload until the refetch lands
+  const excludeQueryKeys = ['authmeswa', 'authmecipp', 'alertsDashboard']
 
   // 👇 Persist TanStack Query cache to localStorage
   useEffect(() => {

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -148,8 +148,7 @@ const App = (props) => {
     setDateLocale(resolvedLocale)
   }, [])
 
-  // authmecipp excluded: /api/me returns 200 with clientPrincipal null when logged out,
-  // persisting that flashes the 401 page on the post-login reload until the refetch lands
+  // authmecipp not persisted, stale clientPrincipal:null flashes 401 on post-login reload
   const excludeQueryKeys = ['authmeswa', 'authmecipp', 'alertsDashboard']
 
   // 👇 Persist TanStack Query cache to localStorage
@@ -164,7 +163,7 @@ const App = (props) => {
         persister: localStoragePersister,
         maxAge: 1000 * 60 * 60 * 24, // 24 hours
         staleTime: 1000 * 60 * 5, // optional: 5 minutes
-        buster: 'v1',
+        buster: 'v2',
         dehydrateOptions: {
           shouldDehydrateQuery: (query) => {
             const queryIsReadyForPersistence = query.state.status === 'success'


### PR DESCRIPTION
tanstack react query + query-sync-storage-persister will save clientPrincipal:null if the user isn't logged in on initial page load into localstorage causing a 401 page flash after a successful login

- added authmecipp as exclusion to stop this part
- added early return to PrivateRoute to indicate roles loading instead of unauthorized
- bump persister buster key to v2 to invalidate previous localstorage caches to prevent possible stale caches hanging on a null principal