### PR TITLE
chore: fix @next/next/no-assign-module-variable and jsx-no-undef rules

### DIFF
--- a/src/components/CippCards/CippUniversalSearchV2.jsx
+++ b/src/components/CippCards/CippUniversalSearchV2.jsx
@@ -58,8 +58,8 @@ async function loadTabOptions() {
 
   for (const basePath of tabOptionPaths) {
     try {
-      const module = await import(`../../pages${basePath}/tabOptions.json`);
-      const options = module.default || module;
+      const tabModule = await import(`../../pages${basePath}/tabOptions.json`);
+      const options = tabModule.default || tabModule;
 
       options.forEach((option) => {
         tabOptions.push({

--- a/src/components/CippComponents/CippBreadcrumbNav.jsx
+++ b/src/components/CippComponents/CippBreadcrumbNav.jsx
@@ -33,8 +33,8 @@ async function loadTabOptions() {
 
   for (const basePath of tabOptionPaths) {
     try {
-      const module = await import(`../../pages${basePath}/tabOptions.json`)
-      const options = module.default || module
+      const tabModule = await import(`../../pages${basePath}/tabOptions.json`)
+      const options = tabModule.default || tabModule
 
       // Add each tab option with metadata
       options.forEach((option) => {

--- a/src/components/CippComponents/CippDocsLookup.jsx
+++ b/src/components/CippComponents/CippDocsLookup.jsx
@@ -1,4 +1,4 @@
-import { Search } from "@mui/icons-material";
+import { Search, Visibility, VisibilityOff } from "@mui/icons-material";
 import { Chip, IconButton, SvgIcon, Tooltip } from "@mui/material";
 import { useState } from "react";
 


### PR DESCRIPTION
79 -> 75 errors

- module is a keyword, renamed the variable in CippUniversalSearchV2 and CippBreadcrumbNav
- added missing icon imports in CippDocsLookup
