### PR TITLE
chore: restore typescript devDependency, eslint-config-next flat config requires it

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.10",
     "eslint-config-prettier": "^10.1.8",
-    "prettier": "^3.9.5"
+    "prettier": "^3.9.5",
+    "typescript": "5.9.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7551,6 +7551,11 @@ typescript-eslint@^8.46.0:
     "@typescript-eslint/typescript-estree" "8.57.1"
     "@typescript-eslint/utils" "8.57.1"
 
+typescript@5.9.3:
+  version "5.9.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
 unbox-primitive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.1.0.tgz#8d9d2c9edeea8460c7f35033a88867944934d1e2"


### PR DESCRIPTION
typescript was removed as a dev dependency in 36071e540 which silently broke `npx eslint` for every fresh clone (Cannot find module 'typescript') since eslint-config-next 16's flat config unconditionally imports typescript-eslint