### PR TITLE
fix(standards): correct inverted value labels for CopilotSettings.imageGeneration

### DIFF
--- a/src/data/standards.json
+++ b/src/data/standards.json
@@ -39,8 +39,8 @@
         "name": "standards.CopilotSettings.imageGeneration",
         "options": [
           { "label": "Do not configure", "value": "donotconfigure" },
-          { "label": "Enabled", "value": "1" },
-          { "label": "Disabled", "value": "0" }
+          { "label": "Disabled", "value": "1" },
+          { "label": "Enabled", "value": "0" }
         ]
       },
       {


### PR DESCRIPTION
## What

`standards.CopilotSettings.imageGeneration` (Designer Image Generation) has its value labels backwards. Currently:

```json
{ "label": "Enabled", "value": "1" },
{ "label": "Disabled", "value": "0" }
```

`microsoft.copilot.imagegeneration`'s actual value semantics on the Graph API (`PATCH /beta/copilot/admin/policySettings/microsoft.copilot.imagegeneration`) are inverted from the intuitive reading: `"1"` means **Disabled**, `"0"` means **Enabled**. As written, selecting "Enabled" in the CIPP UI actually disables Designer image generation for the tenant, and selecting "Disabled" enables it.

## How this was verified

Set the value directly via the Graph API on a Copilot-licensed tenant, then checked the corresponding toggle state in the Microsoft 365 admin center (**Copilot > Settings > Copilot actions > Copilot image generation**):

- `PATCH { "value": "1" }` → admin center shows the setting as **Disabled**.
- `PATCH { "value": "0" }` → admin center shows the setting as **Enabled**.

This matches the inversion already documented at [michev.info: "The sad state of governance APIs for Copilot and Agent 365"](https://michev.info/blog/post/8089/the-sad-state-of-governance-apis-for-copilot-and-agent-365).

## What changed

Swapped the two labels so `"1"` maps to `"Disabled"` and `"0"` maps to `"Enabled"`, matching the API's actual behavior. No other files in this repo reference `imageGeneration`'s values, so this is the complete fix here.